### PR TITLE
fix: run cargo fmt on store.rs (hotfix broken CI on main)

### DIFF
--- a/src/store.rs
+++ b/src/store.rs
@@ -738,16 +738,20 @@ pub fn search_fts(
             "SELECT c.id FROM chunks c JOIN chunks_fts f ON c.id = f.rowid
              WHERE chunks_fts MATCH ?1 AND instr(c.path, ?2) > 0 LIMIT ?3",
         )?;
-        let rows = stmt.query_map(params![sanitized, filter, i64::try_from(limit).unwrap_or(i64::MAX)], |row| {
-            row.get::<_, i64>(0)
-        })?;
+        let rows = stmt.query_map(
+            params![sanitized, filter, i64::try_from(limit).unwrap_or(i64::MAX)],
+            |row| row.get::<_, i64>(0),
+        )?;
         for id in rows.flatten() {
             ids.push(id);
         }
     } else {
         let mut stmt =
             conn.prepare("SELECT rowid FROM chunks_fts WHERE chunks_fts MATCH ?1 LIMIT ?2")?;
-        let rows = stmt.query_map(params![sanitized, i64::try_from(limit).unwrap_or(i64::MAX)], |row| row.get::<_, i64>(0))?;
+        let rows = stmt.query_map(
+            params![sanitized, i64::try_from(limit).unwrap_or(i64::MAX)],
+            |row| row.get::<_, i64>(0),
+        )?;
         for id in rows.flatten() {
             ids.push(id);
         }


### PR DESCRIPTION
## Summary

- The Gemini suggestion applied in #16 (`i64::try_from(limit).unwrap_or(i64::MAX)`) introduced a line that exceeds rustfmt's line width limit.
- `cargo fmt --check` is now failing on `main`, breaking the Rust CI gate.
- This PR runs `cargo fmt` to auto-break the long line — single file change, 1-second fix.

## Root cause

`i64::try_from(limit).unwrap_or(i64::MAX)` is longer than `limit as i64`, pushing the `params![...]` line past 100 chars. rustfmt wants it split across 3 lines.

## Test plan
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean  
- [x] `cargo test` — 136/136 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)