### PR TITLE
chore(deps): upgrade tree-sitter to 0.26 and rusqlite to 0.40

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -324,13 +324,14 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.106"
+version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "066fce287b1d4eafef758e89e09d724a24808a9196fe9756b8ca90e86d0719a2"
+checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
 dependencies = [
+ "find-msvc-tools",
  "jobserver",
  "libc",
- "once_cell",
+ "shlex",
 ]
 
 [[package]]
@@ -846,6 +847,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
 name = "flate2"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -866,6 +873,12 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "foreign-types"
@@ -1052,20 +1065,20 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-dependencies = [
- "ahash",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash",
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -1076,11 +1089,11 @@ checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hashlink"
-version = "0.9.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+checksum = "ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230"
 dependencies = [
- "hashbrown 0.14.5",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -1573,9 +1586,9 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.28.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c10584274047cb335c23d3e61bcef8e323adae7c5c8c760540f73610177fc3f"
+checksum = "a76001fb4daed01e5f2b518aac0b4dc592e7c734da63dbffcf0c64fa612a8d0c"
 dependencies = [
  "cc",
  "pkg-config",
@@ -2337,10 +2350,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "rusqlite"
-version = "0.31.0"
+name = "rsqlite-vfs"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b838eba278d213a8beaf485bd313fd580ca4505a00d5871caeb1457c55322cae"
+checksum = "c51c9ae4df8a7fba42103df5c621fa3c37eccf3a3c650879e90fc48b11cc192c"
+dependencies = [
+ "hashbrown 0.16.1",
+ "thiserror",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b3492ea85308705c3a5cc24fb9b9cf77273d30590349070db42991202b214c4"
 dependencies = [
  "bitflags",
  "fallible-iterator",
@@ -2348,6 +2371,7 @@ dependencies = [
  "hashlink",
  "libsqlite3-sys",
  "smallvec",
+ "sqlite-wasm-rs",
 ]
 
 [[package]]
@@ -2528,6 +2552,7 @@ version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "serde",
@@ -2577,6 +2602,12 @@ dependencies = [
  "cpufeatures 0.3.0",
  "digest 0.11.3",
 ]
+
+[[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "simd-adler32"
@@ -2639,6 +2670,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "sqlite-wasm-rs"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc3efc0da82635d7e1ced0053bbbfa8c7ab9645d0bf36ceb4f7127bb85315d75"
+dependencies = [
+ "cc",
+ "js-sys",
+ "rsqlite-vfs",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2649,6 +2692,12 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2231b7c3057d5e4ad0156fb3dc807d900806020c5ffa3ee6ff2c8c76fb8520"
 
 [[package]]
 name = "strsim"
@@ -3034,62 +3083,72 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter"
-version = "0.20.10"
+version = "0.26.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e747b1f9b7b931ed39a548c1fae149101497de3c1fc8d9e18c62c1a66c683d3d"
+checksum = "4dab76d0b724ba557954125188cf0633a1ca43199ced82d95c7b9c32cc3de1f3"
 dependencies = [
  "cc",
  "regex",
+ "regex-syntax",
+ "serde_json",
+ "streaming-iterator",
+ "tree-sitter-language",
 ]
 
 [[package]]
 name = "tree-sitter-cpp"
-version = "0.20.5"
+version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46b04a5ada71059afb9895966a6cc1094acc8d2ea1971006db26573e7dfebb74"
+checksum = "df2196ea9d47b4ab4a31b9297eaa5a5d19a0b121dceb9f118f6790ad0ab94743"
 dependencies = [
  "cc",
- "tree-sitter",
+ "tree-sitter-language",
 ]
 
 [[package]]
 name = "tree-sitter-go"
-version = "0.20.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ad6d11f19441b961af2fda7f12f5d0dac325f6d6de83836a1d3750018cc5114"
+checksum = "c8560a4d2f835cc0d4d2c2e03cbd0dde2f6114b43bc491164238d333e28b16ea"
 dependencies = [
  "cc",
- "tree-sitter",
+ "tree-sitter-language",
 ]
 
 [[package]]
 name = "tree-sitter-javascript"
-version = "0.20.4"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d015c02ea98b62c806f7329ff71c383286dfc3a7a7da0cc484f6e42922f73c2c"
+checksum = "68204f2abc0627a90bdf06e605f5c470aa26fdcb2081ea553a04bdad756693f5"
 dependencies = [
  "cc",
- "tree-sitter",
+ "tree-sitter-language",
 ]
 
 [[package]]
-name = "tree-sitter-python"
-version = "0.20.4"
+name = "tree-sitter-language"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c93b1b1fbd0d399db3445f51fd3058e43d0b4dcff62ddbdb46e66550978aa5"
+checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
+
+[[package]]
+name = "tree-sitter-python"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bf85fd39652e740bf60f46f4cda9492c3a9ad75880575bf14960f775cb74a1c"
 dependencies = [
  "cc",
- "tree-sitter",
+ "tree-sitter-language",
 ]
 
 [[package]]
 name = "tree-sitter-rust"
-version = "0.20.4"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0832309b0b2b6d33760ce5c0e818cb47e1d72b468516bfe4134408926fa7594"
+checksum = "439e577dbe07423ec2582ac62c7531120dbfccfa6e5f92406f93dd271a120e45"
 dependencies = [
  "cc",
- "tree-sitter",
+ "tree-sitter-language",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ clap = { version = "4", features = ["derive"] }
 anyhow = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-rusqlite = { version = "0.31", features = ["bundled"] }
+rusqlite = { version = "0.40", features = ["bundled"] }
 fastembed = { version = "4" }
 # default-features off: drops esaxx-rs/onig (static-CRT C/C++) which clash with
 # ort-sys's dynamic CRT at link time. nomic-embed's BERT WordPiece tokenizer
@@ -41,12 +41,12 @@ toml = "1.1"
 regex = "1"
 rust-embed = { version = "8", features = ["include-exclude"] }
 libc = "0.2"
-tree-sitter = "0.20"
-tree-sitter-rust = "0.20"
-tree-sitter-python = "0.20"
-tree-sitter-javascript = "0.20"
-tree-sitter-go = "0.20"
-tree-sitter-cpp = "0.20"
+tree-sitter = "0.26"
+tree-sitter-rust = "0.24"
+tree-sitter-python = "0.25"
+tree-sitter-javascript = "0.25"
+tree-sitter-go = "0.25"
+tree-sitter-cpp = "0.23"
 
 [features]
 default = []

--- a/src/chunker.rs
+++ b/src/chunker.rs
@@ -359,7 +359,7 @@ fn find_first_identifier<'a>(node: tree_sitter::Node<'a>, source: &'a [u8]) -> O
             return Some(text.to_string());
         }
     }
-    for i in 0..node.child_count() {
+    for i in 0..node.child_count() as u32 {
         if let Some(child) = node.child(i) {
             if let Some(name) = find_first_identifier(child, source) {
                 return Some(name);
@@ -370,13 +370,13 @@ fn find_first_identifier<'a>(node: tree_sitter::Node<'a>, source: &'a [u8]) -> O
 }
 
 fn chunk_with_parser(
-    language: tree_sitter::Language,
+    language: impl Into<tree_sitter::Language>,
     content: &str,
     path: &str,
     is_symbol_node: fn(&str) -> Option<&'static str>,
 ) -> Vec<Chunk> {
     let mut parser = tree_sitter::Parser::new();
-    if parser.set_language(language).is_err() {
+    if parser.set_language(&language.into()).is_err() {
         let lines: Vec<&str> = content.lines().collect();
         return chunk_by_lines(&lines, path);
     }
@@ -410,7 +410,7 @@ fn chunk_with_parser(
                 kind: kind.to_string(),
             });
         }
-        for i in 0..node.child_count() {
+        for i in 0..node.child_count() as u32 {
             if let Some(child) = node.child(i) {
                 traverse(child, source, is_symbol_node, symbols);
             }
@@ -452,7 +452,7 @@ fn is_rust_symbol(kind: &str) -> Option<&'static str> {
 }
 
 fn chunk_rust(content: &str, path: &str) -> Vec<Chunk> {
-    chunk_with_parser(tree_sitter_rust::language(), content, path, is_rust_symbol)
+    chunk_with_parser(tree_sitter_rust::LANGUAGE, content, path, is_rust_symbol)
 }
 
 fn is_python_symbol(kind: &str) -> Option<&'static str> {
@@ -465,7 +465,7 @@ fn is_python_symbol(kind: &str) -> Option<&'static str> {
 
 fn chunk_python(content: &str, path: &str) -> Vec<Chunk> {
     chunk_with_parser(
-        tree_sitter_python::language(),
+        tree_sitter_python::LANGUAGE,
         content,
         path,
         is_python_symbol,
@@ -485,7 +485,7 @@ fn is_js_ts_symbol(kind: &str) -> Option<&'static str> {
 
 fn chunk_ts_js(content: &str, path: &str) -> Vec<Chunk> {
     let mut chunks = chunk_with_parser(
-        tree_sitter_javascript::language(),
+        tree_sitter_javascript::LANGUAGE,
         content,
         path,
         is_js_ts_symbol,
@@ -584,7 +584,7 @@ fn is_go_symbol(kind: &str) -> Option<&'static str> {
 }
 
 fn chunk_go(content: &str, path: &str) -> Vec<Chunk> {
-    chunk_with_parser(tree_sitter_go::language(), content, path, is_go_symbol)
+    chunk_with_parser(tree_sitter_go::LANGUAGE, content, path, is_go_symbol)
 }
 
 fn is_cpp_symbol(kind: &str) -> Option<&'static str> {
@@ -598,7 +598,7 @@ fn is_cpp_symbol(kind: &str) -> Option<&'static str> {
 }
 
 fn chunk_cpp(content: &str, path: &str) -> Vec<Chunk> {
-    chunk_with_parser(tree_sitter_cpp::language(), content, path, is_cpp_symbol)
+    chunk_with_parser(tree_sitter_cpp::LANGUAGE, content, path, is_cpp_symbol)
 }
 
 fn make_chunk(

--- a/src/store.rs
+++ b/src/store.rs
@@ -738,7 +738,7 @@ pub fn search_fts(
             "SELECT c.id FROM chunks c JOIN chunks_fts f ON c.id = f.rowid
              WHERE chunks_fts MATCH ?1 AND instr(c.path, ?2) > 0 LIMIT ?3",
         )?;
-        let rows = stmt.query_map(params![sanitized, filter, limit], |row| {
+        let rows = stmt.query_map(params![sanitized, filter, limit as i64], |row| {
             row.get::<_, i64>(0)
         })?;
         for id in rows.flatten() {
@@ -747,7 +747,7 @@ pub fn search_fts(
     } else {
         let mut stmt =
             conn.prepare("SELECT rowid FROM chunks_fts WHERE chunks_fts MATCH ?1 LIMIT ?2")?;
-        let rows = stmt.query_map(params![sanitized, limit], |row| row.get::<_, i64>(0))?;
+        let rows = stmt.query_map(params![sanitized, limit as i64], |row| row.get::<_, i64>(0))?;
         for id in rows.flatten() {
             ids.push(id);
         }

--- a/src/store.rs
+++ b/src/store.rs
@@ -738,7 +738,7 @@ pub fn search_fts(
             "SELECT c.id FROM chunks c JOIN chunks_fts f ON c.id = f.rowid
              WHERE chunks_fts MATCH ?1 AND instr(c.path, ?2) > 0 LIMIT ?3",
         )?;
-        let rows = stmt.query_map(params![sanitized, filter, limit as i64], |row| {
+        let rows = stmt.query_map(params![sanitized, filter, i64::try_from(limit).unwrap_or(i64::MAX)], |row| {
             row.get::<_, i64>(0)
         })?;
         for id in rows.flatten() {
@@ -747,7 +747,7 @@ pub fn search_fts(
     } else {
         let mut stmt =
             conn.prepare("SELECT rowid FROM chunks_fts WHERE chunks_fts MATCH ?1 LIMIT ?2")?;
-        let rows = stmt.query_map(params![sanitized, limit as i64], |row| row.get::<_, i64>(0))?;
+        let rows = stmt.query_map(params![sanitized, i64::try_from(limit).unwrap_or(i64::MAX)], |row| row.get::<_, i64>(0))?;
         for id in rows.flatten() {
             ids.push(id);
         }


### PR DESCRIPTION
## Summary

- **tree-sitter 0.20 → 0.26.9** (all grammar crates updated)
- **rusqlite 0.31 → 0.40.0** (safe: ort stays optional/default-off, no cc conflict)

## Changes

### `Cargo.toml`
| Dep | Before | After |
|---|---|---|
| tree-sitter | 0.20 | 0.26 |
| tree-sitter-rust | 0.20 | 0.24 |
| tree-sitter-python | 0.20 | 0.25 |
| tree-sitter-javascript | 0.20 | 0.25 |
| tree-sitter-go | 0.20 | 0.25 |
| tree-sitter-cpp | 0.20 | 0.23 |
| rusqlite | 0.31 | 0.40 |

### `src/chunker.rs`
- `language()` free-fn removed in new grammar crates — replaced with `LANGUAGE: LanguageFn` constant. `chunk_with_parser` signature updated to `impl Into<Language>`.
- `node.child(i)` now takes `u32` (was `usize`) — both traversal loops cast accordingly.

### `src/store.rs`
- `usize` no longer implements `ToSql` in rusqlite 0.40 — `limit` cast to `i64` in `search_fts` params.

## Why not fastembed 5.x?
fastembed 5.x is a major rewrite (adds candle backend, drops pure-ONNX path for some models) and requires a separate investigation. Kept at `"4"` (4.9.0).

## Test plan
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo build --release` — succeeds
- [x] `cargo test` — 136 passed, 0 failed, 5 ignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)