### PR TITLE
feat: add native OpenCode MCP integration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@ tokenix --help
 
 | File | Purpose |
 |---|---|
-| `src/main.rs` | CLI entry (clap), command dispatch, `install-hook`/`remove-hook` helpers (including Antigravity global install/uninstall through `agy plugin` and local `.agents/plugins/tokenix`), `install-binary` (copies the running exe to `global_bin_dir()` — `%LOCALAPPDATA%\tokenix\bin` / `~/.local/bin` — and persists the Windows user PATH via PowerShell `[Environment]::SetEnvironmentVariable`, never `setx`). `banner()` = neon "tokenix" wordmark + tagline; `help_catalog()` = audience-grouped command list (AI agent vs human) + examples, wired via custom `HELP_TEMPLATE` (`before_help`/`after_help`); bare `tokenix` prints this help |
+| `src/main.rs` | CLI entry (clap), command dispatch, `install-hook`/`remove-hook` helpers (including Antigravity global install/uninstall through `agy plugin`, repo-local OpenCode native `opencode.json` MCP registration/removal, and local `.agents/plugins/tokenix`), `install-binary` (copies the running exe to `global_bin_dir()` — `%LOCALAPPDATA%\tokenix\bin` / `~/.local/bin` — and persists the Windows user PATH via PowerShell `[Environment]::SetEnvironmentVariable`, never `setx`). `banner()` = neon "tokenix" wordmark + tagline; `help_catalog()` = audience-grouped command list (AI agent vs human) + examples, wired via custom `HELP_TEMPLATE` (`before_help`/`after_help`); bare `tokenix` prints this help |
 | `src/chunker.rs` | Symbol-aware heuristic chunking, `generate_outline()`, token counting. Tree-sitter for Rust/Python/TS/JS/Go/C++; `chunk_by_symbol_lines()` line-scanning chunkers for grammar-less languages — VB6/VBA (`Sub`/`Function`/`Property`/`Attribute VB_Name`) and SQL (`CREATE [OR REPLACE] <object>`) |
 | `src/embed.rs` | fastembed ONNX — `embed_documents()`, `embed_query()`. Model **registry** (`MODELS`, `spec_for`) + thread-local active model (`set_active_model`/`active_model_id`) + per-id loaded-model cache. Per-model query/doc prefixes; query cache keyed by model |
 | `src/store.rs` | SQLite schema, CRUD, cosine similarity search (int8-quantized vectors + legacy f32 fallback, `quantize_q8`/`backfill_quantized_embeddings`), import graph (`graph_imports`, `file_imports`), hook log I/O + 5 MB rotation, PID index lock, branch-aware DB paths |
@@ -39,7 +39,7 @@ tokenix --help
 | `src/ui.rs` | Shared terminal-UI vocabulary for human-facing CLI output (`box_header`, `bar`, `section`/`kv`, `format_num`, `table` via `tabled`); LLM/JSON output deliberately does not route through it |
 | `src/gain.rs` | `compute_gain()`/`compute_global_gain()`, `GainStats` (incl. `index_saved`/`filter_saved` source split: empty `command` = semantic-index intercept, non-empty = command filter; pre-phase Bash rewrite markers are excluded from `filter_calls`), `MODELS` pricing table (Anthropic/OpenAI/Google) |
 | `src/mcp.rs` | MCP server. `--profile full` exposes all tools; `--profile slim` exposes context/search/call meta-tools for progressive discovery |
