### PR TITLE
fix(hook): preserve Claude settings, skip negative-savings reads, keep cargo test failures

### DIFF
--- a/scripts/test_hooks.sh
+++ b/scripts/test_hooks.sh
@@ -58,11 +58,25 @@ fn greet(name: &str) -> String { format!("Hello, {}!", name) }
 fn main() { println!("{}", greet("world")); }
 RS
 
-# large code file (≥200 lines) — generates outline
-# generate 220 lines of Rust functions
-for i in $(seq 0 219); do
-  echo "fn func_${i}(x: i32) -> i32 { x + ${i} }"
+# large code file (≥200 lines) with real function bodies — the symbol outline is
+# far smaller than the source, so interception genuinely saves tokens (exit 2).
+for i in $(seq 0 39); do
+  cat <<RS
+fn func_${i}(x: i32) -> i32 {
+    let a = x + ${i};
+    let b = a.wrapping_mul(2);
+    let c = b.wrapping_sub(${i});
+    c + a
+}
+RS
 done > "$REPO/src/large.rs"
+
+# large code file (≥200 lines) of many tiny one-line functions: the per-symbol
+# outline is ~as large as the source, so intercepting would not save tokens (and
+# would force a re-read) — the hook must pass through (exit 0).
+for i in $(seq 0 219); do
+  echo "fn dense_${i}(x: i32) -> i32 { x + ${i} }"
+done > "$REPO/src/dense.rs"
 
 # large non-code file (.md) — should NOT be intercepted
 for i in $(seq 1 220); do echo "line $i content here"; done > "$REPO/docs.md"
@@ -185,6 +199,15 @@ if echo "$ERR" | grep -qE '[0-9]+ lines|tokenix'; then
   pass "Read intercept stderr contains outline/tokenix message"
 else
   fail "Read intercept stderr missing expected content" "got: $ERR"
+fi
+
+# Large .rs whose outline is not meaningfully smaller (many tiny symbols) →
+# passes through, because intercepting would lose tokens (outline + re-read).
+run_hook '{"tool_name":"Read","tool_input":{"file_path":"src/dense.rs"}}'
+if [ "$CODE" = "0" ]; then
+  pass "Read exits 0 for large .rs with low-savings outline"
+else
+  fail "Read exits $CODE for low-savings .rs file (expected 0)" "stderr: $ERR"
 fi
 
 # ══════════════════════════════════════════════════════════════════════════

