### PR TITLE
fix(fmt): unblock release pipeline after OpenCode MCP merge

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -3173,7 +3173,8 @@ fn install_opencode() -> Result<()> {
     }
     let mut config: serde_json::Value = if config_path.exists() {
         let raw = std::fs::read_to_string(&config_path)?;
-        serde_json::from_str(&raw).map_err(|e| anyhow::anyhow!("Failed to parse existing opencode.json: {e}"))?
+        serde_json::from_str(&raw)
+            .map_err(|e| anyhow::anyhow!("Failed to parse existing opencode.json: {e}"))?
     } else {
         serde_json::json!({})
     };


### PR DESCRIPTION
## Problem
`cargo fmt --check` was failing on `main` after #31 (OpenCode MCP integration) introduced an over-length line in `src/main.rs`, breaking the Rust CI gate and blocking releases.

## Fix
Reformatted the `opencode.json` parse-error mapping to satisfy rustfmt.

## Verification
- `cargo fmt --check` clean
- `cargo clippy --all-targets` clean
- `cargo test` — 212 passed, 5 ignored, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)