-| `src/mcp_audit.rs` | `tokenix prompt-audit` / `session-audit` — per-agent MCP config discovery + minimal synchronous MCP stdio client (`initialize`/`tools/list`) + token scoring/report |
+| `src/mcp_audit.rs` | `tokenix prompt-audit` / `session-audit` — per-agent MCP config discovery (Claude, Codex, Copilot, OpenCode, Antigravity) + minimal synchronous MCP stdio client (`initialize`/`tools/list`) + token scoring/report |
 | `src/secrets_scan.rs` | `tokenix scan-secrets` — gitleaks-style credential scan of Claude/Gemini/Copilot/Antigravity conversation transcripts under `~`; rules loaded from TOML (`assets/secret-rules/` bundled via `rust-embed`, extended by `<repo>/` then `~/.tokenix/secret-rules/*.toml`, later `id` wins), backtracking-free regex + entropy-gated generic rule. Each finding is attributed to its repo + git branch via the transcript line's `cwd`/`gitBranch` (Claude), falling back to the project dir slug. Report supports `--filter` (substring), `--group <value\|rule\|agent\|file\|repo>`, `--reveal` (raw values, default redacted), `--json`; exit 1 on hits. `scan_findings()` returns structured `ScanFinding`s (raw + redacted) for the TUI; `redact_in_files()` rewrites `[REDACTED]` over a value in text files (SQLite DBs skipped) |
 | `assets/filters/` | 244 TOML output filters embedded via `rust-embed`, each homologated with ≥2 golden `[[tests]]` cases (realistic success + failure-path inputs; the failure case must prove errors are never masked). 522 cases run through the real `apply_filter` pipeline in `bundled_filters_pass_embedded_golden_tests`. User filters in `~/.tokenix/filters/` take priority |
 