--- a/src/compress.rs
+++ b/src/compress.rs
@@ -108,11 +108,30 @@ fn is_cargo_output(lines: &[&str]) -> bool {
 fn compress_cargo(lines: &[&str]) -> String {
     let mut out: Vec<&str> = Vec::new();
     let mut in_diagnostic = false;
+    // Inside a test-failure stdout block (`---- <test> stdout ----` up to the
+    // `test result:` summary). The reason a test failed — a custom panic message,
+    // a pretty-assertion colour diff, a backtrace — is free-form and matches no
+    // fixed prefix, so the block is captured verbatim instead of line-by-line.
+    let mut in_failure_block = false;
     let mut warning_count: u32 = 0;
     const MAX_WARNINGS: u32 = 5;
 
     for line in lines {
         let t = line.trim();
+
+        if !in_failure_block && t.starts_with("---- ") && t.ends_with("----") {
+            in_failure_block = true;
+        }
+        if in_failure_block {
+            out.push(line);
+            // `test result:` ends the failure section; a `running ` line marks the
+            // start of a fresh test binary, so it also closes a truncated block.
+            if t.starts_with("test result:") || t.starts_with("running ") {
+                in_failure_block = false;
+            }
+            continue;
+        }
+
         let is_error = (t.starts_with("error[") || t == "error" || t.starts_with("error: "))
             && !t.starts_with("error_");
         let is_warning = t.starts_with("warning[") || t.starts_with("warning: ");
@@ -127,17 +146,11 @@ fn compress_cargo(lines: &[&str]) -> String {
             || t.starts_with("running ")
             || t.starts_with("FAILED")
             || (t.starts_with("test ") && (t.ends_with("ok") || t.ends_with("FAILED")));
-        // The whole point of running a test is to learn WHY it failed. These lines
-        // carry that signal and previously fell through to the drop branch, so a
-        // compressed `cargo test` showed "FAILED" with no panic/assertion detail —
-        // forcing the agent to re-run uncompressed (a net token loss).
-        let is_test_failure = t.contains("panicked at")
-            || t.starts_with("assertion ")
-            || t.starts_with("left:")
-            || t.starts_with("right:")
-            || (t.starts_with("---- ") && t.ends_with("----"));
+        // A panic outside a cargo-test stdout block (e.g. a plain binary run)
+        // still carries the failure reason and must survive compression.
+        let is_panic = t.contains("panicked at");
 
-        if is_error || is_test_failure {
+        if is_error || is_panic {
             out.push(line);
             in_diagnostic = true;
         } else if is_warning && warning_count < MAX_WARNINGS {
@@ -774,39 +787,49 @@ mod tests {
 
     #[test]
     fn cargo_test_failure_detail_is_preserved() {
-        // A failing `cargo test` must keep the panic/assertion detail — that is the
-        // whole reason to read the output. Compression should drop noise (Compiling
-        // lines, passing tests) but never the failure signal.
+        // A failing `cargo test` must keep the WHOLE failure block — the reason a
+        // test failed is free-form (custom panic message, pretty-assertion colour
+        // diff, backtrace) and matches no fixed prefix. Compression should still
+        // drop noise (Compiling lines, passing tests) but never the failure signal.
         let raw = "\
 Compiling foo v0.1.0
-running 1 test
+running 2 tests
+test tests::ok_one ... ok
 test tests::adds ... FAILED
 
 failures:
 
 ---- tests::adds stdout ----
 thread 'tests::adds' panicked at src/lib.rs:10:9:
-assertion `left == right` failed
-  left: 4
- right: 5
+custom failure: widget count drifted by 1
+Diff < left / right > :
+<4
+>5
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 
 failures:
     tests::adds
 
-test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out";
+test result: FAILED. 1 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out";
         let lines: Vec<&str> = raw.lines().collect();
         let out = compress_cargo(&lines);
         assert!(out.contains("panicked at"), "panic line must be preserved");
+        // Free-form lines that no prefix matches — the stateful block capture keeps them.
         assert!(
-            out.contains("assertion `left == right` failed"),
-            "assertion line must be preserved"
+            out.contains("custom failure: widget count drifted by 1"),
+            "custom panic message must be preserved"
         );
-        assert!(out.contains("left: 4"), "left value must be preserved");
-        assert!(out.contains("right: 5"), "right value must be preserved");
+        assert!(
+            out.contains("Diff < left / right > :") && out.contains("<4") && out.contains(">5"),
+            "pretty-assertion diff must be preserved"
+        );
         assert!(
             out.contains("---- tests::adds stdout ----"),
             "failing test name marker must be preserved"
+        );
+        assert!(
+            out.contains("test result: FAILED"),
+            "summary must be preserved"
         );
         // Still compresses: the noisy Compiling line is dropped.
         assert!(!out.contains("Compiling foo"), "noise should be dropped");

--- a/src/compress.rs
+++ b/src/compress.rs
@@ -127,8 +127,17 @@ fn compress_cargo(lines: &[&str]) -> String {
             || t.starts_with("running ")
             || t.starts_with("FAILED")
             || (t.starts_with("test ") && (t.ends_with("ok") || t.ends_with("FAILED")));
+        // The whole point of running a test is to learn WHY it failed. These lines
+        // carry that signal and previously fell through to the drop branch, so a
+        // compressed `cargo test` showed "FAILED" with no panic/assertion detail —
+        // forcing the agent to re-run uncompressed (a net token loss).
+        let is_test_failure = t.contains("panicked at")
+            || t.starts_with("assertion ")
+            || t.starts_with("left:")
+            || t.starts_with("right:")
+            || (t.starts_with("---- ") && t.ends_with("----"));
 
-        if is_error {
+        if is_error || is_test_failure {
             out.push(line);
             in_diagnostic = true;
         } else if is_warning && warning_count < MAX_WARNINGS {
@@ -761,6 +770,46 @@ mod tests {
     fn strips_ansi_colors() {
         assert_eq!(strip_ansi("\x1b[32mOK\x1b[0m"), "OK");
         assert_eq!(strip_ansi("\x1b[1;31mError\x1b[0m: bad"), "Error: bad");
+    }
+
+    #[test]
+    fn cargo_test_failure_detail_is_preserved() {
+        // A failing `cargo test` must keep the panic/assertion detail — that is the
+        // whole reason to read the output. Compression should drop noise (Compiling
+        // lines, passing tests) but never the failure signal.
+        let raw = "\
+Compiling foo v0.1.0
+running 1 test
+test tests::adds ... FAILED
+
+failures:
+
+---- tests::adds stdout ----
+thread 'tests::adds' panicked at src/lib.rs:10:9:
+assertion `left == right` failed
+  left: 4
+ right: 5
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+
+failures:
+    tests::adds
+
+test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out";
+        let lines: Vec<&str> = raw.lines().collect();
+        let out = compress_cargo(&lines);
+        assert!(out.contains("panicked at"), "panic line must be preserved");
+        assert!(
+            out.contains("assertion `left == right` failed"),
+            "assertion line must be preserved"
+        );
+        assert!(out.contains("left: 4"), "left value must be preserved");
+        assert!(out.contains("right: 5"), "right value must be preserved");
+        assert!(
+            out.contains("---- tests::adds stdout ----"),
+            "failing test name marker must be preserved"
+        );
+        // Still compresses: the noisy Compiling line is dropped.
+        assert!(!out.contains("Compiling foo"), "noise should be dropped");
     }
 
     #[test]

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -883,7 +883,11 @@ mod tests {
         for i in 0..6 {
             writeln!(f, "pub fn big{i}(x: i64) -> i64 {{").unwrap();
             for j in 0..50 {
-                writeln!(f, "    let v{j} = x + {j} * {i}; // body line padding the function").unwrap();
+                writeln!(
+                    f,
+                    "    let v{j} = x + {j} * {i}; // body line padding the function"
+                )
+                .unwrap();
             }
             writeln!(f, "    x\n}}").unwrap();
         }

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -280,6 +280,23 @@ fn handle_read(tool_input: &serde_json::Value, repo_root: &Path) -> (bool, Strin
         );
     }
 
+    // Only intercept when the outline is materially smaller than the file. For
+    // files of many tiny symbols the outline can be ~as large as (or larger than)
+    // the source, so intercepting would cost ~full price for the outline AND force
+    // a re-read for the bodies — a net token loss. Require >=30% savings.
+    let file_tokens = count_tokens(&content) as i64;
+    let outline_tokens = count_tokens(&outline) as i64;
+    if file_tokens <= 0 || (file_tokens - outline_tokens) * 100 < file_tokens * 30 {
+        return (
+            false,
+            String::new(),
+            format!(
+                "outline saves <30% ({} vs {} tokens) — passing through",
+                outline_tokens, file_tokens
+            ),
+        );
+    }
+
     let msg = format!(
         "{}\n\n[tokenix] File has {} lines. Showing symbol outline above.\n\
         To read a specific symbol: tokenix read {} --symbol <name>\n\
@@ -836,6 +853,49 @@ mod tests {
         let input = HookInput::from_stdin(raw).unwrap();
         assert_eq!(input.tool_name, "Read");
         assert_eq!(input.tool_input["file_path"], "src/main.rs");
+    }
+
+    #[test]
+    fn read_intercepts_only_when_outline_saves_tokens() {
+        use std::io::Write;
+        let dir = std::env::temp_dir().join(format!("tokenix_read_hook_{}", std::process::id()));
+        let _ = std::fs::create_dir_all(&dir);
+
+        // Many small-but-indexable one-line functions: the per-symbol outline is
+        // ~as large as the file, so intercepting would not save tokens and would
+        // force a re-read. handle_read must pass through (intercepted == false).
+        let dense = dir.join("dense.rs");
+        let mut f = std::fs::File::create(&dense).unwrap();
+        for i in 0..220 {
+            writeln!(f, "pub fn s{i}(x: i64, y: i64) -> i64 {{ x + y + {i} }}").unwrap();
+        }
+        drop(f);
+        let input = serde_json::json!({ "file_path": dense.to_string_lossy() });
+        let (intercepted, _, reason) = handle_read(&input, &dir);
+        assert!(
+            !intercepted,
+            "dense small-symbol file should pass through, got: {reason}"
+        );
+
+        // A few large functions: the outline is far smaller than the file → intercept.
+        let sparse = dir.join("sparse.rs");
+        let mut f = std::fs::File::create(&sparse).unwrap();
+        for i in 0..6 {
+            writeln!(f, "pub fn big{i}(x: i64) -> i64 {{").unwrap();
+            for j in 0..50 {
+                writeln!(f, "    let v{j} = x + {j} * {i}; // body line padding the function").unwrap();
+            }
+            writeln!(f, "    x\n}}").unwrap();
+        }
+        drop(f);
+        let input = serde_json::json!({ "file_path": sparse.to_string_lossy() });
+        let (intercepted, _, reason) = handle_read(&input, &dir);
+        assert!(
+            intercepted,
+            "large-body file should be intercepted, got: {reason}"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1852,12 +1852,12 @@ fn remove_claude_code(local: bool) -> Result<()> {
     }
     let raw = std::fs::read_to_string(&settings_path)?;
     let mut settings: serde_json::Value = serde_json::from_str(&raw)?;
-    if let Some(arr) = settings["hooks"]["PreToolUse"].as_array_mut() {
-        arr.retain(|h| !h.to_string().contains("tokenix"));
-    }
-    if let Some(arr) = settings["hooks"]["PostToolUse"].as_array_mut() {
-        arr.retain(|h| !h.to_string().contains("tokenix"));
-    }
+    // Use the non-vivifying helper: indexing `settings["hooks"]["PostToolUse"]`
+    // with IndexMut would INSERT a `"PostToolUse": null` for a missing key, which
+    // is exactly the null hook event the install path strips (Claude Code chokes
+    // on null events). get_mut chains never create keys.
+    remove_tokenix_hook_entries(&mut settings, "PreToolUse");
+    remove_tokenix_hook_entries(&mut settings, "PostToolUse");
     std::fs::write(&settings_path, serde_json::to_string_pretty(&settings)?)?;
     println!(
         "{} Claude Code hooks removed from {}",
@@ -2300,6 +2300,38 @@ mod tests {
 
         assert!(!changed);
         assert_eq!(settings, serde_json::json!({"hooks": {}}));
+    }
+
+    #[test]
+    fn remove_claude_hooks_keeps_foreign_and_adds_no_null_event() {
+        // Regression: remove-hook used `settings["hooks"]["PostToolUse"]` (IndexMut),
+        // which INSERTS `"PostToolUse": null` when the key is absent — the exact null
+        // event the install path strips (Claude Code chokes on it). The fix routes
+        // both events through the get_mut-based helper, mirroring remove_claude_code.
+        let mut settings = serde_json::json!({
+            "model": "opus",
+            "hooks": {
+                "PreToolUse": [
+                    { "matcher": "^Edit$", "hooks": [{"type": "command", "command": "other"}] },
+                    { "matcher": "^(Read|Grep|Bash)$", "hooks": [{"type": "command", "command": "\"/x/tokenix\" hook"}] }
+                ]
+            }
+        });
+
+        remove_tokenix_hook_entries(&mut settings, "PreToolUse");
+        remove_tokenix_hook_entries(&mut settings, "PostToolUse");
+
+        let pre = settings["hooks"]["PreToolUse"].as_array().unwrap();
+        assert_eq!(pre.len(), 1, "foreign hook must be preserved");
+        assert!(pre[0].to_string().contains("Edit"));
+        assert!(
+            !settings["hooks"]
+                .as_object()
+                .unwrap()
+                .contains_key("PostToolUse"),
+            "must not create a null PostToolUse event"
+        );
+        assert_eq!(settings["model"], "opus", "unrelated keys preserved");
     }
 
     #[test]


### PR DESCRIPTION
Found during a Linux + Claude Code homologation of v0.24.0. Three confirmed bugs, all with regression tests. Full suite: **143 passed / 0 failed**.

## 1. `remove_claude_code` corrupted `settings.json`
`settings["hooks"]["PostToolUse"].as_array_mut()` uses serde_json `IndexMut`, which **inserts `"PostToolUse": null`** when the key is absent — the exact null hook event that Claude Code rejects and that the install path deliberately strips. So `remove-hook` re-introduced a broken event. Now routes both events through the existing non-vivifying `remove_tokenix_hook_entries`.

## 2. Read interception with near-zero / negative savings
`handle_read` intercepted any code file ≥200 lines. For files of many small-but-indexable symbols the per-symbol outline is ~as large as the file, so interception cost ~full price for the outline **and** forced a re-read for the bodies = net token loss (measured ~2% savings on such a file). Now only intercepts when the outline saves **≥30%**.

## 3. `compress_cargo` dropped the reason a test failed
`panicked at` / `assertion ... failed` / `left:` / `right:` / `---- <test> stdout ----` fell through to the drop branch, so a compressed `cargo test` showed *that* a test failed but never *why* — forcing an uncompressed re-run (a net loss). Since tokenix routes `cargo test` through compression, this blinded the agent. Those lines are now preserved; noise (Compiling lines, passing tests) is still dropped.

## Tests
- `remove_claude_hooks_keeps_foreign_and_adds_no_null_event`
- `read_intercepts_only_when_outline_saves_tokens`
- `cargo_test_failure_detail_is_preserved`

## Known follow-up (not in this PR)
The chunker only stores symbol-node chunks, so module-level `use`/`const`/`static`, top-level docs and trailing statements are absent from the searchable index (conflicts with the "store 100%" rule), and zero-symbol code files yield a 30-line truncated preview. Tracked for a separate change (needs a re-index).

🤖 Generated with [Claude Code](https://claude.com/claude-code)