### PR TITLE
feat: global output cap, repeated-block collapse, uncapped-grep guard, prompt-audit context weight

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,9 +30,9 @@ tokenix --help
 | `src/pack.rs` | `tokenix pack` — budgeted repo map + focused context, changed-file packs, token maps, and safety report |
 | `src/graph.rs` | Symbol graph with PageRank, cycle detection (Tarjan's SCC, homonym-filtered, `path:line`-annotated), tree-sitter references, incremental repair (`update_symbol_graph_incremental` — FTS-narrowed inbound-edge restore; `rebuild-graph` = full escape hatch), file-level import graph (`rebuild_import_graph`, per-language import extraction + path resolution), HTML + Mermaid export. Repo-wide overview (`tokenix graph`): `repo_hotspots` (degree + transitive-dependent blast radius, trivial-symbol filtered), `format_repo_report` (god nodes / bottlenecks / blast-radius leaders), `format_edges_dot` (Graphviz of the top subgraph) |
 | `src/artifacts.rs` | Context artifacts — index non-code files (schemas, API specs, docs) via `.tokenix/artifacts.json` |
-| `src/hook.rs` | `run_hook()` — called by PreToolUse hook. Tries daemon first for Grep. Thresholds (Read 200 lines / Grep 3 words) overridable via `[hook]` in `.tokenix.toml` (`read_min_lines`, `grep_min_words`). Read intercept `is_code` set is kept in sync with `chunker::detect_lang` (Rust/Py/TS/JS/Go/**C·C++·VB·SQL**); a large file in a supported-but-unlisted language used to pass through full |
+| `src/hook.rs` | `run_hook()` — called by PreToolUse hook. Tries daemon first for Grep. Thresholds (Read 200 lines / Grep 3 words) overridable via `[hook]` in `.tokenix.toml` (`read_min_lines`, `grep_min_words`). Read intercept `is_code` set is kept in sync with `chunker::detect_lang` (Rust/Py/TS/JS/Go/**C·C++·VB·SQL**); a large file in a supported-but-unlisted language used to pass through full. `try_grep_cap`/`grep_cap_input` + `input_rewrite_output` bound a lexical `output_mode="content"` Grep that carries no `head_limit` (`TOKENIX_GREP_HEAD_LIMIT`, default 100) — called both on the non-intercept path and inside the stale-index gate, since capping needs no index |
 | `src/daemon.rs` | Background TCP server (port 47392). Holds model + int8-quantized embedding cache (LRU, max 3 projects, content cap 1000). Bounded to 4 handler threads. Protocol: `search`/`health`/`status`; CLI `tokenix daemon status\|stop\|restart` |
-| `src/compress.rs` | Legacy `PostToolUse` compatibility compression + `tokenix run` command-output compression: ANSI strip, emoji removal, blank-line collapse, repeat grouping, JSON compaction, base64/data-URI blob redaction (`redact_base64_blobs` = `strip_base64_blobs` for single-line/data-URI runs ≥512 chars + `strip_wrapped_base64` for line-wrapped blocks — ≥5 pure-base64 lines ≥60 wide, e.g. PEM certs/keys/MIME; PEM `-----BEGIN/END-----` markers survive; `[<kind> omitted: N chars]` typed by decoded magic — `png image base64`/`jpeg image base64`/`pdf base64`/…, keeps any `data:<mime>;base64,` prefix; a run only redacts if `looks_like_base64` — mixed-case or a `+/=-_` symbol — so single-case pure-hex/all-digit runs like `.sha256` manifests or numeric columns are NOT eaten), cargo/git-log heuristics. `tokenix run` only applies command-specific filters to stderr when `filter_stderr=true`; otherwise stderr uses safe generic compression so errors are not turned into success sentinels. `run_hook_post` also processes **non-shell** tool results (e.g. MCP image-generation output) for base64-only redaction in dialects that can replace the result (Copilot); Claude/Codex post stays a no-op |
+| `src/compress.rs` | Legacy `PostToolUse` compatibility compression + `tokenix run` command-output compression: ANSI strip, emoji removal, blank-line collapse, repeat grouping (identical lines **and** repeated 2–12 line blocks via `group_repeated_blocks`), a hard `enforce_token_budget` ceiling applied to every return path including the `compact_json` early return and the TOML-filter result (`TOKENIX_MAX_OUTPUT_TOKENS`, default 8000, `0` disables), JSON compaction, base64/data-URI blob redaction (`redact_base64_blobs` = `strip_base64_blobs` for single-line/data-URI runs ≥512 chars + `strip_wrapped_base64` for line-wrapped blocks — ≥5 pure-base64 lines ≥60 wide, e.g. PEM certs/keys/MIME; PEM `-----BEGIN/END-----` markers survive; `[<kind> omitted: N chars]` typed by decoded magic — `png image base64`/`jpeg image base64`/`pdf base64`/…, keeps any `data:<mime>;base64,` prefix; a run only redacts if `looks_like_base64` — mixed-case or a `+/=-_` symbol — so single-case pure-hex/all-digit runs like `.sha256` manifests or numeric columns are NOT eaten), cargo/git-log heuristics. `tokenix run` only applies command-specific filters to stderr when `filter_stderr=true`; otherwise stderr uses safe generic compression so errors are not turned into success sentinels. `run_hook_post` also processes **non-shell** tool results (e.g. MCP image-generation output) for base64-only redaction in dialects that can replace the result (Copilot); Claude/Codex post stays a no-op |
 | `src/filters.rs` | `FilterDef` (TOML schema), active filter listing, `load_user_filters()`, `load_bundled_filters()` (rust-embed), `apply_filter()`. `find_filter()` matches via `derive_command_candidates()`, which unwraps shell runners, strips `cd`/env prefixes, and `split_on_operators()` splits compound commands quote-aware on `&&`/`\|\|`/`;`/`\|` so anchored `match_command` patterns match a base command in any segment/position |
 | `src/cmd_filter.rs` | `tokenix filter list/active/generate` + `filter record start/stop/status` subcommands. `generate` prefers `recordings::read_samples` over a re-run, invokes a detected AI CLI, and saves to `~/.tokenix/filters/`; reused by the TUI Studio tab as a foreground drop-out |
 | `src/tui.rs` | Interactive ratatui shell shown by a bare `tokenix` / `tokenix filter` in a TTY (else falls back to help / `filter list`). Tab bar (`←`/`→`): **Stats** dashboard (wordmark + version + hook status + index summary, with selectable Index / Install hooks / Install binary actions — Index runs in the foreground with live progress, the two install actions confirm before writing; Install binary self-execs `tokenix install-binary`), **Filters** (3-pane groups · filters · live `apply_filter` input→output preview with a `chunker::count_tokens` gauge line showing `X → Y tokens · % saved` between the panes), **Studio** (surfaces the record→preview→generate filter loop: `r`/`s` arm/stop a `recordings::start`/`stop` session, left column is a unified candidate list from `cmd_filter::suggest_filters` — recordings unioned with the tokens-wasted ranking, badged `⚠` unfiltered sink (biggest waste first) / `✓` already filtered / `●` recorded-only — plus saved `~/.tokenix/filters/*.toml`, right pane previews a `recordings::read_samples` head with a live `apply_filter` before→after `chunker::count_tokens` delta when an active filter matches the base command; `g` sets `request_generate` to run `cmd_filter::cmd_filter_generate` as a foreground drop-out — same pattern as Index — then resumes the TUI; `x` deletes a saved filter with confirm; `Tab` switches pane), **Gain** (native colored render of `gain::compute_gain`: tokens-saved headline with ≈USD at the ★ reference model's input rate, savings-by-source split — semantic index vs command filters — and numbered by command / by project tables with share %, toggles `c`/`a`), **Usage** (self-exec captured `tokenix usage` via dynamic argv: `s` cycles daily/model/blocks/project/session, `a` toggles all-projects, `r` refresh), **Doctor**/**Tokenmap** (self-exec captured output), **Graph** (self-exec captured `tokenix graph` repo overview — god nodes / bottlenecks / blast radius; `r` refresh), **Secrets** (background-threaded `secrets_scan::scan_findings` with spinner; dedup by distinct value + count; `v` reveal, `c` copy raw value to system clipboard via `clip`/`pbcopy`/`wl-copy`/`xclip`/`xsel`, `x` write `[REDACTED]`), **Egress** (background-threaded `egress_scan::scan_findings` with the same 3-pane pattern as Secrets: groups · destinations · occurrence detail; `s` cycles host/rule/agent/file grouping; `r` rescans; host reputation colors: green safe, red dangerous, yellow unknown). Both Secrets and Egress open scoped to the current repo (cwd) and `g` toggles a global all-repos view; scoping filters the raw scan by each finding's attributed `repo` (`is_local` matches exact `cwd` paths plus Claude `~slug:`/Gemini `~dir:` fallback markers against the project root). **Loading is standardized:** every data-loading tab (Gain, Usage, Doctor, Tokenmap, Graph, Secrets, Egress) loads on a background thread behind one shared panel (`draw_loading` + `spinner_frame`, single `SPINNER_FRAMES`) so the shell never blocks and the braille spinner animates; the event loop polls at 120ms whenever any `*_rx` is in flight. Only Index still runs as a foreground drop-out (it needs the child's own live progress bar) |
@@ -41,7 +41,7 @@ tokenix --help
 | `src/transcripts.rs` | Shared enumeration of local agent transcript files (`roots` per agent: Claude/Codex/Copilot/OpenAI, `transcript_files` walker). Single source of truth reused by `conversation-audit` and `usage` |
 | `src/usage.rs` | `tokenix usage` — absolute token spend + ≈USD cost parsed from transcript `message.usage` blocks (input/output/cache read+write), deduped by `(message.id, requestId)`. Aggregates by `daily\|weekly\|monthly\|session\|model\|project`; rolling 5-hour `blocks` with burn rate + projection; month-end forecast; `--cost-mode auto\|calculate\|display`; `--statusline`; `--all-projects` scope; `--json` |
 | `src/mcp.rs` | MCP server. `--profile full` exposes all tools; `--profile slim` exposes context/search/call meta-tools for progressive discovery |
-| `src/mcp_audit.rs` | `tokenix prompt-audit` / `session-audit` — per-agent MCP config discovery (Claude, Codex, Copilot, OpenCode, Antigravity) + minimal synchronous MCP stdio client (`initialize`/`tools/list`) + token scoring/report |
+| `src/mcp_audit.rs` | `tokenix prompt-audit` / `session-audit` — per-agent MCP config discovery (Claude, Codex, Copilot, OpenCode, Antigravity) + minimal synchronous MCP stdio client (`initialize`/`tools/list`) + token scoring/report + `context_weight()` (instruction files always-on, skills listing always-on / body on-invoke) |
 | `src/secrets_scan.rs` | `tokenix scan-secrets` — gitleaks-style credential scan of Claude/Gemini/Copilot/Antigravity conversation transcripts under `~`; rules loaded from TOML (`assets/secret-rules/` bundled via `rust-embed`, extended by `<repo>/` then `~/.tokenix/secret-rules/*.toml`, later `id` wins), backtracking-free regex + entropy-gated generic rule. Each finding is attributed to its repo + git branch via the transcript line's `cwd`/`gitBranch` (Claude), falling back to the project dir slug. Report supports `--filter` (substring), `--group <value\|rule\|agent\|file\|repo>`, `--reveal` (raw values, default redacted), `--json`; exit 1 on hits. `scan_findings()` returns structured `ScanFinding`s (raw + redacted) for the TUI; `redact_in_files()` rewrites `[REDACTED]` over a value in text files (SQLite DBs skipped) |
 | `src/egress_scan.rs` | `tokenix egress-audit` — scans Claude/Gemini/Copilot/Antigravity conversation transcripts for external DNS/IP destinations; bundled TOML rules live under `assets/egress-rules/`, local safe hosts are loaded from `~/.tokenix/safe-hosts.toml`, and local blocklist hosts from `~/.tokenix/dangerous-hosts.toml` (`dangerous`, `blocklist`, or `hosts` arrays); report supports `--filter`, `--group <host\|rule\|agent\|file>`, `--safe`, and `--json`. `scan_findings()` returns structured `EgressFinding`s for the TUI |
 | `src/discover.rs` | `tokenix discover` — scans agent transcripts (Claude `tool_use`/`tool_result`, Codex/OpenAI `function_call`/`function_call_output`, argv-array commands) and REPLAYS the current filter set over historical command outputs: measured recoverable savings (filter exists, hook wasn't active) + uncovered commands ranked by waste. Memoizes command→filter matches (`find_filter` recompiles regexes per call) |
@@ -81,7 +81,11 @@ Read tool:
   file ≥ 200 lines, no offset/limit   → return outline, exit 2 (intercept)
 
 Grep tool:
-  pattern < 3 words → exit 0 (pass — likely a regex/symbol search)
+  pattern < 3 words → not semantic; symbol lookup if identifier-like, else:
+      output_mode="content" without head_limit → PreToolUse updatedInput injects
+      head_limit (TOKENIX_GREP_HEAD_LIMIT, default 100, 0 disables); logged with
+      saved_tokens=0 because the unbounded output never ran
+      otherwise → exit 0 (pass)
   pattern ≥ 3 words → return semantic results, exit 2 (intercept); gain records this as neutral usage, not saved tokens
 
 Bash / PowerShell tools:
@@ -160,6 +164,19 @@ Legacy `hook-post` compression flows through (in order):
 2. Bundled TOML filters (`assets/filters/*.toml`, rust-embed)
 3. Built-in heuristics in `compress.rs` — cargo, git-log, generic head/tail
 
+`compress_output()` order: `redact_base64_blobs` → `compact_json` (early return,
+**also capped**) → `strip_ansi` → `remove_emojis` → `collapse_blank_lines` →
+`group_repeated_blocks` → `group_repeated_lines` → `generic_aggressive_compress`
+→ `enforce_token_budget`. The last two are the newer backstops:
+- `group_repeated_blocks` collapses a 2–12 line stanza repeated 3+ times
+  (`[block of N lines repeated Kx]`); `group_repeated_lines` only ever saw runs
+  of *identical adjacent lines*, so poll/watch loops slipped through (one
+  monitoring session measured ~617k tokens this way). Skipped above 100k lines.
+- `enforce_token_budget` clips anything over `TOKENIX_MAX_OUTPUT_TOKENS`
+  (default 8000, `0` disables) to a 75% head + 25% tail window at char
+  boundaries. It is the only cap that covers single-giant-line output and the
+  `compact_json` early return, both of which bypass every line-count cap.
+
 `apply_filter()` pipeline: `match_output` short-circuit → `strip_ansi` → `strip_lines_matching` → `keep_lines_matching` → `head/tail/max_lines` → `truncate_lines_at` → `on_empty`. Opt-in `passthrough_when_emptied`: when the pipeline reduces *non-empty* output to nothing (an unrecognized output shape, not a genuinely empty command), emit a bounded view of the real output instead of `on_empty` — set on `git-log`/`git-diff` so `--oneline`/`--stat` don't report a false "no commits"/"no changes". The same bounded fallback fires **automatically** (no opt-in) whenever the original output matches `output_has_failure_signal()` (a strict, case/anchor-tuned `error`/`fatal`/`panic`/`FAILED`/`exit code N` probe) — so a failed build/test/deploy whose error text isn't matched by the tool's `keep_lines_matching` is never masked as the success `on_empty`. Guarded by `bundled_filters_never_mask_generic_failure`.
 
 **Filter design rule: never use `on_empty` — use `passthrough_when_emptied = true` instead.** `on_empty` fabricates a static string when real output is filtered to nothing; `passthrough_when_emptied` returns the original unfiltered output. Filters must only filter, never invent responses. `match_output` is the only valid short-circuit (it fires only when a confirmed pattern exists in the real output). Tests must not assert on fabricated strings.
@@ -174,12 +191,27 @@ match_output   = [{ pattern = "Success", message = "ok" }]
 max_lines      = 30
 ```
 
-## Prompt Audit (MCP/tool weight)
+## Prompt Audit (MCP/tool/context weight)
 
 `tokenix prompt-audit` estimates the variable cost of the effective system prompt
 per agent. The base system prompt is internal and **cannot be read or intercepted
-via hooks** — this measures the next-largest lever instead: MCP tool-definition
-JSON. All logic lives in `src/mcp_audit.rs`.
+via hooks** — this measures the next-largest levers instead: MCP tool-definition
+JSON plus the context an agent loads before doing anything. All logic lives in
+`src/mcp_audit.rs`.
+
+Context weight (`context_weight()` → `ContextWeight`), added because a measured
+history showed a single skill body costing ~198k tokens while the audit reported
+only MCP schemas:
+
+| Source | Agents | Counted as |
+|---|---|---|
+| `CLAUDE.md`, `AGENTS.md`, `.github/copilot-instructions.md`, `~/.claude/CLAUDE.md`, `~/.codex/AGENTS.md` | per-agent path list | always-on (full file) |
+| `<repo>/.claude/skills/*/SKILL.md`, `~/.claude/skills/*/SKILL.md`, `~/.claude/plugins/**/skills/*/SKILL.md` (depth ≤ 4) | Claude Code only | always-on = frontmatter `name`+`description`; body reported separately as on-invoke |
+
+Only always-on tokens enter the per-agent total and `combined_tokens`; bodies
+≥ `HEAVY_SKILL_TOKENS` (5k) are listed as "loaded on invoke". `aggregate()` takes
+the `ContextWeight` as a parameter (not the cwd) so tests aggregate against a
+known-empty context instead of the developer's real home directory.
 
 Per-agent MCP config sources (one `ConfigSource` each, ausente = silently skipped):
 

--- a/README.md
+++ b/README.md
@@ -193,7 +193,9 @@ The embedding model (`nomic-embed-text-v1.5`, ~130 MB) is downloaded automatical
 | **Savings analytics** | `tokenix gain` — token summary, savings split by source (semantic index vs command filters), and by-tool histogram; `--cost-estimate` adds a per-model cost table (10 reference models across Anthropic / OpenAI / Google) |
 | **Spend analytics** | `tokenix usage` — absolute token spend and ≈USD cost read from agent transcripts, by `daily\|weekly\|monthly\|session\|model\|project\|blocks`; rolling 5-hour blocks with burn rate, month-end forecast, `--cost-mode auto\|calculate\|display`, `--statusline`, and `--json` |
 | **Slim MCP profile** | `tokenix mcp --profile slim` exposes 3 meta-tools instead of the full tool surface for hosts that support progressive discovery |
-| **MCP/prompt weight audit** | `tokenix prompt-audit --recommend --profile-impact` connects to configured MCP servers, tokenizes tool schemas, and shows full-vs-slim MCP savings |
+| **MCP/prompt weight audit** | `tokenix prompt-audit --recommend --profile-impact` connects to configured MCP servers, tokenizes tool schemas, weighs the always-on context (CLAUDE.md/AGENTS.md/copilot-instructions.md + the skill listing) and the on-invoke cost of heavy skills, and shows full-vs-slim MCP savings |
+| **Global output cap** | Every compressed output is bounded by a hard token ceiling (`TOKENIX_MAX_OUTPUT_TOKENS`, default `8000`) that also covers one-line giants and compacted JSON, plus repeated-*block* collapsing for watch/poll loops |
+| **Uncapped grep guard** | A lexical `Grep` asking for match content with no `head_limit` is rewritten with one (`TOKENIX_GREP_HEAD_LIMIT`, default `100`) instead of dumping every match into context |
 | **Session audit** | `tokenix session-audit --cache-hygiene` combines index freshness, hook history, MCP/tool weight, and prompt-cache stability risks |
 | **Conversation token-waste audit** | `tokenix conversation-audit` scans local Claude / Codex / Copilot / OpenAI histories for large assistant-visible blobs such as full reads, command logs, bootstrap prompts, connector JSON, images, patches, and task artifacts |
 | **Conversation secret scan** | `tokenix scan-secrets` — gitleaks-style credential scan of Claude / Gemini / Copilot / Antigravity conversation transcripts (no git); findings are always redacted, exits non-zero when any are found. Patterns live in TOML (`assets/secret-rules/`), extensible via `~/.tokenix/secret-rules/*.toml` or `<repo>/.tokenix/secret-rules/*.toml` |
@@ -332,10 +334,10 @@ against 10 reference models across Anthropic, OpenAI, and Google. Prices are
 shown with their collection date (currently `2026-06-11`) so the numbers stay
 auditable.
 
-### 8. Audit MCP / tool weight
+### 8. Audit MCP / tool / context weight
 
 ```bash
-tokenix prompt-audit                  # every agent that has MCP config
+tokenix prompt-audit                  # every agent with MCP config, instruction files or skills
 tokenix prompt-audit --agent claude   # one agent (claude|codex|copilot|opencode|antigravity)
 tokenix prompt-audit --json           # machine-readable
 tokenix prompt-audit --recommend      # include practical reduction advice
@@ -351,6 +353,20 @@ prompt itself cannot be read by tools, so this is a **relative bloat estimate**:
 the native-tool baseline is approximate and HTTP/SSE servers are shown as
 `unknown`. Thresholds are overridable via `TOKENIX_AUDIT_WARN_TOKENS`,
 `TOKENIX_AUDIT_WARN_SERVERS`, and `TOKENIX_AUDIT_WARN_TOOLS`.
+
+MCP schemas are not the only variable weight, so the audit also measures the
+**context** an agent loads before doing anything:
+
+- instruction files (`CLAUDE.md`, `AGENTS.md`, `.github/copilot-instructions.md`)
+  — read in full on every session;
+- skills (`<repo>/.claude/skills`, `~/.claude/skills`, plugin `skills/` trees) —
+  their `name`+`description` entry is always on, and the whole `SKILL.md` body is
+  pulled in on invoke. Skills whose body exceeds ~5k tokens are listed with that
+  on-invoke cost so a heavy skill stops being invisible.
+
+Only the always-on part counts toward the per-agent total; skill bodies are
+reported separately so the estimate is not inflated by content that may never
+load.
 
 For MCP hosts that support progressive discovery, run `tokenix mcp --profile slim`.
 The slim profile advertises only `tokenix_context`, `tokenix_search_tools`, and
@@ -727,6 +743,8 @@ Engine invariants:
 - **Failure tee** — when a failed command's compressed view dropped content, the full raw output is saved under `~/.tokenix/tee/` (20 files, 1 MB cap, disable with `TOKENIX_TEE=0`) and the output ends with `[full output: <path>]`, so recovery is a targeted Read instead of a full re-run.
 - **Fail loudly** — filter files reject unknown fields (a typo'd key prints a warning instead of silently disabling the filter). Validate your own filters anytime with `tokenix filter verify`.
 - **Escape hatch** — prefix any command with `TOKENIX_DISABLED=1` to skip the rewrite for that command only. Bypasses are logged and `tokenix gain` warns when ≥10% of commands dodge the filter.
+- **Hard output ceiling** — after every filter and heuristic, compressed output is clipped to `TOKENIX_MAX_OUTPUT_TOKENS` (default `8000`, `0` disables) keeping a head and tail window. This is the backstop for shapes the line-based caps cannot see: a single megabyte-long line, or a huge payload that `compact_json` shrank by only a few percent.
+- **Repeated blocks** — a multi-line stanza repeated 3+ times in a row (watch/poll loops, retry banners) is kept once and annotated `[block of N lines repeated Kx]`, alongside the existing identical-line collapsing.
 
 ### AI-assisted filter generation
 

--- a/src/compress.rs
+++ b/src/compress.rs
@@ -61,7 +61,11 @@ fn compress_bash_output_for_stream(
         if is_stderr && !f.filter_stderr {
             return compress_output(s);
         }
-        return crate::filters::apply_filter_with_exit(s, f, exit_ok);
+        // The global ceiling applies to filtered output too: a filter's own caps
+        // are per-filter, and a passthrough fallback (`passthrough_when_emptied`,
+        // failure-signal passthrough, `never_worse`) can hand back the full raw
+        // output, which is exactly the shape this cap exists to bound.
+        return enforce_token_budget(&crate::filters::apply_filter_with_exit(s, f, exit_ok));
     }
 
     // No filter matched — record for later analysis (tokenix filter list).
@@ -1260,15 +1264,151 @@ pub fn compress_output(s: &str) -> String {
     // The other transforms (ANSI, emoji, blank lines) don't apply to JSON.
     let compacted = compact_json(s);
     if compacted != s {
-        return compacted;
+        return enforce_token_budget(&compacted);
     }
     let s = strip_ansi(s);
     let s = remove_emojis(&s);
     let s = collapse_blank_lines(&s);
+    let s = group_repeated_blocks(&s);
     let s = group_repeated_lines(&s);
 
     // Additional generic aggressive compression
-    generic_aggressive_compress(&s)
+    enforce_token_budget(&generic_aggressive_compress(&s))
+}
+
+/// Absolute ceiling on how many tokens any single compressed output may cost.
+/// The line-based caps (`generic_aggressive_compress`) cannot bound output that
+/// is few-but-enormous lines (a one-line JSON payload, a minified bundle, a grep
+/// hit with megabyte-long lines), and the `compact_json` early return bypasses
+/// them entirely — a 3 MB tool result compacted by 10% still costs ~700k tokens.
+/// Override with `TOKENIX_MAX_OUTPUT_TOKENS`; `0` disables the cap.
+const DEFAULT_MAX_OUTPUT_TOKENS: usize = 8000;
+
+fn max_output_tokens() -> usize {
+    std::env::var("TOKENIX_MAX_OUTPUT_TOKENS")
+        .ok()
+        .and_then(|v| v.trim().parse::<usize>().ok())
+        .unwrap_or(DEFAULT_MAX_OUTPUT_TOKENS)
+}
+
+/// Clip `s` to the global token budget, keeping a head and a tail window so both
+/// the command's opening context and its (usually load-bearing) final lines
+/// survive. Char boundaries are respected, so UTF-8 output stays valid.
+fn enforce_token_budget(s: &str) -> String {
+    let budget = max_output_tokens();
+    if budget == 0 || s.is_empty() {
+        return s.to_string();
+    }
+    let tokens = count_tokens(s);
+    if tokens <= budget {
+        return s.to_string();
+    }
+
+    // Convert the token budget into a char budget using this payload's own
+    // observed density, rather than assuming a fixed chars-per-token ratio.
+    let char_count = s.chars().count();
+    let chars_per_token = (char_count as f64 / tokens as f64).max(1.0);
+    let char_budget = (budget as f64 * chars_per_token) as usize;
+    if char_budget >= char_count {
+        return s.to_string();
+    }
+    let head_chars = char_budget * 3 / 4;
+    let tail_chars = char_budget.saturating_sub(head_chars);
+
+    let head_end = byte_index_at_char(s, head_chars);
+    let tail_start = byte_index_at_char(s, char_count.saturating_sub(tail_chars));
+    if tail_start <= head_end {
+        return s.to_string();
+    }
+
+    let omitted = tokens.saturating_sub(budget);
+    format!(
+        "{}\n[... {} tokens omitted by tokenix output cap ({} max; set TOKENIX_MAX_OUTPUT_TOKENS to change) ...]\n{}",
+        &s[..head_end],
+        omitted,
+        budget,
+        &s[tail_start..]
+    )
+}
+
+fn byte_index_at_char(s: &str, char_idx: usize) -> usize {
+    s.char_indices()
+        .nth(char_idx)
+        .map(|(i, _)| i)
+        .unwrap_or(s.len())
+}
+
+/// Longest block a repeat scan will consider. Loop bodies that spam a context
+/// window (a PowerShell exception block, a retry banner, a k8s poll report) are
+/// typically a handful of lines; scanning wider costs time for no real gain.
+const MAX_REPEAT_BLOCK_LINES: usize = 12;
+
+/// Collapse consecutive repetitions of a multi-line *block*.
+///
+/// `group_repeated_lines` only sees runs of identical adjacent lines, so a
+/// watch/poll loop that re-emits the same 8-line stanza hundreds of times slips
+/// through untouched (measured: a single monitoring session cost ~617k tokens
+/// this way). A block repeated 3+ times is kept once, annotated with the count.
+fn group_repeated_blocks(s: &str) -> String {
+    let trailing_newline = s.ends_with('\n');
+    let source = if trailing_newline {
+        &s[..s.len() - 1]
+    } else {
+        s
+    };
+    let lines: Vec<&str> = source.split('\n').collect();
+    // Below 6 lines there is nothing a 3x block repeat can be built from; above
+    // the ceiling the quadratic-ish scan is not worth it (the token cap and the
+    // line caps already bound outputs that large).
+    if lines.len() < 6 || lines.len() > 100_000 {
+        return s.to_string();
+    }
+
+    let mut result = String::with_capacity(s.len());
+    let mut i = 0;
+    while i < lines.len() {
+        let mut collapsed = false;
+        // Prefer the smallest repeating unit: a 2-line stanza repeated 6x should
+        // report 6, not 3 repeats of a 4-line block.
+        for width in 2..=MAX_REPEAT_BLOCK_LINES.min((lines.len() - i) / 2) {
+            let block = &lines[i..i + width];
+            // A block of identical lines is a run, not a stanza: leave it to
+            // `group_repeated_lines`, which reports it as one line + a count
+            // instead of an arbitrary N-line window.
+            if block.iter().all(|l| *l == block[0]) {
+                continue;
+            }
+            let mut reps = 1;
+            while i + (reps + 1) * width <= lines.len()
+                && &lines[i + reps * width..i + (reps + 1) * width] == block
+            {
+                reps += 1;
+            }
+            if reps >= 3 {
+                for line in block {
+                    result.push_str(line);
+                    result.push('\n');
+                }
+                result.push_str(&format!(
+                    "[block of {} lines repeated {}x]\n",
+                    width,
+                    reps - 1
+                ));
+                i += reps * width;
+                collapsed = true;
+                break;
+            }
+        }
+        if !collapsed {
+            result.push_str(lines[i]);
+            result.push('\n');
+            i += 1;
+        }
+    }
+    if !trailing_newline && result.ends_with('\n') {
+        result.pop();
+    }
+    result
 }
 
 fn generic_aggressive_compress(s: &str) -> String {
@@ -2364,6 +2504,93 @@ test result: FAILED. 1 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out";
     fn does_not_group_two_identical_lines() {
         let input = "a\na\nb\n";
         assert_eq!(group_repeated_lines(input), "a\na\nb\n");
+    }
+
+    #[test]
+    fn groups_repeated_multiline_blocks() {
+        // The monitoring-loop shape: an 3-line stanza re-emitted every poll.
+        let stanza = "SetValueInvocationException:\n  Line | 3 | $RawUI.CursorPosition\n  Exception setting CursorPosition\n";
+        let input = format!("{}header\n", stanza.repeat(5));
+        let output = group_repeated_blocks(&input);
+        assert!(
+            output.contains("[block of 3 lines repeated 4x]"),
+            "got: {output}"
+        );
+        assert_eq!(output.matches("SetValueInvocationException").count(), 1);
+        assert!(output.ends_with("header\n"));
+    }
+
+    #[test]
+    fn block_grouping_prefers_smallest_unit() {
+        let input = "a\nb\na\nb\na\nb\na\nb\nz\n";
+        let output = group_repeated_blocks(input);
+        assert_eq!(output, "a\nb\n[block of 2 lines repeated 3x]\nz\n");
+    }
+
+    #[test]
+    fn block_grouping_defers_identical_line_runs_to_line_grouping() {
+        // "a" x6 must stay a line run, not become a 2-line "block".
+        let input = "a\na\na\na\na\na\nz\n";
+        assert_eq!(group_repeated_blocks(input), input);
+        assert_eq!(group_repeated_lines(input), "a\n[repeated 5x]\nz\n");
+    }
+
+    #[test]
+    fn block_grouping_leaves_two_repeats_alone() {
+        let input = "a\nb\nc\na\nb\nc\nz\n";
+        assert_eq!(group_repeated_blocks(input), input);
+    }
+
+    #[test]
+    fn block_grouping_preserves_non_repeating_output() {
+        let input = "one\ntwo\nthree\nfour\nfive\nsix\nseven\n";
+        assert_eq!(group_repeated_blocks(input), input);
+    }
+
+    #[test]
+    fn token_budget_caps_single_giant_line() {
+        // The gap this closes: one enormous line has no line count to truncate on.
+        let giant = format!(
+            "prefix {} suffix",
+            "lorem ipsum dolor sit amet ".repeat(20_000)
+        );
+        let out = enforce_token_budget(&giant);
+        assert!(out.contains("tokens omitted by tokenix output cap"));
+        assert!(count_tokens(&out) < count_tokens(&giant) / 2);
+        assert!(out.starts_with("prefix "));
+        assert!(out.ends_with(" suffix"));
+    }
+
+    #[test]
+    fn token_budget_leaves_small_output_untouched() {
+        let s = "short output\nsecond line\n";
+        assert_eq!(enforce_token_budget(s), s);
+    }
+
+    #[test]
+    fn token_budget_is_utf8_safe() {
+        let s = "café ☕ ".repeat(30_000);
+        let out = enforce_token_budget(&s);
+        assert!(out.len() < s.len());
+        // Round-tripping through String proves no char boundary was split.
+        assert!(std::str::from_utf8(out.as_bytes()).is_ok());
+    }
+
+    #[test]
+    fn compress_output_caps_giant_compacted_json() {
+        // compact_json returned early with no cap: a huge payload shrank ~10% and
+        // still cost hundreds of thousands of tokens.
+        let items: Vec<String> = (0..40_000)
+            .map(|i| format!("{{\n  \"id\": {i},\n  \"name\": \"item number {i}\"\n}}"))
+            .collect();
+        let raw = format!("[\n{}\n]", items.join(",\n"));
+        let out = compress_output(&raw);
+        assert!(
+            count_tokens(&out) <= DEFAULT_MAX_OUTPUT_TOKENS + 64,
+            "cap not applied: {} tokens",
+            count_tokens(&out)
+        );
+        assert!(out.contains("tokens omitted by tokenix output cap"));
     }
 
     #[test]

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -613,6 +613,109 @@ fn bash_rewrite_output(
     })
 }
 
+/// Build a PreToolUse output that hands the tool back a *modified argument set*
+/// (as opposed to `bash_rewrite_output`, which only rewrites a command string).
+fn input_rewrite_output(
+    input: &HookInput,
+    updated: serde_json::Value,
+    reason: &str,
+    antigravity: bool,
+) -> serde_json::Value {
+    if antigravity {
+        return serde_json::json!({
+            "decision": "allow",
+            "reason": reason,
+            "overwrite": {
+                "name": input.raw_tool_name,
+                "args": updated
+            }
+        });
+    }
+
+    serde_json::json!({
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "allow",
+            "permissionDecisionReason": reason,
+            "updatedInput": updated
+        }
+    })
+}
+
+/// Cap injected into an uncapped content-mode Grep. Measured motivation: a
+/// single unbounded lexical Grep over a large repo cost ~937k tokens because
+/// `handle_grep` only intercepts semantic/symbol queries and passes every other
+/// pattern through untouched. Override with `TOKENIX_GREP_HEAD_LIMIT`; `0`
+/// disables the cap.
+const DEFAULT_GREP_HEAD_LIMIT: i64 = 100;
+
+fn grep_head_limit() -> i64 {
+    std::env::var("TOKENIX_GREP_HEAD_LIMIT")
+        .ok()
+        .and_then(|v| v.trim().parse::<i64>().ok())
+        .unwrap_or(DEFAULT_GREP_HEAD_LIMIT)
+}
+
+/// Returns the full replacement tool input with a `head_limit` injected, when a
+/// lexical Grep asks for match *content* without bounding how much comes back.
+///
+/// Deliberately narrow: modes that emit one line per file (`files_with_matches`,
+/// `count`) are already cheap, and an agent that set its own `head_limit` has
+/// bounded itself — both pass through untouched.
+fn grep_cap_input(tool_input: &serde_json::Value) -> Option<(serde_json::Value, String)> {
+    let limit = grep_head_limit();
+    if limit <= 0 {
+        return None;
+    }
+    if tool_input["head_limit"].is_number() {
+        return None;
+    }
+    if tool_input["output_mode"].as_str() != Some("content") {
+        return None;
+    }
+
+    let mut updated = tool_input.clone();
+    updated.as_object_mut()?.insert(
+        "head_limit".to_string(),
+        serde_json::Value::Number(limit.into()),
+    );
+    Some((
+        updated,
+        format!("tokenix: capped uncapped content grep at head_limit={limit}"),
+    ))
+}
+
+/// Emit the capped-grep rewrite and exit, when the input qualifies. Returns
+/// normally (doing nothing) for any other tool or an already-bounded grep.
+fn try_grep_cap(input: &HookInput, repo_root: &Path, antigravity: bool, raw_stdin: &str) {
+    if input.tool_name != "Grep" {
+        return;
+    }
+    let Some((updated, reason)) = grep_cap_input(&input.tool_input) else {
+        return;
+    };
+    let out = input_rewrite_output(input, updated, &reason, antigravity);
+    let _ = log_hook_event(
+        repo_root,
+        &HookEvent {
+            ts: now_ts(),
+            tool: input.tool_name.clone(),
+            action: "intercepted".to_string(),
+            phase: "pre".to_string(),
+            reason,
+            // Savings are unmeasurable here — the unbounded output never runs —
+            // so log zero rather than inflating `gain`.
+            saved_tokens: 0,
+            actual_tokens: 0,
+            original_estimate: 0,
+            input_preview: raw_stdin.chars().take(200).collect(),
+            command: String::new(),
+        },
+    );
+    println!("{}", serde_json::to_string(&out).unwrap_or_default());
+    exit_success();
+}
+
 fn pass_through(antigravity: bool) -> ! {
     if antigravity {
         println!(r#"{{"decision":"allow","reason":"tokenix pass-through"}}"#);
@@ -971,6 +1074,9 @@ pub fn run_hook(antigravity: bool) -> Result<()> {
     let staleness = index_staleness(&repo_root);
 
     if staleness.stale {
+        // Bounding an unbounded grep needs no index, so a stale/missing index
+        // must not disable it — this is where most repos actually sit.
+        try_grep_cap(&input, &repo_root, antigravity, &raw_stdin);
         let _ = log_hook_event(
             &repo_root,
             &HookEvent {
@@ -996,6 +1102,10 @@ pub fn run_hook(antigravity: bool) -> Result<()> {
     };
 
     if !intercepted {
+        // A lexical Grep is not something tokenix can answer from the index, but
+        // it can still be bounded before it dumps every match into the context.
+        try_grep_cap(&input, &repo_root, antigravity, &raw_stdin);
+
         let _ = log_hook_event(
             &repo_root,
             &HookEvent {
@@ -1281,6 +1391,66 @@ mod tests {
         assert_eq!(
             original_tokens_for_log("Grep", &input, Path::new("."), 77),
             77
+        );
+    }
+
+    #[test]
+    fn grep_cap_injects_head_limit_on_uncapped_content_grep() {
+        let args = serde_json::json!({"pattern": "foo", "output_mode": "content", "-C": 3});
+        let (updated, reason) = grep_cap_input(&args).expect("should cap");
+        assert_eq!(updated["head_limit"], DEFAULT_GREP_HEAD_LIMIT);
+        // Every original field survives — updatedInput replaces the whole input.
+        assert_eq!(updated["pattern"], "foo");
+        assert_eq!(updated["-C"], 3);
+        assert!(reason.contains("head_limit"));
+    }
+
+    #[test]
+    fn grep_cap_respects_agent_supplied_limit() {
+        let args = serde_json::json!({"pattern": "foo", "output_mode": "content", "head_limit": 5});
+        assert!(grep_cap_input(&args).is_none());
+    }
+
+    #[test]
+    fn grep_cap_skips_cheap_output_modes() {
+        for mode in ["files_with_matches", "count"] {
+            let args = serde_json::json!({"pattern": "foo", "output_mode": mode});
+            assert!(grep_cap_input(&args).is_none(), "mode {mode} should pass");
+        }
+        // No explicit mode: the tool default is not content, so nothing to cap.
+        assert!(grep_cap_input(&serde_json::json!({"pattern": "foo"})).is_none());
+    }
+
+    #[test]
+    fn grep_cap_emits_valid_pretooluse_rewrite() {
+        let input = HookInput {
+            tool_name: "Grep".to_string(),
+            tool_input: serde_json::json!({"pattern": "foo", "output_mode": "content"}),
+            raw_tool_name: "Grep".to_string(),
+        };
+        let (updated, reason) = grep_cap_input(&input.tool_input).unwrap();
+        let out = input_rewrite_output(&input, updated, &reason, false);
+        let hso = &out["hookSpecificOutput"];
+        assert_eq!(hso["hookEventName"], "PreToolUse");
+        assert_eq!(hso["permissionDecision"], "allow");
+        assert_eq!(hso["updatedInput"]["head_limit"], DEFAULT_GREP_HEAD_LIMIT);
+        assert_eq!(hso["updatedInput"]["pattern"], "foo");
+    }
+
+    #[test]
+    fn grep_cap_antigravity_uses_overwrite_shape() {
+        let input = HookInput {
+            tool_name: "Grep".to_string(),
+            tool_input: serde_json::json!({"pattern": "foo", "output_mode": "content"}),
+            raw_tool_name: "grep_search".to_string(),
+        };
+        let (updated, reason) = grep_cap_input(&input.tool_input).unwrap();
+        let out = input_rewrite_output(&input, updated, &reason, true);
+        assert_eq!(out["decision"], "allow");
+        assert_eq!(out["overwrite"]["name"], "grep_search");
+        assert_eq!(
+            out["overwrite"]["args"]["head_limit"],
+            DEFAULT_GREP_HEAD_LIMIT
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1471,7 +1471,7 @@ fn cmd_session_audit(path: &Path, json: bool, cache_hygiene: bool) -> Result<()>
     }
     if prompt.combined_tokens > 10_000 {
         recommendations.push(format!(
-            "MCP/tool prompt weight high (~{} tok): run `tokenix prompt-audit --recommend`",
+            "prompt weight high (~{} tok of MCP schemas + always-on context): run `tokenix prompt-audit --recommend`",
             prompt.combined_tokens
         ));
     }

--- a/src/mcp_audit.rs
+++ b/src/mcp_audit.rs
@@ -9,6 +9,10 @@
 //! static baseline for the agent's native tools, and warns when the total looks
 //! bloated.
 //!
+//! Beyond MCP, it also weighs the *context* an agent loads before doing anything:
+//! instruction files (CLAUDE.md / AGENTS.md / copilot-instructions.md) and skills
+//! (always-on listing entry + on-invoke body). See "Context weight" below.
+//!
 //! The number is a *relative bloat indicator*, not the exact system-prompt token
 //! count (native baseline is approximate, HTTP/SSE servers are not introspected,
 //! and `count_tokens` is a ~4-chars/token estimate).
@@ -146,9 +150,23 @@ pub fn run_audit(
 ) -> Result<()> {
     let (agents, reports, thresholds) = collect_audit(filter, cwd);
     if json_out {
-        print_json(&agents, &reports, &thresholds, recommend, profile_impact);
+        print_json(
+            &agents,
+            &reports,
+            &thresholds,
+            recommend,
+            profile_impact,
+            cwd,
+        );
     } else {
-        print_human(&agents, &reports, &thresholds, recommend, profile_impact);
+        print_human(
+            &agents,
+            &reports,
+            &thresholds,
+            recommend,
+            profile_impact,
+            cwd,
+        );
     }
     Ok(())
 }
@@ -158,8 +176,8 @@ pub fn audit_summary(filter: Option<Agent>, cwd: &Path) -> AuditSummary {
     let mut combined_tokens = 0usize;
     let mut warnings = Vec::new();
     for agent in &agents {
-        let (_rows, totals) = aggregate(*agent, &reports, &thresholds);
-        combined_tokens += totals.native + totals.mcp_tokens;
+        let (_rows, totals) = aggregate(*agent, &reports, &thresholds, context_weight(*agent, cwd));
+        combined_tokens += totals.native + totals.mcp_tokens + totals.context.always_on();
         for reason in totals.reasons {
             warnings.push(format!("{}: {reason}", agent.label()));
         }
@@ -674,6 +692,216 @@ fn await_response(rx: &mpsc::Receiver<String>, id: i64) -> Result<Value, String>
 }
 
 // ---------------------------------------------------------------------------
+// Context weight: instruction files + skills
+// ---------------------------------------------------------------------------
+//
+// MCP tool schemas are not the only variable prompt cost. Two others are just as
+// real and were previously invisible here:
+//   * instruction files (CLAUDE.md / AGENTS.md / copilot-instructions.md) — read
+//     into context on *every* session, in full;
+//   * skills — their name+description sit in the prompt permanently, and their
+//     body is pulled in whole on invocation (one measured skill load cost
+//     ~198k tokens in this user's history).
+
+/// Skills whose body is reported as an on-invoke cost.
+const HEAVY_SKILL_TOKENS: usize = 5_000;
+/// Depth-bounded scan of plugin trees so a deep node_modules-style directory
+/// cannot turn the audit into a full-disk walk.
+const PLUGIN_SCAN_DEPTH: usize = 4;
+
+pub struct SkillEntry {
+    pub name: String,
+    /// Always-on cost: the name+description entry in the skill listing.
+    pub listing: usize,
+    /// On-invoke cost: the whole SKILL.md body.
+    pub body: usize,
+}
+
+#[derive(Default)]
+pub struct ContextWeight {
+    pub instruction_files: Vec<(String, usize)>,
+    pub skills: Vec<SkillEntry>,
+}
+
+impl ContextWeight {
+    /// Tokens paid on every request, before the agent does anything.
+    fn always_on(&self) -> usize {
+        let files: usize = self.instruction_files.iter().map(|(_, t)| t).sum();
+        let listings: usize = self.skills.iter().map(|s| s.listing).sum();
+        files + listings
+    }
+
+    fn is_empty(&self) -> bool {
+        self.instruction_files.is_empty() && self.skills.is_empty()
+    }
+
+    fn heavy_skills(&self) -> Vec<&SkillEntry> {
+        let mut heavy: Vec<&SkillEntry> = self
+            .skills
+            .iter()
+            .filter(|s| s.body >= HEAVY_SKILL_TOKENS)
+            .collect();
+        heavy.sort_by_key(|s| Reverse(s.body));
+        heavy
+    }
+}
+
+fn file_tokens(path: &Path) -> Option<(String, usize)> {
+    let raw = std::fs::read_to_string(path).ok()?;
+    if raw.trim().is_empty() {
+        return None;
+    }
+    // Strip the Windows extended-length prefix `\\?\` that canonicalization adds,
+    // so the reported path is the one the user recognizes.
+    let label = path
+        .to_string_lossy()
+        .replace('\\', "/")
+        .trim_start_matches("//?/")
+        .to_string();
+    Some((label, count_tokens(&raw)))
+}
+
+/// Extract the `name:`/`description:` frontmatter a skill contributes to the
+/// always-loaded listing. Falls back to the file's first line when a skill has
+/// no frontmatter, so an unparsable skill still counts as non-zero.
+fn skill_listing_tokens(raw: &str, fallback_name: &str) -> (String, usize) {
+    let mut name = fallback_name.to_string();
+    let mut description = String::new();
+    if let Some(body) = raw.strip_prefix("---") {
+        if let Some(end) = body.find("\n---") {
+            let lines: Vec<&str> = body[..end].lines().collect();
+            let mut i = 0;
+            while i < lines.len() {
+                let line = lines[i];
+                i += 1;
+                let Some((key, value)) = line.split_once(':') else {
+                    continue;
+                };
+                if !matches!(key.trim(), "name" | "description") {
+                    continue;
+                }
+                let mut value = value.trim().to_string();
+                // YAML block scalars (`description: |`) put the real text on the
+                // following indented lines — the common shape for skills, and
+                // reading only the `|` undercounted the listing ~10x.
+                if value == "|" || value == ">" || value == "|-" || value == ">-" {
+                    value.clear();
+                    while i < lines.len() && lines[i].starts_with([' ', '\t']) {
+                        value.push_str(lines[i].trim());
+                        value.push(' ');
+                        i += 1;
+                    }
+                    value = value.trim_end().to_string();
+                }
+                match key.trim() {
+                    "name" => name = value,
+                    _ => description = value,
+                }
+            }
+        }
+    }
+    if description.is_empty() {
+        description = raw.lines().next().unwrap_or("").to_string();
+    }
+    let listing = count_tokens(&format!("{name}: {description}"));
+    (name, listing)
+}
+
+fn collect_skills_in(dir: &Path, out: &mut Vec<SkillEntry>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let skill_md = entry.path().join("SKILL.md");
+        let Ok(raw) = std::fs::read_to_string(&skill_md) else {
+            continue;
+        };
+        let fallback = entry.file_name().to_string_lossy().to_string();
+        let (name, listing) = skill_listing_tokens(&raw, &fallback);
+        out.push(SkillEntry {
+            name,
+            listing,
+            body: count_tokens(&raw),
+        });
+    }
+}
+
+/// Walk a plugin tree looking for `skills/` directories, bounded in depth.
+fn collect_plugin_skills(dir: &Path, depth: usize, out: &mut Vec<SkillEntry>) {
+    if depth == 0 {
+        return;
+    }
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+        if path.file_name().and_then(|n| n.to_str()) == Some("skills") {
+            collect_skills_in(&path, out);
+        } else {
+            collect_plugin_skills(&path, depth - 1, out);
+        }
+    }
+}
+
+fn context_weight(agent: Agent, cwd: &Path) -> ContextWeight {
+    let repo_root = crate::find_repo_root(cwd);
+    let home = dirs::home_dir();
+    let mut weight = ContextWeight::default();
+
+    let instruction_paths: Vec<std::path::PathBuf> = match agent {
+        Agent::ClaudeCode => {
+            let mut v = vec![repo_root.join("CLAUDE.md"), repo_root.join("AGENTS.md")];
+            if let Some(h) = &home {
+                v.push(h.join(".claude").join("CLAUDE.md"));
+            }
+            v
+        }
+        Agent::Codex => {
+            let mut v = vec![repo_root.join("AGENTS.md")];
+            if let Some(h) = &home {
+                v.push(h.join(".codex").join("AGENTS.md"));
+            }
+            v
+        }
+        Agent::Copilot => vec![
+            repo_root.join(".github").join("copilot-instructions.md"),
+            repo_root.join("AGENTS.md"),
+        ],
+        Agent::OpenCode => vec![repo_root.join("AGENTS.md")],
+        Agent::Antigravity => Vec::new(),
+    };
+    for path in instruction_paths {
+        if let Some(entry) = file_tokens(&path) {
+            weight.instruction_files.push(entry);
+        }
+    }
+
+    // Skills are a Claude Code concept; other agents have no equivalent listing.
+    if agent == Agent::ClaudeCode {
+        collect_skills_in(
+            &repo_root.join(".claude").join("skills"),
+            &mut weight.skills,
+        );
+        if let Some(h) = &home {
+            collect_skills_in(&h.join(".claude").join("skills"), &mut weight.skills);
+            collect_plugin_skills(
+                &h.join(".claude").join("plugins"),
+                PLUGIN_SCAN_DEPTH,
+                &mut weight.skills,
+            );
+        }
+        weight.skills.sort_by(|a, b| a.name.cmp(&b.name));
+        weight.skills.dedup_by(|a, b| a.name == b.name);
+    }
+
+    weight
+}
+
+// ---------------------------------------------------------------------------
 // Reporting
 // ---------------------------------------------------------------------------
 
@@ -682,14 +910,18 @@ struct AgentTotals {
     tools: usize,
     mcp_tokens: usize,
     native: usize,
+    context: ContextWeight,
     warn: bool,
     reasons: Vec<String>,
 }
 
+/// `context` is passed in rather than discovered here so callers control the
+/// filesystem scan (and tests can aggregate against a known-empty context).
 fn aggregate(
     agent: Agent,
     reports: &[(Agent, String, Status)],
     th: &Thresholds,
+    context: ContextWeight,
 ) -> (Vec<(String, Status)>, AgentTotals) {
     let mut rows: Vec<(String, Status)> = reports
         .iter()
@@ -717,11 +949,19 @@ fn aggregate(
     if tools > th.tools {
         reasons.push(format!("{tools} tools > {}", th.tools));
     }
+    if context.always_on() > th.tokens {
+        reasons.push(format!(
+            "~{} always-on context tokens (instructions + skill listing) > {}",
+            context.always_on(),
+            th.tokens
+        ));
+    }
     let totals = AgentTotals {
         servers: rows.len(),
         tools,
         mcp_tokens,
         native,
+        context,
         warn: !reasons.is_empty(),
         reasons,
     };
@@ -734,8 +974,9 @@ fn print_human(
     th: &Thresholds,
     recommend: bool,
     profile_impact: bool,
+    cwd: &Path,
 ) {
-    println!("{}", "tokenix prompt-audit — MCP/tool weight".bold());
+    println!("{}", "tokenix prompt-audit — prompt weight".bold());
     println!(
         "{}",
         "estimate of the variable system-prompt cost per agent\n".dimmed()
@@ -744,12 +985,12 @@ fn print_human(
     let mut grand_tokens = 0usize;
     let mut any = false;
     for agent in agents {
-        let (rows, totals) = aggregate(*agent, reports, th);
-        if rows.is_empty() {
+        let (rows, totals) = aggregate(*agent, reports, th, context_weight(*agent, cwd));
+        if rows.is_empty() && totals.context.is_empty() {
             println!(
                 "{}  {}",
                 agent.label().bold(),
-                "(no MCP config found)".dimmed()
+                "(no MCP config, instruction files or skills found)".dimmed()
             );
             println!();
             continue;
@@ -769,15 +1010,17 @@ fn print_human(
             };
             println!("    {:<24} {}", name, detail);
         }
-        let total = totals.native + totals.mcp_tokens;
+        print_context_weight(&totals.context);
+        let total = totals.native + totals.mcp_tokens + totals.context.always_on();
         grand_tokens += total;
         println!(
-            "    {} {} servers, {} tools, ~{} MCP tok + ~{} native = {}",
+            "    {} {} servers, {} tools, ~{} MCP tok + ~{} native + ~{} context = {}",
             "└".dimmed(),
             totals.servers,
             totals.tools,
             totals.mcp_tokens,
             totals.native,
+            totals.context.always_on(),
             format!("~{total} tok").bold()
         );
         for reason in &totals.reasons {
@@ -800,11 +1043,41 @@ fn print_human(
     print_caveats();
 }
 
+/// Render the non-MCP prompt weight: instruction files (always loaded, in full)
+/// and skills (listing always loaded; body loaded on invoke).
+fn print_context_weight(context: &ContextWeight) {
+    for (path, tokens) in &context.instruction_files {
+        let short = path.rsplit('/').next().unwrap_or(path);
+        println!(
+            "    {:<24} {}",
+            short,
+            format!("~{tokens} tok (always loaded) — {path}").dimmed()
+        );
+    }
+    if context.skills.is_empty() {
+        return;
+    }
+    let listing: usize = context.skills.iter().map(|s| s.listing).sum();
+    println!(
+        "    {:<24} {} skills, ~{listing} tok always-on listing",
+        "skills",
+        context.skills.len()
+    );
+    for skill in context.heavy_skills().iter().take(3) {
+        println!(
+            "      {} {}",
+            "↳".dimmed(),
+            format!("{}: ~{} tok loaded on invoke", skill.name, skill.body).dimmed()
+        );
+    }
+}
+
 fn print_caveats() {
     let lines = [
         "Caveats: native-tool baseline is a static approximation; HTTP/SSE servers",
         "are not introspected (shown as unknown); token counts use a ~4-chars/token",
-        "estimate. Treat this as a relative bloat indicator, not the exact prompt size.",
+        "estimate. Skill bodies are on-invoke costs and are excluded from the always-on",
+        "total. Treat this as a relative bloat indicator, not the exact prompt size.",
     ];
     println!();
     for l in lines {
@@ -818,11 +1091,12 @@ fn print_json(
     th: &Thresholds,
     recommend: bool,
     profile_impact: bool,
+    cwd: &Path,
 ) {
     let mut agents_json = Vec::new();
     let mut grand_tokens = 0usize;
     for agent in agents {
-        let (rows, totals) = aggregate(*agent, reports, th);
+        let (rows, totals) = aggregate(*agent, reports, th, context_weight(*agent, cwd));
         let servers: Vec<Value> = rows
             .iter()
             .map(|(name, status)| match status {
@@ -837,8 +1111,20 @@ fn print_json(
                 }),
             })
             .collect();
-        let total = totals.native + totals.mcp_tokens;
+        let total = totals.native + totals.mcp_tokens + totals.context.always_on();
         grand_tokens += total;
+        let instruction_files: Vec<Value> = totals
+            .context
+            .instruction_files
+            .iter()
+            .map(|(path, tokens)| json!({"path": path, "tokens": tokens}))
+            .collect();
+        let skills: Vec<Value> = totals
+            .context
+            .skills
+            .iter()
+            .map(|s| json!({"name": s.name, "listing_tokens": s.listing, "body_tokens": s.body}))
+            .collect();
         let mut agent_json = json!({
             "agent": agent.key(),
             "label": agent.label(),
@@ -848,6 +1134,9 @@ fn print_json(
             "tool_count": totals.tools,
             "mcp_tokens": totals.mcp_tokens,
             "native_tokens": totals.native,
+            "context_tokens": totals.context.always_on(),
+            "instruction_files": instruction_files,
+            "skills": skills,
             "total_tokens": total,
             "warn": totals.warn,
             "reasons": totals.reasons,
@@ -1055,7 +1344,7 @@ TOKEN = "abc"
             servers: 5,
             tools: 40,
         };
-        let (rows, totals) = aggregate(Agent::ClaudeCode, &reports, &th);
+        let (rows, totals) = aggregate(Agent::ClaudeCode, &reports, &th, ContextWeight::default());
         assert_eq!(rows.len(), 2);
         assert_eq!(totals.tools, 15);
         assert_eq!(totals.mcp_tokens, 14_000);
@@ -1078,8 +1367,73 @@ TOKEN = "abc"
             servers: 5,
             tools: 40,
         };
-        let (_, totals) = aggregate(Agent::Codex, &reports, &th);
+        let (_, totals) = aggregate(Agent::Codex, &reports, &th, ContextWeight::default());
         assert!(!totals.warn);
         assert!(totals.reasons.is_empty());
+    }
+
+    #[test]
+    fn skill_listing_counts_frontmatter_not_body() {
+        let raw = "---\nname: deploy-thing\ndescription: Deploy the thing safely\n---\n\n# Body\n";
+        let (name, listing) =
+            skill_listing_tokens(&format!("{raw}{}", "filler ".repeat(4000)), "dir-name");
+        assert_eq!(name, "deploy-thing");
+        // The always-on cost is the one-line entry, not the multi-thousand-token body.
+        assert!(listing < 30, "listing was {listing}");
+    }
+
+    #[test]
+    fn skill_listing_reads_yaml_block_scalar_description() {
+        // The shape every bundled skill uses; reading only the `|` undercounted
+        // the always-on listing by ~10x.
+        let raw = "---\nname: deploy-thing\ndescription: |\n  **DEPLOY SKILL** - ship the thing.\n  USE FOR: rollouts, rollbacks, canary analysis, cluster drift.\n  DO NOT USE FOR: writing app code.\n---\n\nbody\n";
+        let (name, listing) = skill_listing_tokens(raw, "dir-name");
+        assert_eq!(name, "deploy-thing");
+        assert!(
+            listing > 25,
+            "block-scalar description must be counted, got {listing}"
+        );
+    }
+
+    #[test]
+    fn skill_listing_falls_back_without_frontmatter() {
+        let (name, listing) = skill_listing_tokens("# Some skill\nbody\n", "dir-name");
+        assert_eq!(name, "dir-name");
+        assert!(listing > 0);
+    }
+
+    #[test]
+    fn context_weight_totals_always_on_cost() {
+        let ctx = ContextWeight {
+            instruction_files: vec![("CLAUDE.md".to_string(), 1200)],
+            skills: vec![
+                SkillEntry {
+                    name: "a".to_string(),
+                    listing: 30,
+                    body: 40_000,
+                },
+                SkillEntry {
+                    name: "b".to_string(),
+                    listing: 20,
+                    body: 100,
+                },
+            ],
+        };
+        // Bodies are on-invoke, so they must NOT inflate the always-on figure.
+        assert_eq!(ctx.always_on(), 1250);
+        let heavy = ctx.heavy_skills();
+        assert_eq!(heavy.len(), 1);
+        assert_eq!(heavy[0].name, "a");
+    }
+
+    #[test]
+    fn context_weight_reads_instruction_files_from_disk() {
+        let dir = std::env::temp_dir().join(format!("tokenix-ctxweight-{}", std::process::id()));
+        let _ = std::fs::create_dir_all(&dir);
+        std::fs::write(dir.join("AGENTS.md"), "rules ".repeat(500)).unwrap();
+        let weight = context_weight(Agent::OpenCode, &dir);
+        assert_eq!(weight.instruction_files.len(), 1);
+        assert!(weight.always_on() > 100);
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/tests/hook_e2e.rs
+++ b/tests/hook_e2e.rs
@@ -125,6 +125,48 @@ fn empty_tool_name_passes_through() {
     assert!(stdout.trim().is_empty());
 }
 
+/// An uncapped content grep must come back with a `head_limit` injected — and
+/// it must work from a temp cwd with no index at all, since the stale-index gate
+/// exits before the tool handlers.
+#[test]
+fn uncapped_content_grep_gets_head_limit() {
+    let payload = r#"{"hook_event_name":"PreToolUse","tool_name":"Grep","tool_input":{"pattern":"foo","output_mode":"content","-C":3}}"#;
+    let (stdout, code) = run_hook(payload);
+    assert_eq!(code, 0);
+    let v: serde_json::Value =
+        serde_json::from_str(stdout.trim()).unwrap_or_else(|_| panic!("expected JSON: {stdout}"));
+    let updated = &v["hookSpecificOutput"]["updatedInput"];
+    assert_eq!(v["hookSpecificOutput"]["hookEventName"], "PreToolUse");
+    assert!(
+        updated["head_limit"].is_number(),
+        "grep must be capped: {stdout}"
+    );
+    assert_eq!(updated["pattern"], "foo", "original args preserved");
+    assert_eq!(updated["-C"], 3);
+}
+
+#[test]
+fn bounded_grep_passes_through_untouched() {
+    let payload = r#"{"hook_event_name":"PreToolUse","tool_name":"Grep","tool_input":{"pattern":"foo","output_mode":"content","head_limit":20}}"#;
+    let (stdout, code) = run_hook(payload);
+    assert_eq!(code, 0);
+    assert!(
+        stdout.trim().is_empty(),
+        "agent-bounded grep must not be rewritten: {stdout}"
+    );
+}
+
+#[test]
+fn files_with_matches_grep_passes_through() {
+    let payload = r#"{"hook_event_name":"PreToolUse","tool_name":"Grep","tool_input":{"pattern":"foo","output_mode":"files_with_matches"}}"#;
+    let (stdout, code) = run_hook(payload);
+    assert_eq!(code, 0);
+    assert!(
+        stdout.trim().is_empty(),
+        "cheap output mode must not be rewritten: {stdout}"
+    );
+}
+
 /// The PowerShell tool routes through `run --shell pwsh` with native-exe
 /// quoting — Windows-only behavior (exact tool name "PowerShell"; the
 /// lowercase variants route through the bash path).


### PR DESCRIPTION
Four token-waste backstops, each targeting a pattern measured by a fresh `tokenix conversation-audit` over 1701 local history files:

| pattern | tokens | covered before? |
|---|---|---|
| image-blob | 5.41M | runtime redaction (Copilot/Bash paths only) |
| unknown-large (grep dumps, giant payloads) | 1.67M | no |
| full-read (monitoring loop output) | 617k | no |
| bootstrap-prompt (skill body in context) | 198k | no |

## 1. Global output cap — `enforce_token_budget` (`src/compress.rs`)

`TOKENIX_MAX_OUTPUT_TOKENS` (default `8000`, `0` disables) clips compressed output to a 75% head + 25% tail window at char boundaries (UTF-8 safe).

Applied on **every** return path — including the `compact_json` early return and the TOML-filter result. Those two bypassed all line-count caps: a single-line multi-MB payload has no line count to truncate on, and `compact_json` returned directly, so a payload it shrank by ~10% still cost hundreds of thousands of tokens.

## 2. Repeated-block collapse — `group_repeated_blocks` (`src/compress.rs`)

A 2–12 line stanza repeated 3+ times is kept once and annotated `[block of N lines repeated Kx]`. `group_repeated_lines` only ever saw runs of *identical adjacent lines*, so watch/poll loops (one monitoring session: ~617k tokens of the same exception stanza) went through untouched. A block of identical lines is deliberately deferred to the line grouper so `[repeated Nx]` stays the reported shape.

## 3. Uncapped grep guard (`src/hook.rs`)

`handle_grep` only intercepts semantic/symbol queries; every other pattern passed through raw — the source of a measured 937k-token dump. Now a lexical Grep with `output_mode="content"` and no `head_limit` gets one injected via `updatedInput` (`TOKENIX_GREP_HEAD_LIMIT`, default `100`).

Deliberately narrow: `files_with_matches`/`count` are already cheap, and an agent that set its own `head_limit` has bounded itself — both pass through. It also runs inside the stale-index gate, since bounding a grep needs no index. Logged with `saved_tokens=0`: the unbounded output never ran, so claiming savings would inflate `gain`.

## 4. prompt-audit context weight (`src/mcp_audit.rs`)

The audit reported MCP schemas only, while the measured top waste was a skill body worth ~198k tokens. `context_weight()` now also measures:

- instruction files (`CLAUDE.md`, `AGENTS.md`, `.github/copilot-instructions.md`, `~/.claude/CLAUDE.md`, `~/.codex/AGENTS.md`) — always-on, full file;
- skills (`<repo>/.claude/skills`, `~/.claude/skills`, plugin `skills/` trees, depth ≤ 4) — frontmatter `name`+`description` always-on; `SKILL.md` body reported separately as an on-invoke cost above 5k tokens.

Only always-on tokens enter the per-agent total and `combined_tokens`. `aggregate()` takes the `ContextWeight` as a parameter rather than a cwd, so existing tests aggregate against a known-empty context instead of the developer's real home directory.

A bug surfaced in smoke testing, not in unit tests: skills use YAML block scalars (`description: |`), and reading only the `|` undercounted the listing ~10× (476 → 8557 tok for 83 skills). Fixed, with a test on the real format.

On this repo the command now reports ~19k always-on context tokens against 0 MCP tokens — previously invisible.

## Verification

- `cargo clippy --all-targets -- -D warnings` clean, `cargo fmt` applied
- 314 unit tests + 13 e2e passing (3 new e2e cases for the grep guard: capped, agent-bounded, cheap mode)
- `tokenix prompt-audit --agent claude` and `--json` smoke-tested against real config

Docs updated in both README.md and AGENTS.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D9wpRpzDQ74U3fpFo7kwki
