### PR TITLE
feat(embed): flexible embedding-model registry (select model per index)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,7 @@ tokenix --help
 |---|---|
 | `src/main.rs` | CLI entry (clap), command dispatch, `install-hook`/`remove-hook` helpers |
 | `src/chunker.rs` | Symbol-aware heuristic chunking, `generate_outline()`, token counting |
-| `src/embed.rs` | fastembed ONNX — `embed_documents()`, `embed_query()`. Model cached in `OnceCell` |
+| `src/embed.rs` | fastembed ONNX — `embed_documents()`, `embed_query()`. Model **registry** (`MODELS`, `spec_for`) + thread-local active model (`set_active_model`/`active_model_id`) + per-id loaded-model cache. Per-model query/doc prefixes; query cache keyed by model |
 | `src/store.rs` | SQLite schema, CRUD, cosine similarity search, hook log I/O |
 | `src/indexer.rs` | File walk + incremental index pipeline. Embeds in batches of 512 |
 | `src/query.rs` | Hybrid semantic/lexical ranking + result formatting |
@@ -167,6 +167,8 @@ but a `node` grandchild may linger briefly until stdin EOF. Kill-the-tree
 **Add an agent to `prompt-audit`:** `mcp_audit.rs` — add an `Agent` variant (with `label`/`key`/`native_tokens`), a `discover_<agent>()` config source, and an `AuditAgent` value + mapping in `main.rs`. Reuse `parse_json_map` for JSON `mcpServers`-style configs.
 
 **Change token budget:** `query.rs` — `DEFAULT_BUDGET` constant, or pass `--budget` flag.
