### PR TITLE
fix(filters): normalize terraform/tofu -chdir global flag

### DIFF
--- a/src/filters.rs
+++ b/src/filters.rs
@@ -1050,7 +1050,7 @@ fn strip_subcommand_global_opts(argv: &[String]) -> Vec<String> {
         } else if a.len() >= 2 && a.starts_with('-') {
             if let Some((key, _)) = a.split_once('=') {
                 if valued.contains(&key) {
-                    i += 1; // -chdir=dir
+                    i += 1; // -opt=value
                     continue;
                 }
             }
@@ -2213,11 +2213,13 @@ on_empty = "empty filter output"
         assert_eq!(eff("cargo +nightly test"), "cargo test");
         // terraform / tofu `-chdir=DIR` global flag precedes the subcommand.
         assert_eq!(eff("terraform -chdir=./infra apply"), "terraform apply");
+        assert_eq!(eff("terraform -chdir ./infra apply"), "terraform apply");
         assert_eq!(
             eff("terraform -chdir=/a/b plan -out=p"),
             "terraform plan -out=p"
         );
         assert_eq!(eff("tofu -chdir=. init"), "tofu init");
+        assert_eq!(eff("kubectl -n=prod get pods"), "kubectl get pods");
         // Subcommand-less or unknown tools are untouched.
         assert_eq!(eff("git status"), "git status");
         assert_eq!(eff("ls -la"), "ls -la");

--- a/src/filters.rs
+++ b/src/filters.rs
@@ -977,6 +977,7 @@ fn strip_subcommand_global_opts(argv: &[String]) -> Vec<String> {
             ],
             &["-D", "--debug", "--tls", "--tlsverify"],
         ),
+        "terraform" | "tofu" => (&["-chdir"], &[]),
         "cargo" => (&[], &[]),
         "pnpm" => (
             &[
@@ -1047,6 +1048,12 @@ fn strip_subcommand_global_opts(argv: &[String]) -> Vec<String> {
             }
             break;
         } else if a.len() >= 2 && a.starts_with('-') {
+            if let Some((key, _)) = a.split_once('=') {
+                if valued.contains(&key) {
+                    i += 1; // -chdir=dir
+                    continue;
+                }
+            }
             if valued.contains(&a.as_str()) {
                 i += if i + 1 < argv.len() { 2 } else { 1 }; // -C dir
                 continue;
@@ -2204,6 +2211,13 @@ on_empty = "empty filter output"
         assert_eq!(eff("kubectl -n prod get pods"), "kubectl get pods");
         assert_eq!(eff("docker -H tcp://h ps -a"), "docker ps -a");
         assert_eq!(eff("cargo +nightly test"), "cargo test");
+        // terraform / tofu `-chdir=DIR` global flag precedes the subcommand.
+        assert_eq!(eff("terraform -chdir=./infra apply"), "terraform apply");
+        assert_eq!(
+            eff("terraform -chdir=/a/b plan -out=p"),
+            "terraform plan -out=p"
+        );
+        assert_eq!(eff("tofu -chdir=. init"), "tofu init");
         // Subcommand-less or unknown tools are untouched.
         assert_eq!(eff("git status"), "git status");
         assert_eq!(eff("ls -la"), "ls -la");


### PR DESCRIPTION
## Problem

A `conversation-audit` sweep of local Claude session history flagged a **22k-token unfiltered `terraform apply`** (on a `module.vm_setup.*` infra stack) as the single largest command-output waste — hundreds of per-resource `<resource>: Refreshing state... [id=…]` lines that should have been stripped.

Root cause: terraform/tofu place their global flag **before** the subcommand — `terraform -chdir=./infra apply`. The bundled `terraform-*` filters anchor on `^terraform\s+apply\b` (etc.), so the `-chdir=DIR` prefix made every one of them miss, and the raw refresh dump reached the model unfiltered.

This is the same global-option bug class already fixed for `git -C`, `kubectl -n`, `docker -H`, and `cargo +toolchain` in `strip_subcommand_global_opts`.

## Fix

- Add a `terraform | tofu` arm to `strip_subcommand_global_opts` (valued flag `-chdir`).
- Teach the single-dash branch the `-flag=value` form so `-chdir=./infra` is peeled off (terraform requires the `=` form).

Effect: `terraform -chdir=./infra apply` normalizes to `terraform apply`, so the existing `terraform-apply` / `terraform-plan` / etc. filters match and their keep-allowlists drop the refresh noise.

## Tests

Extended `strip_subcommand_global_opts_normalizes_tool_globals`:

```
eff("terraform -chdir=./infra apply")     == "terraform apply"
eff("terraform -chdir=/a/b plan -out=p")  == "terraform plan -out=p"
eff("tofu -chdir=. init")                 == "tofu init"
```

`cargo fmt` clean, targeted test green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
