### PR TITLE
fix(filters): stop hiding real output of network/state commands

### DIFF
--- a/assets/filters/gh-cli.toml
+++ b/assets/filters/gh-cli.toml
@@ -2,35 +2,28 @@
 description = "Compact GitHub CLI output"
 match_command = "^gh\\s+\\w+\\b"
 strip_ansi = true
+# Strip only blank lines and the success checkmark decorations. Real output
+# (PR/issue URLs, list tables, `gh auth status`, etc.) is the signal and must
+# survive — never collapse it to a bare "ok".
 strip_lines_matching = [
   "^\\s*$",
-  "^✓ ",
-  "^✔ ",
-  "^Creating ",
-  "^Created ",
-  "^Updated ",
-  "^Deleted "
-]
-keep_lines_matching = [
-  "error:",
-  "Error:",
-  "failed",
-  "FAILED",
-  "not found",
-  "unauthorized",
-  "rate limit"
+  "^\\s*✓\\s*$",
+  "^\\s*✔\\s*$"
 ]
 max_lines = 40
+passthrough_when_emptied = true
 on_empty = "gh: ok"
 
 [[tests.gh-cli]]
-name = "clean pr create"
+name = "clean pr create keeps url"
 input = """
 Creating pull request for feature-branch into main in owner/repo
 
 https://github.com/owner/repo/pull/42
 """
-expected = "gh: ok"
+expected = """
+Creating pull request for feature-branch into main in owner/repo
+https://github.com/owner/repo/pull/42"""
 
 [[tests.gh-cli]]
 name = "error shown"

--- a/assets/filters/gh-issue.toml
+++ b/assets/filters/gh-issue.toml
@@ -2,39 +2,19 @@
 description = "Compact gh issue output"
 match_command = "^gh\\s+issue\\s+(list|view|create|close|reopen|comment|edit|transfer|pin|unpin|develop)\\b"
 strip_ansi = true
+# Strip blank lines and success checkmark decorations only. Field lines, the
+# issue body, comments, and URLs are the signal and must survive.
 strip_lines_matching = [
   "^\\s*$",
   "^\\s*✓",
-  "^\\s*✔",
-  "^Creating",
-  "^Created",
-  "^Updating",
-  "^Closed",
-  "^Reopened",
-]
-keep_lines_matching = [
-  "error:",
-  "Error:",
-  "failed",
-  "FAILED",
-  "not found",
-  "unauthorized",
-  "rate limit",
-  "#",
-  "title:",
-  "state:",
-  "author:",
-  "assignees:",
-  "labels:",
-  "milestone:",
-  "body:",
-  "comments:",
+  "^\\s*✔"
 ]
 max_lines = 40
+passthrough_when_emptied = true
 on_empty = "gh issue: ok"
 
 [[tests.gh-issue]]
-name = "issue view"
+name = "issue view keeps body and comments"
 input = """
 title: Bug in login
 state: OPEN
@@ -56,7 +36,9 @@ author: user
 assignees: user
 labels: bug, high-priority
 milestone: v1.0
+Login fails with 500 error when password contains special characters.
 comments:
+  user: investigating...
   user: fixed in PR #42"""
 
 [[tests.gh-issue]]

--- a/assets/filters/gh-pr.toml
+++ b/assets/filters/gh-pr.toml
@@ -2,45 +2,19 @@
 description = "Compact gh pr output"
 match_command = "^gh\\s+pr\\s+(list|view|create|checkout|merge|ready|comment|edit|close|reopen|diff|checks|status)\\b"
 strip_ansi = true
+# Strip blank lines and the passing-check decorations only. Field lines, failing
+# checks, and the PR URL are the signal and must survive.
 strip_lines_matching = [
   "^\\s*$",
   "^\\s*✓",
-  "^\\s*✔",
-  "^Creating",
-  "^Created",
-  "^Updating",
-  "^Merged",
-  "^Closed",
-  "^Reopened",
-]
-keep_lines_matching = [
-  "error:",
-  "Error:",
-  "failed",
-  "FAILED",
-  "not found",
-  "unauthorized",
-  "rate limit",
-  "#",
-  "PR-",
-  "title:",
-  "state:",
-  "author:",
-  "reviewers:",
-  "assignees:",
-  "labels:",
-  "milestone:",
-  "base:",
-  "head:",
-  "checks:",
-  "passing",
-  "failing",
+  "^\\s*✔"
 ]
 max_lines = 40
+passthrough_when_emptied = true
 on_empty = "gh pr: ok"
 
 [[tests.gh-pr]]
-name = "pr view"
+name = "pr view keeps fields and url"
 input = """
 title: Add new feature
 state: OPEN
@@ -70,7 +44,8 @@ milestone: v1.0
 base: main
 head: feature/new-feature
 checks:
-  ✗ Tests (2 failing)"""
+  ✗ Tests (2 failing)
+view this pull request on GitHub: https://github.com/owner/repo/pull/42"""
 
 [[tests.gh-pr]]
 name = "error shown"