+
+**Embedding model (flexible):** `embed.rs` `MODELS` registry maps a friendly id → `EmbeddingModel` + query/doc prefixes. Default is `nomic-v1.5` (existing indexes keep working). Select with `tokenix index --model <id>` or `TOKENIX_EMBED_MODEL=<id>`. The chosen model is **stamped in the index `meta` (`embed_model`)**; query/hook/daemon read it back via `store::index_model_id` and `embed::set_active_model` so query vectors always match the indexed docs. The model is **sticky** (a plain re-index keeps it); an explicit switch forces a full re-embed. `index_staleness` only flags a model change when `TOKENIX_EMBED_MODEL` is explicitly set. The embedding cache key (`chunk_embedding_key`) and the persistent query cache are namespaced by model id. Add a built-in model: append a `ModelSpec` (use the non-quantized variant if the Qdrant-Q ONNX fails ORT's `SkipLayerNormalization`). `tokenix doctor` lists available + active + this-repo's model.
 
 **Update pricing table:** `gain.rs` — edit `MODELS` constant. Fields: `name`, `input_per_1m` (USD), `reference` (marks ★ model).
 

--- a/README.md
+++ b/README.md
@@ -346,7 +346,9 @@ tokenix install-hook --tool all
 |---|---|
 | `--only-cpu` | Force CPU embedding even on a GPU-enabled build (no-op on CPU-only builds) |
 
-**`tokenix index`** — `--force/-f`, `--cpu-profile <low\|default\|max>`, `--jobs N`, `--embed-batch N` (default 16 CPU / 64 GPU), `--if-stale`, `--path/-p`
+**`tokenix index`** — `--force/-f`, `--cpu-profile <low\|default\|max>`, `--jobs N`, `--embed-batch N` (default 16 CPU / 64 GPU), `--if-stale`, `--path/-p`, `--model <id>`
+
+**Embedding model** — default `nomic-v1.5`. Select another with `tokenix index --model <id>` or `TOKENIX_EMBED_MODEL=<id>`; run `tokenix doctor` to list available ids (`nomic-v1.5`, `bge-small`, `bge-base`, `minilm-l6`, `e5-small`). The model is stamped into the index and read back at query time, so search always matches what was indexed; it is sticky across re-indexes and an explicit switch re-embeds. `nomic-v1.5` (768d) is the quality default; `bge-small` (384d) indexes faster; `e5-small` is multilingual. Existing indexes keep working unchanged.
 
 **`tokenix query`** — `--budget/-b` (1200), `--k` (20), `--file/-f`, `--path/-p`
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -544,6 +544,10 @@ fn search_handler(
     budget: usize,
     file_filter: Option<&str>,
 ) -> String {
+    // Use the model the project's index was built with (this handler thread only).
+    if let Some(model_id) = store::index_model_id(Path::new(project_root)) {
+        crate::embed::set_active_model(&model_id);
+    }
     // Embed outside the lock — takes 50-100ms, holds no mutex.
     let query_vec = match embed_query(query) {
         Ok(v) => v,

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -40,6 +40,23 @@ pub fn run_doctor() -> Result<()> {
     println!();
 
     section("Embedding model");
+    let active = crate::embed::active_model_id();
+    kv(
+        "active",
+        &format!("{} ({})", active, crate::embed::spec_for(&active).note),
+    );
+    // If run inside an indexed repo, show the model that index was built with.
+    if let Ok(cwd) = std::env::current_dir() {
+        let root = crate::store::find_project_root(&cwd);
+        if let Some(indexed) = crate::store::index_model_id(&root) {
+            kv("this repo's index", &indexed);
+        }
+    }
+    let available: Vec<String> = crate::embed::MODELS
+        .iter()
+        .map(|m| m.id.to_string())
+        .collect();
+    kv("available", &available.join(", "));
     let model_dir = crate::embed::model_cache_dir();
     match dir_size(&model_dir) {
         Some(bytes) if bytes > 0 => kv(

--- a/src/embed.rs
+++ b/src/embed.rs
@@ -104,7 +104,7 @@ pub fn active_model_id() -> String {
 
 /// Loaded models keyed by id. Leaked to `'static` so callers get a stable
 /// reference; the process loads each model at most once.
-static MODELS_CACHE: OnceCell<Mutex<HashMap<String, &'static TextEmbedding>>> = OnceCell::new();
+static MODELS_CACHE: OnceCell<Mutex<HashMap<String, &'static OnceCell<TextEmbedding>>>> = OnceCell::new();
 
 /// When true, the GPU execution provider is skipped even on a GPU-enabled build.
 /// Set by `main()` from the `--only-cpu` flag before the model is first used.

--- a/src/embed.rs
+++ b/src/embed.rs
@@ -2,10 +2,109 @@ use anyhow::{anyhow, Result};
 use fastembed::{EmbeddingModel, InitOptions, TextEmbedding};
 use once_cell::sync::OnceCell;
 use rusqlite::{params, Connection};
+use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Mutex;
 
-static MODEL: OnceCell<TextEmbedding> = OnceCell::new();
+/// Friendly id of the model used when nothing is configured. Existing indexes were
+/// built with this, so it stays the default to avoid forcing a re-index.
+pub const DEFAULT_MODEL_ID: &str = "nomic-v1.5";
+
+/// A selectable embedding model. `doc_prefix`/`query_prefix` are model-specific:
+/// nomic uses `search_document:`/`search_query:`, e5 uses `passage:`/`query:`,
+/// bge/minilm use none. Using the wrong prefix silently degrades retrieval.
+pub struct ModelSpec {
+    pub id: &'static str,
+    pub model: EmbeddingModel,
+    pub doc_prefix: &'static str,
+    pub query_prefix: &'static str,
+    pub note: &'static str,
+}
+
+/// Built-in ONNX models (run on the current fastembed/ORT backend, no extra deps).
+pub const MODELS: &[ModelSpec] = &[
+    ModelSpec {
+        id: "nomic-v1.5",
+        model: EmbeddingModel::NomicEmbedTextV15Q,
+        doc_prefix: "search_document: ",
+        query_prefix: "search_query: ",
+        note: "768d · English · quantized · default",
+    },
+    // Non-quantized ONNX: the Qdrant-quantized bge/minilm graphs use a fused
+    // SkipLayerNormalization op that the pinned ORT build cannot run (missing
+    // input). The fp32 graphs load cleanly; they are larger to download but still
+    // far fewer params than nomic, so indexing is faster.
+    ModelSpec {
+        id: "bge-small",
+        model: EmbeddingModel::BGESmallENV15,
+        doc_prefix: "",
+        query_prefix: "",
+        note: "384d · English · ~33M params, fast",
+    },
+    ModelSpec {
+        id: "bge-base",
+        model: EmbeddingModel::BGEBaseENV15,
+        doc_prefix: "",
+        query_prefix: "",
+        note: "768d · English",
+    },
+    ModelSpec {
+        id: "minilm-l6",
+        model: EmbeddingModel::AllMiniLML6V2,
+        doc_prefix: "",
+        query_prefix: "",
+        note: "384d · English · ~22M params, fastest, lower quality",
+    },
+    ModelSpec {
+        id: "e5-small",
+        model: EmbeddingModel::MultilingualE5Small,
+        doc_prefix: "passage: ",
+        query_prefix: "query: ",
+        note: "384d · multilingual",
+    },
+];
+
+/// Look up a model by id, falling back to the default for unknown ids so a bad
+/// `TOKENIX_EMBED_MODEL` never breaks indexing/search (doctor surfaces the warning).
+pub fn spec_for(id: &str) -> &'static ModelSpec {
+    MODELS.iter().find(|m| m.id == id).unwrap_or(&MODELS[0])
+}
+
+pub fn is_known_model(id: &str) -> bool {
+    MODELS.iter().any(|m| m.id == id)
+}
+
+thread_local! {
+    /// Per-thread active model id. Set explicitly by the index path (from the
+    /// chosen model) and by the query/hook path (from the index's stamped model),
+    /// so the daemon's handler threads can serve different projects/models without
+    /// racing on a shared global.
+    static ACTIVE_MODEL: std::cell::RefCell<Option<String>> = const { std::cell::RefCell::new(None) };
+}
+
+/// Set the active embedding model for the current thread. Pass a friendly id from
+/// [`MODELS`]; unknown ids resolve to the default.
+pub fn set_active_model(id: &str) {
+    let id = spec_for(id).id.to_string();
+    ACTIVE_MODEL.with(|m| *m.borrow_mut() = Some(id));
+}
+
+/// Resolve the active model id: thread-local override, else `TOKENIX_EMBED_MODEL`,
+/// else the default.
+pub fn active_model_id() -> String {
+    if let Some(id) = ACTIVE_MODEL.with(|m| m.borrow().clone()) {
+        return id;
+    }
+    match std::env::var("TOKENIX_EMBED_MODEL") {
+        Ok(id) if !id.trim().is_empty() => spec_for(id.trim()).id.to_string(),
+        _ => DEFAULT_MODEL_ID.to_string(),
+    }
+}
+
+/// Loaded models keyed by id. Leaked to `'static` so callers get a stable
+/// reference; the process loads each model at most once.
+static MODELS_CACHE: OnceCell<Mutex<HashMap<String, &'static TextEmbedding>>> = OnceCell::new();
 
 /// When true, the GPU execution provider is skipped even on a GPU-enabled build.
 /// Set by `main()` from the `--only-cpu` flag before the model is first used.
@@ -111,69 +210,94 @@ fn deserialize_vec(bytes: &[u8]) -> Vec<f32> {
         .collect()
 }
 
-fn model() -> Result<&'static TextEmbedding> {
-    MODEL
-        .get_or_try_init(|| {
-            // OMP_NUM_THREADS=1: limits OpenMP thread count for non-Windows ORT builds.
-            // On Windows, ORT prebuilt uses OpenMP; this var is set in main() before hook runs.
-            // Set here too as belt-and-suspenders for indexer and query paths.
-            #[allow(unused_unsafe)]
-            if std::env::var("OMP_NUM_THREADS").is_err() {
-                unsafe { std::env::set_var("OMP_NUM_THREADS", "1") };
-            }
-            let cache_dir = model_cache_dir();
-            std::fs::create_dir_all(&cache_dir).ok();
-
-            #[allow(unused_mut)]
-            let mut options =
-                InitOptions::new(EmbeddingModel::NomicEmbedTextV15Q).with_cache_dir(cache_dir);
-
-            // GPU-by-default with automatic CPU fallback. Register the GPU provider
-            // first and CPU second, so ORT uses the GPU when available and falls back
-            // to CPU otherwise. `--only-cpu` (FORCE_CPU) skips the GPU provider entirely.
-            #[cfg(feature = "cuda")]
-            if !force_cpu() {
-                options = options.with_execution_providers(vec![
-                    ort::execution_providers::CUDAExecutionProvider::default().build(),
-                    ort::execution_providers::CPUExecutionProvider::default().build(),
-                ]);
-            }
-
-            #[cfg(all(not(feature = "cuda"), feature = "directml"))]
-            if !force_cpu() {
-                options = options.with_execution_providers(vec![
-                    ort::execution_providers::DirectMLExecutionProvider::default().build(),
-                    ort::execution_providers::CPUExecutionProvider::default().build(),
-                ]);
-            }
-
-            TextEmbedding::try_new(options)
-        })
-        .map_err(|e| anyhow!("Embedding model init failed: {e}"))
+/// Get (loading once) the model for a friendly id. The lock is held across the
+/// load so two threads never load the same model twice; after first load it is a
+/// brief map lookup.
+fn model_for(id: &str) -> Result<&'static TextEmbedding> {
+    let cache = MODELS_CACHE.get_or_init(|| Mutex::new(HashMap::new()));
+    let mut map = cache
+        .lock()
+        .map_err(|_| anyhow!("embedding model cache poisoned"))?;
+    if let Some(m) = map.get(id) {
+        return Ok(*m);
+    }
+    let te = build_text_embedding(spec_for(id).model.clone())
+        .map_err(|e| anyhow!("Embedding model '{id}' init failed: {e}"))?;
+    // Leak once: the model lives for the rest of the process anyway.
+    let leaked: &'static TextEmbedding = Box::leak(Box::new(te));
+    map.insert(id.to_string(), leaked);
+    Ok(leaked)
 }
 
-/// Embed a batch of document texts for indexing.
-/// Applies the "search_document:" prefix required by nomic-embed-text-v1.5.
+fn build_text_embedding(model: EmbeddingModel) -> Result<TextEmbedding> {
+    // OMP_NUM_THREADS=1: limits OpenMP thread count for non-Windows ORT builds.
+    // On Windows, ORT prebuilt uses OpenMP; this var is set in main() before hook runs.
+    // Set here too as belt-and-suspenders for indexer and query paths.
+    #[allow(unused_unsafe)]
+    if std::env::var("OMP_NUM_THREADS").is_err() {
+        unsafe { std::env::set_var("OMP_NUM_THREADS", "1") };
+    }
+    let cache_dir = model_cache_dir();
+    std::fs::create_dir_all(&cache_dir).ok();
+
+    #[allow(unused_mut)]
+    let mut options = InitOptions::new(model).with_cache_dir(cache_dir);
+
+    // GPU-by-default with automatic CPU fallback. Register the GPU provider
+    // first and CPU second, so ORT uses the GPU when available and falls back
+    // to CPU otherwise. `--only-cpu` (FORCE_CPU) skips the GPU provider entirely.
+    #[cfg(feature = "cuda")]
+    if !force_cpu() {
+        options = options.with_execution_providers(vec![
+            ort::execution_providers::CUDAExecutionProvider::default().build(),
+            ort::execution_providers::CPUExecutionProvider::default().build(),
+        ]);
+    }
+
+    #[cfg(all(not(feature = "cuda"), feature = "directml"))]
+    if !force_cpu() {
+        options = options.with_execution_providers(vec![
+            ort::execution_providers::DirectMLExecutionProvider::default().build(),
+            ort::execution_providers::CPUExecutionProvider::default().build(),
+        ]);
+    }
+
+    TextEmbedding::try_new(options)
+}
+
+/// Embed a batch of document texts for indexing, applying the active model's
+/// document prefix.
 pub fn embed_documents(texts: &[String]) -> Result<Vec<Vec<f32>>> {
     if texts.is_empty() {
         return Ok(vec![]);
     }
+    let id = active_model_id();
+    let spec = spec_for(&id);
     let prefixed: Vec<String> = texts
         .iter()
-        .map(|t| format!("search_document: {t}"))
+        .map(|t| format!("{}{t}", spec.doc_prefix))
         .collect();
-    model()?.embed(prefixed, None).map_err(|e| anyhow!("{e}"))
+    model_for(&id)?
+        .embed(prefixed, None)
+        .map_err(|e| anyhow!("{e}"))
 }
 
-/// Embed a single query string for semantic search.
-/// Applies the "search_query:" prefix required by nomic-embed-text-v1.5.
+/// Embed a single query string for semantic search, applying the active model's
+/// query prefix. The persistent query cache is keyed by `(model_id, text)` so a
+/// model switch never returns vectors from a different model.
 pub fn embed_query(text: &str) -> Result<Vec<f32>> {
+    let id = active_model_id();
+    let spec = spec_for(&id);
+    // Unit-separator keeps the model id and query text unambiguous; old plain-text
+    // cache rows simply never match and are regenerated under the new key.
+    let cache_key = format!("{id}\u{1f}{text}");
+
     // 1. Try checking the persistent query cache
     if let Some(conn) = open_query_cache_db() {
         if let Ok(mut stmt) =
             conn.prepare("SELECT embedding FROM query_cache WHERE query_text = ?1")
         {
-            if let Ok(mut rows) = stmt.query(params![text]) {
+            if let Ok(mut rows) = stmt.query(params![cache_key]) {
                 if let Ok(Some(row)) = rows.next() {
                     if let Ok(blob) = row.get::<_, Vec<u8>>(0) {
                         return Ok(deserialize_vec(&blob));
@@ -184,8 +308,8 @@ pub fn embed_query(text: &str) -> Result<Vec<f32>> {
     }
 
     // 2. Generate embedding if not cached
-    let prefixed = format!("search_query: {text}");
-    let vec = model()?
+    let prefixed = format!("{}{text}", spec.query_prefix);
+    let vec = model_for(&id)?
         .embed(vec![prefixed], None)
         .map_err(|e| anyhow!("{e}"))?
         .into_iter()
@@ -197,7 +321,7 @@ pub fn embed_query(text: &str) -> Result<Vec<f32>> {
         let blob = serialize_vec(&vec);
         let _ = conn.execute(
             "INSERT OR REPLACE INTO query_cache (query_text, embedding) VALUES (?1, ?2)",
-            params![text, blob],
+            params![cache_key, blob],
         );
     }
 
@@ -228,6 +352,30 @@ mod tests {
     fn embed_documents_empty_returns_empty() {
         let result = embed_documents(&[]).expect("empty embed should succeed");
         assert!(result.is_empty());
+    }
+
+    #[test]
+    fn registry_defaults_and_lookups() {
+        // Default is nomic-v1.5 and it carries nomic's prefixes.
+        assert_eq!(active_model_id(), DEFAULT_MODEL_ID);
+        let nomic = spec_for("nomic-v1.5");
+        assert_eq!(nomic.query_prefix, "search_query: ");
+        assert_eq!(nomic.doc_prefix, "search_document: ");
+        // e5 needs its own prefixes; bge/minilm use none.
+        assert_eq!(spec_for("e5-small").query_prefix, "query: ");
+        assert_eq!(spec_for("bge-small").doc_prefix, "");
+        // Unknown ids fall back to the default rather than breaking.
+        assert!(!is_known_model("does-not-exist"));
+        assert_eq!(spec_for("does-not-exist").id, DEFAULT_MODEL_ID);
+    }
+
+    #[test]
+    fn set_active_model_overrides_default() {
+        set_active_model("bge-small");
+        assert_eq!(active_model_id(), "bge-small");
+        // Unknown id normalizes to default.
+        set_active_model("bogus");
+        assert_eq!(active_model_id(), DEFAULT_MODEL_ID);
     }
 
     #[test]

--- a/src/embed.rs
+++ b/src/embed.rs
@@ -104,7 +104,7 @@ pub fn active_model_id() -> String {
 
 /// Loaded models keyed by id. Leaked to `'static` so callers get a stable
 /// reference; the process loads each model at most once.
-static MODELS_CACHE: OnceCell<Mutex<HashMap<String, &'static OnceCell<TextEmbedding>>>> = OnceCell::new();
+static MODELS_CACHE: OnceCell<Mutex<HashMap<String, &'static TextEmbedding>>> = OnceCell::new();
 
 /// When true, the GPU execution provider is skipped even on a GPU-enabled build.
 /// Set by `main()` from the `--only-cpu` flag before the model is first used.

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -75,7 +75,13 @@ fn mtime_of(path: &Path) -> f64 {
 fn chunk_embedding_key(text: &str) -> String {
     let mut hasher = sha2::Sha256::new();
     hasher.update(text.as_bytes());
-    hex::encode(hasher.finalize())
+    // Namespace the cache by model: vectors from different models are not
+    // interchangeable, so re-indexing under a new model must not reuse old ones.
+    format!(
+        "{}:{}",
+        crate::embed::active_model_id(),
+        hex::encode(hasher.finalize())
+    )
 }
 
 fn rel_path(repo_root: &Path, abs: &Path) -> String {
@@ -267,6 +273,31 @@ pub fn index_repo_with_options<F>(
 where
     F: FnMut(&str),
 {
+    // Resolve and pin the embedding model for this whole run so documents and the
+    // stamped meta agree. Precedence: an explicit TOKENIX_EMBED_MODEL wins; else
+    // keep the model the existing index already uses (sticky — a plain re-index
+    // must not silently switch models); else the default.
+    let prev_model = crate::store::index_model_id(repo_root);
+    let explicit_model = std::env::var("TOKENIX_EMBED_MODEL")
+        .ok()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .map(|s| crate::embed::spec_for(&s).id.to_string());
+    let model_id = explicit_model
+        .clone()
+        .or_else(|| prev_model.clone())
+        .unwrap_or_else(|| crate::embed::DEFAULT_MODEL_ID.to_string());
+    crate::embed::set_active_model(&model_id);
+
+    // An explicit model switch makes the existing per-chunk vectors incompatible,
+    // so force a full re-embed to keep the index single-model.
+    let mut options = options;
+    if let (Some(prev), Some(explicit)) = (&prev_model, &explicit_model) {
+        if prev != explicit {
+            options.force = true;
+        }
+    }
+
     let conn = open_db(repo_root, true)?.unwrap();
     init_schema(&conn, 768)?;
     let existing: Arc<HashMap<String, (i64, f64, String)>> = Arc::new(load_all_file_info(&conn)?);
@@ -540,10 +571,18 @@ mod tests {
     fn test_chunk_embedding_key() {
         let text = "hello world";
         let key = chunk_embedding_key(text);
-        assert_eq!(key.len(), 64); // SHA-256 hex is 64 chars
+        // "<model-id>:<64-hex>" — namespaced so different models never collide.
+        let (model, hash) = key.split_once(':').expect("key has model prefix");
+        assert_eq!(model, crate::embed::active_model_id());
+        assert_eq!(hash.len(), 64); // SHA-256 hex is 64 chars
 
         let key2 = chunk_embedding_key(text);
         assert_eq!(key, key2); // deterministic
+
+        // Switching the model changes the namespace, preventing cache reuse.
+        crate::embed::set_active_model("bge-small");
+        assert!(chunk_embedding_key(text).starts_with("bge-small:"));
+        crate::embed::set_active_model(crate::embed::DEFAULT_MODEL_ID);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -103,6 +103,11 @@ enum Commands {
         jobs: Option<usize>,
         #[arg(long, help = "Embedding batch size for indexing")]
         embed_batch: Option<usize>,
+        #[arg(
+            long,
+            help = "Embedding model id (e.g. nomic-v1.5, bge-small). See `tokenix doctor`"
+        )]
+        model: Option<String>,
         #[arg(long, help = "Update file chunks and symbol graph without embedding")]
         no_embed: bool,
     },
@@ -437,8 +442,17 @@ fn main() -> Result<()> {
             cpu_profile,
             jobs,
             embed_batch,
+            model,
             no_embed,
         } => {
+            if let Some(model) = model.as_deref() {
+                if !crate::embed::is_known_model(model) {
+                    let ids: Vec<&str> = crate::embed::MODELS.iter().map(|m| m.id).collect();
+                    anyhow::bail!("unknown --model '{model}'. Available: {}", ids.join(", "));
+                }
+                crate::embed::set_active_model(model);
+                set_env_override("TOKENIX_EMBED_MODEL", model);
+            }
             configure_index_limits(cpu_profile, only_cpu, jobs, embed_batch);
             cmd_index(&path, force, if_stale, no_embed)
         }

--- a/src/query.rs
+++ b/src/query.rs
@@ -18,6 +18,11 @@ pub fn query_index(
         None => return Ok(None),
     };
 
+    // Embed the query with the SAME model the index was built with (read from the
+    // index meta) so query and document vectors are comparable.
+    if let Some(model_id) = crate::store::index_model_id(repo_root) {
+        crate::embed::set_active_model(&model_id);
+    }
     let vec = embed_query(query_text)?;
     let candidate_k = (k.saturating_mul(5)).max(50);
     let mut results = hybrid_search(&conn, &vec, query_text, candidate_k, file_filter)?;

--- a/src/store.rs
+++ b/src/store.rs
@@ -1038,6 +1038,25 @@ pub fn index_staleness(repo_root: &Path) -> IndexStaleness {
         };
     }
 
+    // A model change only makes the index stale when a model is *explicitly*
+    // requested via TOKENIX_EMBED_MODEL. Otherwise queries use whatever model the
+    // index was built with (read from meta), so a differing local default must not
+    // invalidate a perfectly usable index (e.g. a hook with no env set).
+    if let Ok(desired_raw) = std::env::var("TOKENIX_EMBED_MODEL") {
+        let desired_raw = desired_raw.trim();
+        if !desired_raw.is_empty() {
+            let desired = crate::embed::spec_for(desired_raw).id;
+            let stored = meta_value(&conn, "embed_model")
+                .unwrap_or_else(|| crate::embed::DEFAULT_MODEL_ID.to_string());
+            if stored != desired {
+                return IndexStaleness {
+                    stale: true,
+                    reason: format!("embedding model changed ({stored} -> {desired})"),
+                };
+            }
+        }
+    }
+
     if let Some(current) = git_fingerprint(repo_root) {
         match meta_value(&conn, "git_fingerprint") {
             Some(stored) if stored == current => {}
@@ -1091,10 +1110,21 @@ pub fn index_staleness(repo_root: &Path) -> IndexStaleness {
 
 pub fn write_index_meta(conn: &Connection, repo_root: &Path, indexed_at: f64) -> Result<()> {
     set_meta(conn, "indexed_at", &indexed_at.to_string())?;
+    set_meta(conn, "embed_model", &crate::embed::active_model_id())?;
     if let Some(fp) = git_fingerprint(repo_root) {
         set_meta(conn, "git_fingerprint", &fp)?;
     }
     Ok(())
+}
+
+/// The embedding model id the index was built with. Defaults to the historical
+/// model for indexes created before model stamping. `None` if there is no index.
+pub fn index_model_id(repo_root: &Path) -> Option<String> {
+    let conn = open_db(repo_root, false).ok()??;
+    Some(
+        meta_value(&conn, "embed_model")
+            .unwrap_or_else(|| crate::embed::DEFAULT_MODEL_ID.to_string()),
+    )
 }
 
 fn meta_value(conn: &Connection, key: &str) -> Option<String> {


### PR DESCRIPTION
Makes the embedding model **configurable** instead of hard-coded `nomic-embed-v1.5`, **without changing the default** — existing indexes keep working untouched.

## Why
Users asked to index with lighter/faster or code-specialized models. Today the model is fixed in `embed.rs`.

## What
- **Registry** (`embed.rs::MODELS`): `nomic-v1.5` (default), `bge-small`, `bge-base`, `minilm-l6`, `e5-small`, each with the correct query/document prefixes (nomic `search_*:`, e5 `query:`/`passage:`, bge/minilm none — wrong prefixes silently hurt recall).
- **Select** via `tokenix index --model <id>` or `TOKENIX_EMBED_MODEL=<id>`.
- **Consistency by construction**: the chosen model is stamped into the index `meta`; query/hook/daemon read it back (`store::index_model_id` → `embed::set_active_model`) so query vectors always match the indexed documents.
- **Sticky**: a plain re-index keeps the index's model; only an explicit `--model`/env switch re-embeds (full), and the embedding cache + query cache are **namespaced by model** so vectors are never mixed.
- **No false staleness**: `index_staleness` flags a model change only when `TOKENIX_EMBED_MODEL` is explicitly set, so a hook with no env never rejects a usable index.
- **Daemon-safe**: active model is thread-local, so handler threads serving different projects don't race.
- `tokenix doctor` lists available + active + this-repo's model.
- bge/minilm use the **non-quantized** ONNX (the Qdrant-Q graphs fail this ORT build's `SkipLayerNormalization`; nomic-Q is fine and stays default).

## Tests
Registry/prefix/override unit tests + updated `chunk_embedding_key` test. Full suite green; fmt/clippy clean. Functionally verified: index with `--model bge-small` → stamped + query consistent; plain re-index stays bge; explicit switch to nomic re-embeds.

## Follow-up (separate PR)
Custom-ONNX slot (`UserDefinedEmbeddingModel`) to add **jina-embeddings-v2-base-code** (code-specialized) + a comparative code-retrieval benchmark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)