@@ -181,6 +181,7 @@ Per-agent MCP config sources (one `ConfigSource` each, ausente = silently skippe
 |---|---|---|
 | Claude Code | `<repo>/.mcp.json` + `~/.claude.json` (`mcpServers` + `projects[<cwd>]`) | JSON |
 | Codex | `~/.codex/config.toml` → `[mcp_servers.<name>]` | TOML (`toml` dep) |
+| OpenCode | `<repo>/opencode.json` (`mcp`) | JSON |
 | Antigravity | `~/.gemini/antigravity-cli/mcp_config.json` (`mcp_config_path()`) | JSON |
 | Copilot | `.vscode/mcp.json` (`servers`) + VS Code user `mcp.json` | JSON, best-effort |
 
@@ -344,6 +345,11 @@ The daemon auto-starts on first Grep hook call. Run `tokenix serve` manually onl
 
 ### OpenAI Codex CLI
 - Config: `~/.codex/hooks.json` for `PreToolUse` Bash rewrites + optional shell helpers under `~/.codex/`
+
+### OpenCode
+- Config: repo-local `opencode.json` native `mcp` block
+- Shape: `{"mcp":{"tokenix":{"type":"local","command":["tokenix","mcp"]}}}`
+- Note: tokenix does **not** install `experimental.hook`; OpenCode support is native MCP registration only
 
 ### Antigravity
 - Global config: `~/.gemini/config/plugins/tokenix/`, installed and registered through `agy plugin install`

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 
 ---
 
-> **tokenix** is a local-first Rust CLI that helps AI coding agents understand a repository without dumping huge files into the prompt. It indexes your code, finds relevant chunks by meaning, returns compact file outlines, and can hook into AI tools to replace noisy reads and command output with smaller, more useful context. Works with Claude Code, GitHub Copilot, OpenAI Codex CLI, Gemini, and any MCP client. **No Ollama or external server required.**
+> **tokenix** is a local-first Rust CLI that helps AI coding agents understand a repository without dumping huge files into the prompt. It indexes your code, finds relevant chunks by meaning, returns compact file outlines, and can hook into AI tools to replace noisy reads and command output with smaller, more useful context. Works with Claude Code, GitHub Copilot, OpenAI Codex CLI, OpenCode, Gemini, and any MCP client. **No Ollama or external server required.**
 
 ```
 Without tokenix:  Read(src/auth/middleware.rs) → 800 lines → ~2,400 tokens  (illustrative)
@@ -194,6 +194,7 @@ The embedding model (`nomic-embed-text-v1.5`, ~130 MB) is downloaded automatical
 | [Claude Code](https://docs.anthropic.com/en/docs/claude-code) | `PreToolUse` hooks in `~/.claude/settings.json` or project `.claude/settings.local.json` |
 | [GitHub Copilot](https://docs.github.com/en/copilot) | `.github/copilot-instructions.md` + VS Code-compatible `.github/hooks/hooks.json` |
 | [OpenAI Codex CLI](https://help.openai.com/en/articles/11096431-openai-codex-cli-getting-started) | `~/.codex/hooks.json` for `PreToolUse` Bash rewrites + optional shell helpers |
+| OpenCode | `tokenix install-hook --tool opencode` — registers `tokenix mcp` in a native `opencode.json` `mcp` block |
 | Antigravity | `tokenix install-hook --tool antigravity` — installs and validates a native `PreToolUse` plugin through `agy plugin` |
 | Any MCP client | `tokenix mcp` — Model Context Protocol server over stdin/stdout (`--tool mcp`) |
 
@@ -309,7 +310,7 @@ auditable.
 
 ```bash
 tokenix prompt-audit                  # every agent that has MCP config
-tokenix prompt-audit --agent claude   # one agent (claude|codex|copilot|antigravity)
+tokenix prompt-audit --agent claude   # one agent (claude|codex|copilot|opencode|antigravity)
 tokenix prompt-audit --json           # machine-readable
 tokenix prompt-audit --recommend      # include practical reduction advice
 tokenix conversation-audit            # scan agent histories for token-waste blobs
@@ -409,6 +410,27 @@ echo '. ~/.codex/tokenix-init.ps1' >> $PROFILE
 
 Then use `tx-read` and `tx-query` as shell helpers. On Windows this also installs `~/.codex/hooks.json` and a PowerShell wrapper that forwards `PreToolUse` intercepts for Bash-like terminal tools (`Bash`, `run_in_terminal`) and normalizes `grep_search` to the same semantic path as `Grep`.
 
+### OpenCode
+
+```bash
+tokenix install-hook --tool opencode
+```
+
+Writes a native `opencode.json` entry for `mcp.tokenix` in the current repository root:
+
+```json
+{
+  "mcp": {
+    "tokenix": {
+      "type": "local",
+      "command": ["tokenix", "mcp"]
+    }
+  }
+}
+```
+
+This integration is MCP-only. tokenix does **not** install OpenCode `experimental.hook` entries and does **not** emulate Claude-style `PreToolUse` / `PostToolUse` hooks in OpenCode. The generated config expects `tokenix` to be available on `PATH`; run `tokenix install-binary` first if needed.
+
 ### Antigravity
 
 ```bash
@@ -429,6 +451,8 @@ The native hook handles Antigravity's `toolCall.name/args` payload and returns
 ```bash
 tokenix install-hook --tool all
 ```
+
+`--tool all` intentionally skips OpenCode. Use `tokenix install-hook --tool opencode` explicitly when you want tokenix to write a repo-local `opencode.json` MCP registration.
 
 ---
 
@@ -528,13 +552,13 @@ tokenix install-hook --tool all
 
 **`tokenix flow`** — `--depth/-d` (3), `--format <text\|mermaid>`, `--output/-o`, `--path/-p`
 
-**`tokenix install-hook` / `remove-hook`** — `--tool <claude-code\|copilot\|codex\|mcp\|antigravity\|all>` (default `all`), `--local` (Claude Code, Copilot, and Antigravity)
+**`tokenix install-hook` / `remove-hook`** — `--tool <claude-code\|copilot\|codex\|mcp\|opencode\|antigravity\|all>` (default `all`), `--local` (Claude Code, Copilot, and Antigravity)
 
 **`tokenix pack`** — `--mode/--profile <plan\|debug\|audit\|security\|review>`, `--budget N` (8000), `--format <markdown\|xml\|json>`, `--changed`, `--since REF`, `--token-map`, `--output/-o`
 
 **`tokenix benchmark`** — `--budget N` (1200), `--json`, `--refresh-index`, `--cases FILE`
 
-**`tokenix prompt-audit`** — `--agent <claude\|codex\|copilot\|antigravity\|all>` (default `all`), `--json`, `--recommend`, `--profile-impact`
+**`tokenix prompt-audit`** — `--agent <claude\|codex\|copilot\|opencode\|antigravity\|all>` (default `all`), `--json`, `--recommend`, `--profile-impact`
 
 **`tokenix session-audit`** — `--json`, `--cache-hygiene`, `--path/-p`
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -76,6 +76,8 @@ enum Tool {
     Codex,
     #[value(name = "mcp")]
     Mcp,
+    #[value(name = "opencode")]
+    OpenCode,
     #[value(name = "antigravity")]
     Antigravity,
     #[value(name = "all")]
@@ -90,6 +92,8 @@ enum AuditAgent {
     Codex,
     #[value(name = "copilot")]
     Copilot,
+    #[value(name = "opencode")]
+    OpenCode,
     #[value(name = "antigravity")]
     Antigravity,
     #[value(name = "all")]
@@ -438,7 +442,7 @@ enum Commands {
             long,
             value_enum,
             default_value = "all",
-            help = "Target tool: claude-code | copilot | codex | mcp | antigravity | all"
+            help = "Target tool: claude-code | copilot | codex | mcp | opencode | antigravity | all"
         )]
         tool: Tool,
         #[arg(
@@ -945,6 +949,7 @@ fn main() -> Result<()> {
                 AuditAgent::Claude => Some(mcp_audit::Agent::ClaudeCode),
                 AuditAgent::Codex => Some(mcp_audit::Agent::Codex),
                 AuditAgent::Copilot => Some(mcp_audit::Agent::Copilot),
+                AuditAgent::OpenCode => Some(mcp_audit::Agent::OpenCode),
                 AuditAgent::Antigravity => Some(mcp_audit::Agent::Antigravity),
                 AuditAgent::All => None,
             };
@@ -2492,6 +2497,7 @@ fn cmd_install_hook(tool: Tool, local: bool) -> Result<()> {
         Tool::Copilot => install_copilot(local)?,
         Tool::Codex => install_codex()?,
         Tool::Mcp => install_mcp_server()?,
+        Tool::OpenCode => install_opencode()?,
         Tool::Antigravity => install_antigravity(local)?,
         Tool::All => {
             install_claude_code(local)?;
@@ -3009,6 +3015,7 @@ fn cmd_remove_hook(tool: Tool, local: bool) -> Result<()> {
         Tool::Copilot => remove_copilot(local)?,
         Tool::Codex => remove_codex()?,
         Tool::Mcp => remove_mcp_server()?,
+        Tool::OpenCode => remove_opencode()?,
         Tool::Antigravity => remove_antigravity(local)?,
         Tool::All => {
             remove_claude_code(local)?;
@@ -3123,6 +3130,87 @@ fn mcp_config_path() -> Result<PathBuf> {
         .join(".gemini")
         .join("antigravity-cli")
         .join("mcp_config.json"))
+}
+
+fn opencode_config_path() -> Result<PathBuf> {
+    let cwd = std::env::current_dir()?;
+    let repo_root = store::find_project_root(&cwd);
+    Ok(repo_root.join("opencode.json"))
+}
+
+fn opencode_mcp_entry(tokenix_bin: &str) -> serde_json::Value {
+    serde_json::json!({
+        "type": "local",
+        "command": [tokenix_bin, "mcp"]
+    })
+}
+
+fn upsert_opencode_mcp(config: &mut serde_json::Value, tokenix_bin: &str) {
+    if !config.get("mcp").is_some_and(serde_json::Value::is_object) {
+        config["mcp"] = serde_json::json!({});
+    }
+    config["mcp"]["tokenix"] = opencode_mcp_entry(tokenix_bin);
+}
+
+fn remove_opencode_mcp(config: &mut serde_json::Value) -> bool {
+    let Some(mcp) = config.get_mut("mcp").and_then(|v| v.as_object_mut()) else {
+        return false;
+    };
+    let removed = mcp.remove("tokenix").is_some();
+    let empty = mcp.is_empty();
+    if empty {
+        if let Some(root) = config.as_object_mut() {
+            root.remove("mcp");
+        }
+    }
+    removed
+}
+
+fn install_opencode() -> Result<()> {
+    let config_path = opencode_config_path()?;
+    if let Some(parent) = config_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let mut config: serde_json::Value = if config_path.exists() {
+        let raw = std::fs::read_to_string(&config_path)?;
+        serde_json::from_str(&raw).unwrap_or(serde_json::json!({}))
+    } else {
+        serde_json::json!({})
+    };
+    upsert_opencode_mcp(&mut config, "tokenix");
+    std::fs::write(&config_path, serde_json::to_string_pretty(&config)?)?;
+    println!(
+        "{} OpenCode MCP registered    ->  {}",
+        "ok".green(),
+        config_path.display()
+    );
+    println!("  MCP:         tokenix mcp (native `opencode.json` registration)");
+    println!(
+        "  Note: OpenCode support is MCP-only; no experimental.hook or PreToolUse/PostToolUse wiring is installed."
+    );
+    println!(
+        "  Note: the generated config uses `tokenix` from PATH. Run `tokenix install-binary` first if needed."
+    );
+    Ok(())
+}
+
+fn remove_opencode() -> Result<()> {
+    let config_path = opencode_config_path()?;
+    if !config_path.exists() {
+        println!("{} OpenCode config not found.", "~".yellow());
+        return Ok(());
+    }
+    let raw = std::fs::read_to_string(&config_path)?;
+    let mut config: serde_json::Value = serde_json::from_str(&raw)?;
+    if remove_opencode_mcp(&mut config) {
+        std::fs::write(&config_path, serde_json::to_string_pretty(&config)?)?;
+        println!(
+            "{} OpenCode MCP removed from {}",
+            "ok".green(),
+            config_path.display()
+        );
+    }
+    Ok(())
 }
 
 fn install_mcp_server() -> Result<()> {
@@ -3613,7 +3701,7 @@ fn help_catalog() -> String {
         (
             "install-hook",
             "",
-            "Wire tokenix into Claude / Copilot / Codex / Antigravity",
+            "Wire tokenix into Claude / Copilot / Codex / OpenCode / Antigravity",
         ),
         ("remove-hook", "", "Remove tokenix hooks"),
         ("doctor", "", "Diagnose embedding backend, GPU, daemon"),
@@ -3926,6 +4014,77 @@ mod tests {
     }
 
     #[test]
+    fn upsert_opencode_mcp_preserves_foreign_keys() {
+        let mut config = serde_json::json!({
+            "model": "openai/gpt-5.4",
+            "mcp": {
+                "docs": {
+                    "type": "local",
+                    "command": ["uvx", "mcp-docs"]
+                }
+            },
+            "permission": {"bash": "allow"}
+        });
+
+        upsert_opencode_mcp(&mut config, "tokenix");
+
+        assert_eq!(config["model"], "openai/gpt-5.4");
+        assert_eq!(config["permission"]["bash"], "allow");
+        assert_eq!(config["mcp"]["docs"]["command"][0], "uvx");
+        assert_eq!(config["mcp"]["tokenix"]["type"], "local");
+        assert_eq!(config["mcp"]["tokenix"]["command"][0], "tokenix");
+        assert_eq!(config["mcp"]["tokenix"]["command"][1], "mcp");
+        assert!(
+            config
+                .get("experimental")
+                .and_then(|v| v.get("hook"))
+                .is_none(),
+            "OpenCode native install must not create experimental hooks"
+        );
+    }
+
+    #[test]
+    fn remove_opencode_mcp_preserves_foreign_servers() {
+        let mut config = serde_json::json!({
+            "mcp": {
+                "tokenix": {
+                    "type": "local",
+                    "command": ["tokenix", "mcp"]
+                },
+                "docs": {
+                    "type": "remote",
+                    "url": "https://example.com/mcp"
+                }
+            }
+        });
+
+        let removed = remove_opencode_mcp(&mut config);
+
+        assert!(removed);
+        assert!(config["mcp"].get("tokenix").is_none());
+        assert_eq!(config["mcp"]["docs"]["url"], "https://example.com/mcp");
+    }
+
+    #[test]
+    fn remove_opencode_mcp_drops_empty_mcp_container() {
+        let mut config = serde_json::json!({
+            "mcp": {
+                "tokenix": {
+                    "type": "local",
+                    "command": ["tokenix", "mcp"]
+                }
+            },
+            "model": "openai/gpt-5.4"
+        });
+
+        let removed = remove_opencode_mcp(&mut config);
+
+        assert!(removed);
+        assert!(config.get("mcp").is_none());
+        assert_eq!(config["model"], "openai/gpt-5.4");
+    }
+
+    #[test]
     fn hook_install_targets_exclude_discontinued_gemini_cli() {
         let targets: Vec<_> = Tool::value_variants()
             .iter()
@@ -3934,5 +4093,6 @@ mod tests {
             .collect();
         assert!(!targets.iter().any(|target| target == "gemini"));
         assert!(targets.iter().any(|target| target == "antigravity"));
+        assert!(targets.iter().any(|target| target == "opencode"));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3173,7 +3173,7 @@ fn install_opencode() -> Result<()> {
     }
     let mut config: serde_json::Value = if config_path.exists() {
         let raw = std::fs::read_to_string(&config_path)?;
-        serde_json::from_str(&raw).unwrap_or(serde_json::json!({}))
+        serde_json::from_str(&raw).map_err(|e| anyhow::anyhow!("Failed to parse existing opencode.json: {e}"))?
     } else {
         serde_json::json!({})
     };

--- a/src/mcp_audit.rs
+++ b/src/mcp_audit.rs
@@ -34,15 +34,17 @@ pub enum Agent {
     ClaudeCode,
     Codex,
     Copilot,
+    OpenCode,
     Antigravity,
 }
 
 impl Agent {
-    pub fn all() -> [Agent; 4] {
+    pub fn all() -> [Agent; 5] {
         [
             Agent::ClaudeCode,
             Agent::Codex,
             Agent::Copilot,
+            Agent::OpenCode,
             Agent::Antigravity,
         ]
     }
@@ -52,6 +54,7 @@ impl Agent {
             Agent::ClaudeCode => "Claude Code",
             Agent::Codex => "Codex",
             Agent::Copilot => "Copilot",
+            Agent::OpenCode => "OpenCode",
             Agent::Antigravity => "Antigravity",
         }
     }
@@ -61,6 +64,7 @@ impl Agent {
             Agent::ClaudeCode => "claude-code",
             Agent::Codex => "codex",
             Agent::Copilot => "copilot",
+            Agent::OpenCode => "opencode",
             Agent::Antigravity => "antigravity",
         }
     }
@@ -73,6 +77,7 @@ impl Agent {
             Agent::ClaudeCode => 2500,
             Agent::Codex => 1500,
             Agent::Copilot => 1500,
+            Agent::OpenCode => 1500,
             Agent::Antigravity => 1500,
         }
     }
@@ -210,6 +215,7 @@ fn discover(agent: Agent, cwd: &Path) -> Vec<ServerSpec> {
         Agent::ClaudeCode => discover_claude(cwd),
         Agent::Codex => discover_codex(),
         Agent::Copilot => discover_copilot(cwd),
+        Agent::OpenCode => discover_opencode(cwd),
         Agent::Antigravity => discover_antigravity(),
     }
 }
@@ -392,6 +398,77 @@ fn discover_antigravity() -> Vec<ServerSpec> {
     if let Some(v) = read_json(&path) {
         if let Some(map) = v.get("mcpServers").and_then(Value::as_object) {
             parse_json_map(Agent::Antigravity, map, &mut out);
+        }
+    }
+    out
+}
+
+fn discover_opencode(cwd: &Path) -> Vec<ServerSpec> {
+    let repo_root = crate::find_repo_root(cwd);
+    let path = repo_root.join("opencode.json");
+    let Some(v) = read_json(&path) else {
+        return Vec::new();
+    };
+    let Some(map) = v.get("mcp").and_then(Value::as_object) else {
+        return Vec::new();
+    };
+    opencode_specs_from_map(map)
+}
+
+fn opencode_specs_from_map(map: &serde_json::Map<String, Value>) -> Vec<ServerSpec> {
+    let mut out = Vec::new();
+    for (name, entry) in map {
+        match entry.get("type").and_then(Value::as_str) {
+            Some("remote") => {
+                if let Some(url) = entry.get("url").and_then(Value::as_str) {
+                    out.push(ServerSpec {
+                        agent: Agent::OpenCode,
+                        name: name.clone(),
+                        transport: Transport::Http {
+                            url: url.to_string(),
+                        },
+                    });
+                }
+            }
+            Some("local") => {
+                let Some(command) = entry
+                    .get("command")
+                    .and_then(Value::as_array)
+                    .and_then(|arr| arr.first())
+                    .and_then(Value::as_str)
+                else {
+                    continue;
+                };
+                let args = entry
+                    .get("command")
+                    .and_then(Value::as_array)
+                    .map(|arr| {
+                        arr.iter()
+                            .skip(1)
+                            .filter_map(|x| x.as_str().map(String::from))
+                            .collect()
+                    })
+                    .unwrap_or_default();
+                let env = entry
+                    .get("environment")
+                    .and_then(Value::as_object)
+                    .map(|o| {
+                        o.iter()
+                            .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_string())))
+                            .collect()
+                    })
+                    .unwrap_or_default();
+                out.push(ServerSpec {
+                    agent: Agent::OpenCode,
+                    name: name.clone(),
+                    transport: Transport::Stdio {
+                        command: command.to_string(),
+                        args,
+                        env,
+                    },
+                });
+            }
+            _ => {}
         }
     }
     out
@@ -923,6 +1000,31 @@ TOKEN = "abc"
                 assert_eq!(command, "uvx");
                 assert_eq!(args, &vec!["mcp-docs".to_string()]);
                 assert_eq!(env, &vec![("TOKEN".to_string(), "abc".to_string())]);
+            }
+            _ => panic!("expected stdio"),
+        }
+    }
+
+    #[test]
+    fn parses_opencode_local_mcp() {
+        let val = json!({
+            "tokenix": {
+                "type": "local",
+                "command": ["tokenix", "mcp"],
+                "environment": {"TOKENIX_PROFILE": "slim"}
+            }
+        });
+        let specs = opencode_specs_from_map(val.as_object().unwrap());
+        assert_eq!(specs.len(), 1);
+        assert_eq!(specs[0].name, "tokenix");
+        match &specs[0].transport {
+            Transport::Stdio { command, args, env } => {
+                assert_eq!(command, "tokenix");
+                assert_eq!(args, &vec!["mcp".to_string()]);
+                assert_eq!(
+                    env,
+                    &vec![("TOKENIX_PROFILE".to_string(), "slim".to_string())]
+                );
             }
             _ => panic!("expected stdio"),
         }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1860,6 +1860,7 @@ fn detect_agents() -> Vec<AgentStatus> {
             ],
         ),
         status("Codex", &[(home.join(".codex/hooks.json"), "global")]),
+        status("OpenCode", &[(repo.join("opencode.json"), "local")]),
         status(
             "Antigravity",
             &[


### PR DESCRIPTION
## Summary
- add explicit `--tool opencode` support via repo-local native `opencode.json` MCP registration
- extend prompt-audit and TUI status detection to understand OpenCode
- document that OpenCode support is MCP-only and intentionally excluded from `--tool all`

## Verification
- `cargo +stable test upsert_opencode_mcp_preserves_foreign_keys`
- `cargo +stable test remove_opencode_mcp_preserves_foreign_servers`
- `cargo +stable test remove_opencode_mcp_drops_empty_mcp_container`
- `cargo +stable test parses_opencode_local_mcp`
- `cargo +stable test hook_install_targets_exclude_discontinued_gemini_cli`
- `cargo +stable test`
- `cargo +stable build`
- CLI help checks for `install-hook`, `remove-hook`, `prompt-audit`
- temp repo smoke test for `install-hook --tool opencode` / `remove-hook --tool opencode`

Constraint: Keep OpenCode support native and generic; no personal config paths or experimental hooks
Rejected: Folding OpenCode into `--tool all` | would silently write `opencode.json` in repos where the user did not ask for it
Confidence: high
Scope-risk: narrow