--- a/assets/filters/gh-run.toml
+++ b/assets/filters/gh-run.toml
@@ -2,43 +2,19 @@
 description = "Compact gh run output"
 match_command = "^gh\\s+run\\s+(list|view|watch|download|rerun|cancel|delete)\\b"
 strip_ansi = true
+# Strip blank lines and the passing-step decorations only. Field lines, failing
+# steps, error context, and the run URL are the signal and must survive.
 strip_lines_matching = [
   "^\\s*$",
   "^\\s*✓",
-  "^\\s*✔",
-  "^Downloading",
-  "^Completed",
-  "^Rerunning",
-  "^Cancelling",
-]
-keep_lines_matching = [
-  "error:",
-  "Error:",
-  "failed",
-  "FAILED",
-  "not found",
-  "unauthorized",
-  "rate limit",
-  "workflow:",
-  "run:",
-  "status:",
-  "conclusion:",
-  "created:",
-  "head_branch:",
-  "head_sha:",
-  "jobs:",
-  "passed",
-  "failed",
-  "skipped",
-  "completed",
-  "in_progress",
-  "queued",
+  "^\\s*✔"
 ]
 max_lines = 40
+passthrough_when_emptied = true
 on_empty = "gh run: ok"
 
 [[tests.gh-run]]
-name = "run view"
+name = "run view keeps fields and url"
 input = """
 workflow: CI
 run: 12345
@@ -65,7 +41,9 @@ created: 2024-01-15T10:30:00Z
 head_branch: feature/new-feature
 head_sha: abc123
 jobs:
-    Error: Compilation failed"""
+  ✗ build (3m 45s)
+    Error: Compilation failed
+view this run on GitHub: https://github.com/owner/repo/actions/runs/12345"""
 
 [[tests.gh-run]]
 name = "error shown"

--- a/assets/filters/git-fetch.toml
+++ b/assets/filters/git-fetch.toml
@@ -2,18 +2,14 @@
 description = "Compact git fetch output"
 match_command = "^git\\s+fetch\\b"
 strip_ansi = true
+# Strip remote progress only; the "From" header and refspec updates are the
+# signal and must survive.
 strip_lines_matching = [
   "^\\s*$",
-  "^remote:",
-  "^From "
-]
-keep_lines_matching = [
-  "error:",
-  "fatal:",
-  "failed",
-  "Permission denied"
+  "^remote:"
 ]
 max_lines = 20
+passthrough_when_emptied = true
 on_empty = "git fetch: done"
 
 [[tests.git-fetch]]
@@ -25,7 +21,9 @@ remote: Compressing objects: 100% (25/25), done.
 From github.com:user/repo
    abc123..def456  main     -> origin/main
 """
-expected = "git fetch: done"
+expected = """
+From github.com:user/repo
+   abc123..def456  main     -> origin/main"""
 
 [[tests.git-fetch]]
 name = "error shown"

--- a/assets/filters/git-pull.toml
+++ b/assets/filters/git-pull.toml
@@ -2,26 +2,16 @@
 description = "Compact git pull output"
 match_command = "^git\\s+pull\\b"
 strip_ansi = true
+# Strip remote/unpack progress only. The "Updating"/"Fast-forward" range,
+# diffstat, and any conflict lines are the signal and must survive.
 strip_lines_matching = [
   "^\\s*$",
   "^remote:",
   "^Unpacking objects:",
-  "^From ",
-  "^ *\\[new branch\\]",
-  "^ *\\[new tag\\]",
-  "^Already up to date",
-  "^Fast-forward",
-  "^Updating "
-]
-keep_lines_matching = [
-  "error:",
-  "fatal:",
-  "CONFLICT",
-  "Automatic merge failed",
-  "Merge conflict",
-  "Unmerged paths"
+  "^Already up to date"
 ]
 max_lines = 30
+passthrough_when_emptied = true
 on_empty = "git pull: ok"
 
 [[tests.git-pull]]
@@ -38,7 +28,13 @@ Fast-forward
  src/main.rs | 2 ++
  1 file changed, 2 insertions(+)
 """
-expected = "git pull: ok"
+expected = """
+From github.com:user/repo
+   abc123..def456  main     -> origin/main
+Updating abc123..def456
+Fast-forward
+ src/main.rs | 2 ++
+ 1 file changed, 2 insertions(+)"""
 
 [[tests.git-pull]]
 name = "conflict shown"
@@ -51,5 +47,8 @@ CONFLICT (content): Merge conflict in src/main.rs
 Automatic merge failed; fix conflicts and then commit the result.
 """
 expected = """
