### PR TITLE
perf: fix CPU/memory/disk spikes under parallel hook load

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,11 +22,13 @@ tokenix --help
 | `src/main.rs` | CLI commands (clap). All `cmd_*` functions live here. |
 | `src/chunker.rs` | AST chunking per language + `generate_outline()`. Token counting. |
 | `src/embed.rs` | fastembed ONNX — `embed_documents()`, `embed_query()`. Model cached in `OnceCell`. |
-| `src/store.rs` | SQLite schema, CRUD, cosine similarity search, hook log I/O, `load_all_embeddings()` |
-| `src/indexer.rs` | File walk + incremental index pipeline |
+| `src/store.rs` | SQLite schema, CRUD, cosine similarity search, hook log I/O |
+| `src/indexer.rs` | File walk + incremental index pipeline. Embeds in batches of 512; wraps per-file inserts in transactions. |
 | `src/query.rs` | Search + result formatting |
 | `src/hook.rs` | `run_hook()` — called by Claude Code's PreToolUse hook. Tries daemon first for Grep. |
-| `src/daemon.rs` | Background TCP server (port 47392). Holds model + in-memory embedding cache. |
+| `src/daemon.rs` | Background TCP server (port 47392). Holds model + embedding cache (LRU, max 3 projects, content cap 1000). Bounded to 4 handler threads. |
+| `src/filters.rs` | Configurable output filter definitions (regex-based line keep/strip rules). |
+| `src/cmd_filter.rs` | `cmd_filter` command — lists per-command compression stats from hook log. |
 | `src/gain.rs` | Analytics from `.tokenix/hook.log` |
 
 ## Critical Rules
@@ -98,6 +100,11 @@ echo '{"type":"health"}' | nc 127.0.0.1 47392
 ```
 
 The daemon holds the ONNX model and all embeddings in RAM. Warm Grep calls via daemon take ~80ms vs ~430ms for cold in-process embed. The daemon auto-starts on first Grep hook call — manual `tokenix serve` is not required.
+
+**Resource limits (prevents PC freeze under parallel hooks):**
+- Max **4 concurrent handler threads** (rayon `ThreadPool`) — unbounded spawning was the primary Windows freeze trigger.
+- **Spawn lock** (`daemon.pid.spawning`) + PID liveness check — prevents N parallel hooks from each spawning a separate 130 MB daemon process.
+- **Content cache capped at 1000 entries** per project — evicted (cleared) when exceeded; hot entries repopulate on demand from SQLite.
 
 ## Common Tasks
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -183,6 +183,14 @@ fn port_path() -> Option<PathBuf> {
 // ---- Server -----------------------------------------------------------------
 
 pub fn run_serve(port: Option<u16>) -> Result<()> {
+    // Must be set before ONNX Runtime initializes its thread pool (reads OMP_NUM_THREADS at init).
+    #[allow(unused_unsafe)]
+    unsafe {
+        if std::env::var("OMP_NUM_THREADS").is_err() {
+            std::env::set_var("OMP_NUM_THREADS", "2");
+        }
+    }
+
     let port = port.unwrap_or_else(daemon_port);
 
     if let Some(p) = pid_path() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -149,7 +149,20 @@ fn main() -> Result<()> {
     let cli = Cli::parse();
 
     match cli.command {
-        Commands::Index { path, force, if_stale } => cmd_index(&path, force, if_stale),
+        Commands::Index { path, force, if_stale } => {
+            // Cap parallelism for indexing: rayon chunking + ONNX embedding.
+            // Without limits, large repos max out all CPU cores and freeze the PC.
+            #[allow(unused_unsafe)]
+            unsafe {
+                if std::env::var("RAYON_NUM_THREADS").is_err() {
+                    std::env::set_var("RAYON_NUM_THREADS", "4");
+                }
+                if std::env::var("OMP_NUM_THREADS").is_err() {
+                    std::env::set_var("OMP_NUM_THREADS", "2");
+                }
+            }
+            cmd_index(&path, force, if_stale)
+        }
         Commands::Query {
             text,
             budget,


### PR DESCRIPTION
- daemon: cap connection handlers to 4 threads via rayon ThreadPool (unbounded thread::spawn was the primary freeze trigger on Windows)
- daemon: set OMP_NUM_THREADS=2 at startup before ONNX Runtime init (ORT reads this at thread pool creation — setting it later has no effect)
- daemon: add spawn lock + PID liveness check to prevent N parallel daemon spawns each loading the 130 MB ONNX model
- daemon: cap content HashMap at 1000 entries to stop unbounded growth
- indexer: embed in batches of 512 to reduce peak RAM during indexing
- indexer: wrap per-file SQLite inserts in BEGIN/COMMIT transaction (reduces disk I/O from 20K individual WAL writes to 1 per file)
- index cmd: cap RAYON_NUM_THREADS=4 and OMP_NUM_THREADS=2 so large repo indexing does not max out all CPU cores and freeze the PC
- docs: update CLAUDE.md with new files and resource limit notes