+From github.com:user/repo
+   abc123..def456  main     -> origin/main
+Auto-merging src/main.rs
 CONFLICT (content): Merge conflict in src/main.rs
 Automatic merge failed; fix conflicts and then commit the result."""

--- a/assets/filters/git-push.toml
+++ b/assets/filters/git-push.toml
@@ -2,6 +2,9 @@
 description = "Compact git push output"
 match_command = "^git\\s+push\\b"
 strip_ansi = true
+# Strip only the progress noise. The push *result* (destination + refspec +
+# new-branch line) is the signal and must survive — never collapse a real push
+# to a bare "ok" that hides what was pushed.
 strip_lines_matching = [
   "^\\s*$",
   "^Enumerating objects:",
@@ -9,21 +12,12 @@ strip_lines_matching = [
   "^Compressing objects:",
   "^Writing objects:",
   "^Total ",
-  "^To ",
-  "^ *\\[new branch\\]",
-  "^ *\\[new tag\\]",
   "^Branch.*set up to track",
   "^Everything up-to-date"
 ]
-keep_lines_matching = [
-  "error:",
-  "fatal:",
-  "rejected",
-  "failed to push",
-  "non-fast-forward",
-  "Updates were rejected"
-]
 max_lines = 20
+# If an unexpected format strips to empty, show the real output instead of on_empty.
+passthrough_when_emptied = true
 on_empty = "git push: ok"
 
 [[tests.git-push]]
@@ -37,7 +31,9 @@ To github.com:user/repo.git
    abc123..def456  main -> main
 Branch 'main' set up to track remote branch 'main' from 'origin'.
 """
-expected = "git push: ok"
+expected = """
+To github.com:user/repo.git
+   abc123..def456  main -> main"""
 
 [[tests.git-push]]
 name = "rejected push shown"
@@ -50,6 +46,9 @@ hint: its remote counterpart. Integrate the remote changes (e.g.
 hint: 'git pull ...') before pushing again.
 """
 expected = """
+To github.com:user/repo.git
  ! [rejected]        main -> main (non-fast-forward)
 error: failed to push some refs to 'github.com:user/repo.git'
-hint: Updates were rejected because the tip of your current branch is behind"""
+hint: Updates were rejected because the tip of your current branch is behind
+hint: its remote counterpart. Integrate the remote changes (e.g.
+hint: 'git pull ...') before pushing again."""

--- a/assets/filters/kubectl-get.toml
+++ b/assets/filters/kubectl-get.toml
@@ -2,20 +2,15 @@
 description = "Compact kubectl get output"
 match_command = "^kubectl(?:\\s+(?:-[A-Za-z][-A-Za-z0-9]*|--[A-Za-z][-A-Za-z0-9]*)(?:[=\\s]+\\S+)?)*\\s+get\\b"
 strip_ansi = true
+# Strip blank lines and the verbose pod header only. Every resource row is the
+# signal and must survive — a status whitelist would drop nodes/services/jobs/
+# configmaps (no "Running" column) and falsely report "no resources".
 strip_lines_matching = [
   "^\\s*$",
   "^NAME\\s+READY\\s+STATUS\\s+RESTARTS\\s+AGE"
 ]
-keep_lines_matching = [
-  "Running",
-  "Pending",
-  "CrashLoopBackOff",
-  "Error",
-  "Completed",
-  "Terminating",
-  "Evicted"
-]
 max_lines = 40
+passthrough_when_emptied = true
 on_empty = "kubectl get: no resources"
 
 [[tests.kubectl-get]]
@@ -39,3 +34,15 @@ myapp-db-def456         0/1     CrashLoopBackOff   5          10m
 expected = """
 myapp-web-abc123        1/1     Running            0          2h
 myapp-db-def456         0/1     CrashLoopBackOff   5          10m"""
+
+[[tests.kubectl-get]]
+name = "nodes shown not falsely empty"
+input = """
+NAME      STATUS   ROLES           AGE   VERSION
+node-1    Ready    control-plane   90d   v1.30.2
+node-2    Ready    <none>          90d   v1.30.2
+"""
+expected = """
+NAME      STATUS   ROLES           AGE   VERSION
+node-1    Ready    control-plane   90d   v1.30.2
+node-2    Ready    <none>          90d   v1.30.2"""


### PR DESCRIPTION
git-push/fetch/pull, gh-cli/pr/run/issue and kubectl-get used an error-only keep_lines_matching whitelist, so successful output was discarded and replaced by a canned on_empty line — hiding push refspecs, PR URLs, run details and resource rows (kubectl get falsely reported "no resources" for nodes/services/ jobs). Drop the whitelist so result lines survive, keep stripping genuine progress noise, and set passthrough_when_emptied so an unrecognized format shows the real output instead of a false summary. Golden tests updated accordingly.