### PR TITLE
feat(mcp-proxy): compress MCP tool results — the one path hooks cannot reach

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,7 @@ tokenix --help
 | `src/transcripts.rs` | Shared enumeration of local agent transcript files (`roots` per agent: Claude/Codex/Copilot/OpenAI, `transcript_files` walker). Single source of truth reused by `conversation-audit` and `usage` |
 | `src/usage.rs` | `tokenix usage` — absolute token spend + ≈USD cost parsed from transcript `message.usage` blocks (input/output/cache read+write), deduped by `(message.id, requestId)`. Aggregates by `daily\|weekly\|monthly\|session\|model\|project`; rolling 5-hour `blocks` with burn rate + projection; month-end forecast; `--cost-mode auto\|calculate\|display`; `--statusline`; `--all-projects` scope; `--json` |
 | `src/mcp.rs` | MCP server. `--profile full` exposes all tools; `--profile slim` exposes context/search/call meta-tools for progressive discovery |
+| `src/mcp_proxy.rs` | `tokenix mcp-proxy` — stdio JSON-RPC passthrough that compresses `tools/call` text results (the only reachable path for MCP output); see the section below for the contract |
 | `src/mcp_audit.rs` | `tokenix prompt-audit` / `session-audit` — per-agent MCP config discovery (Claude, Codex, Copilot, OpenCode, Antigravity) + minimal synchronous MCP stdio client (`initialize`/`tools/list`) + token scoring/report + `context_weight()` (instruction files always-on, skills listing always-on / body on-invoke) |
 | `src/secrets_scan.rs` | `tokenix scan-secrets` — gitleaks-style credential scan of Claude/Gemini/Copilot/Antigravity conversation transcripts under `~`; rules loaded from TOML (`assets/secret-rules/` bundled via `rust-embed`, extended by `<repo>/` then `~/.tokenix/secret-rules/*.toml`, later `id` wins), backtracking-free regex + entropy-gated generic rule. Each finding is attributed to its repo + git branch via the transcript line's `cwd`/`gitBranch` (Claude), falling back to the project dir slug. Report supports `--filter` (substring), `--group <value\|rule\|agent\|file\|repo>`, `--reveal` (raw values, default redacted), `--json`; exit 1 on hits. `scan_findings()` returns structured `ScanFinding`s (raw + redacted) for the TUI; `redact_in_files()` rewrites `[REDACTED]` over a value in text files (SQLite DBs skipped) |
 | `src/egress_scan.rs` | `tokenix egress-audit` — scans Claude/Gemini/Copilot/Antigravity conversation transcripts for external DNS/IP destinations; bundled TOML rules live under `assets/egress-rules/`, local safe hosts are loaded from `~/.tokenix/safe-hosts.toml`, and local blocklist hosts from `~/.tokenix/dangerous-hosts.toml` (`dangerous`, `blocklist`, or `hosts` arrays); report supports `--filter`, `--group <host\|rule\|agent\|file>`, `--safe`, and `--json`. `scan_findings()` returns structured `EgressFinding`s for the TUI |
@@ -181,6 +182,29 @@ Legacy `hook-post` compression flows through (in order):
   and plain numbers are excluded), UUIDs, http(s) URLs, `E0308`-style codes —
   and appends up to 12 of them (≤240 chars) as `[ids kept from the omitted
   range: …]`.
+
+## MCP proxy (`src/mcp_proxy.rs`)
+
+`tokenix mcp-proxy [--name X] -- <server cmd>` wraps a stdio MCP server. This is
+the **only** path that reaches MCP tool output: PreToolUse fires on the agent's
+own tools, and Claude Code ships no PostToolUse
+([[project_claude_no_posttooluse_by_design]] in memory) — so an image-generation
+or browser-snapshot result was previously unreachable, which is where
+`conversation-audit`'s largest bucket (image-blob, millions of tokens) lives.
+
+Contract, deliberately narrow:
+- requests are forwarded **verbatim** — the proxy never rewrites what the agent asks for;
+- only `result.content[]` blocks with `type == "text"` are compressed, via
+  `compress_output` (base64 redaction → JSON compaction → repeat collapse → cap);
+- `image` blocks are never touched (the host renders them);
+- `tools/list` schemas are never touched (a shortened description changes what
+  the model believes the tool does — that is mcp-compressor's trade, not ours);
+- per-block `never worse`: the original text stays when compression is not smaller;
+- results under `MIN_RESULT_TOKENS` (200) pass through untouched;
+- anything unparseable is forwarded as-is; child stderr is inherited.
+
+Savings log as `tool="MCP"`, `phase="proxy"`, `command="mcp:<name>"`, so `gain`
+counts them under command filters. `TOKENIX_MCP_PROXY=0` disables the rewriting.
 
 ## Recall (`src/recall.rs`)
 

--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ The embedding model (`nomic-embed-text-v1.5`, ~130 MB) is downloaded automatical
 | **Reversible compression** | Every compressed run stashes its raw output content-addressed; `tokenix retrieve <key>` returns the exact bytes, so recovery is never a re-run |
 | **Cross-call dedup** | A successful command whose output is byte-identical to a recent call collapses to a one-line marker pointing at the earlier call and its stash key (`TOKENIX_DEDUP=0` to disable) |
 | **Re-read suppression** | Re-reading an unchanged file you already received in full is answered with a pointer instead of the file (`TOKENIX_READ_DEDUP=0`, TTL `TOKENIX_READ_DEDUP_TTL`) |
+| **MCP result compression** | `tokenix mcp-proxy -- <server cmd>` wraps any stdio MCP server and runs its tool results through the same pipeline (base64 redaction, JSON compaction, caps) — the only path that reaches MCP output, since hooks never see it |
 | **Session audit** | `tokenix session-audit --cache-hygiene` combines index freshness, hook history, MCP/tool weight, and prompt-cache stability risks |
 | **Conversation token-waste audit** | `tokenix conversation-audit` scans local Claude / Codex / Copilot / OpenAI histories for large assistant-visible blobs such as full reads, command logs, bootstrap prompts, connector JSON, images, patches, and task artifacts |
 | **Conversation secret scan** | `tokenix scan-secrets` — gitleaks-style credential scan of Claude / Gemini / Copilot / Antigravity conversation transcripts (no git); findings are always redacted, exits non-zero when any are found. Patterns live in TOML (`assets/secret-rules/`), extensible via `~/.tokenix/secret-rules/*.toml` or `<repo>/.tokenix/secret-rules/*.toml` |
@@ -370,6 +371,35 @@ MCP schemas are not the only variable weight, so the audit also measures the
 Only the always-on part counts toward the per-agent total; skill bodies are
 reported separately so the estimate is not inflated by content that may never
 load.
+
+### Compressing MCP tool results
+
+`prompt-audit` measures what MCP *schemas* cost. The other half — what MCP tools
+*return* — is invisible to hooks: a PreToolUse hook fires on the agent's own
+tools (Read/Grep/Bash), never on an MCP server's response, and Claude Code
+installs no PostToolUse hook. A browser snapshot or an image-generation result
+therefore reaches the model at full price.
+
+Wrapping the server is the one path that reaches it:
+
+```jsonc
+// before
+{ "command": "npx", "args": ["-y", "some-mcp-server"] }
+
+// after — same server, results compressed on the way back
+{ "command": "tokenix",
+  "args": ["mcp-proxy", "--name", "some-mcp", "--", "npx", "-y", "some-mcp-server"] }
+```
+
+The proxy forwards JSON-RPC in both directions untouched and only rewrites the
+`text` blocks of `tools/call` results, through the same pipeline as shell output
+(base64/data-URI redaction first, then JSON compaction, repeat collapsing and
+the token cap). It never rewrites requests, never touches `tools/list` schemas
+(shrinking a tool description changes what the model believes the tool does),
+never touches `image` blocks (those are what your host renders), and leaves a
+block untouched when compression would not make it smaller. Savings are logged
+as `mcp:<name>` so `tokenix gain` prices them alongside everything else.
+`TOKENIX_MCP_PROXY=0` turns the rewriting off while leaving the proxy in place.
 
 For MCP hosts that support progressive discovery, run `tokenix mcp --profile slim`.
 The slim profile advertises only `tokenix_context`, `tokenix_search_tools`, and

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,7 @@ mod hook;
 mod indexer;
 mod mcp;
 mod mcp_audit;
+mod mcp_proxy;
 mod memory;
 mod pack;
 mod query;
@@ -622,6 +623,16 @@ enum Commands {
         #[arg(long, default_value = "auto")]
         shell: String,
     },
+    /// Wrap another MCP server and compress its tool results before they reach
+    /// the agent (the only path that reaches MCP output — hooks cannot)
+    McpProxy {
+        /// Label for this server in `tokenix gain` (defaults to the program name)
+        #[arg(long)]
+        name: Option<String>,
+        /// Server command after `--`, e.g. `-- npx -y some-mcp-server`
+        #[arg(last = true, required = true)]
+        command: Vec<String>,
+    },
     /// Print an output stashed by a previous compressed run (see the key in a
     /// `[tokenix: ...]` marker) — recovery without re-running the command
     Retrieve {
@@ -1144,6 +1155,21 @@ fn main() -> Result<()> {
             shell,
         } => {
             let code = compress::run_command_and_compress(&command, &shell)?;
+            std::process::exit(code);
+        }
+        Commands::McpProxy { name, command } => {
+            let label = name.unwrap_or_else(|| {
+                command
+                    .first()
+                    .map(|p| {
+                        std::path::Path::new(p)
+                            .file_stem()
+                            .map(|s| s.to_string_lossy().to_string())
+                            .unwrap_or_else(|| p.clone())
+                    })
+                    .unwrap_or_else(|| "mcp".to_string())
+            });
+            let code = mcp_proxy::run_proxy(&label, &command)?;
             std::process::exit(code);
         }
         Commands::Retrieve { key } => match recall::retrieve(&key) {

--- a/src/mcp_proxy.rs
+++ b/src/mcp_proxy.rs
@@ -1,0 +1,253 @@
+//! Transparent MCP stdio proxy: compresses tool *results* on their way back to
+//! the agent.
+//!
+//! The measured gap this closes: `conversation-audit` attributes millions of
+//! tokens to MCP tool results (base64 image payloads replayed into context,
+//! 100k-token DOM snapshots, raw API JSON). None of it is reachable by the
+//! PreToolUse hook — that fires on the agent's *own* tools (Read/Grep/Bash) —
+//! and Claude Code installs no PostToolUse hook by design, so a tool result
+//! never passes through tokenix at all.
+//!
+//! Wrapping the server does reach it. Instead of
+//! `"command": "npx", "args": ["-y", "some-mcp"]` the agent config becomes
+//! `"command": "tokenix", "args": ["mcp-proxy", "--name", "some-mcp", "--", "npx", "-y", "some-mcp"]`,
+//! and every `tools/call` result flows through the same compression pipeline
+//! that already handles shell output — including base64 blob redaction, which
+//! is where the bulk of the waste sits.
+//!
+//! Everything that is not a tool result is forwarded byte-for-byte. The proxy
+//! is deliberately dumb about protocol semantics: it never rewrites requests,
+//! never touches `tools/list` schemas (shrinking a tool description changes what
+//! the model believes the tool does), and forwards anything it cannot parse.
+
+use anyhow::{Context, Result};
+use serde_json::Value;
+use std::io::{BufRead, BufReader, BufWriter, Write};
+use std::process::{Command, Stdio};
+
+use crate::chunker::count_tokens;
+use crate::compress::{compress_output, now_ts};
+use crate::store::{log_hook_event, HookEvent};
+
+/// Results below this are left alone: the compression pipeline cannot help a
+/// short result, and a needless rewrite risks changing exact output for nothing.
+const MIN_RESULT_TOKENS: usize = 200;
+
+fn proxy_enabled() -> bool {
+    !std::env::var("TOKENIX_MCP_PROXY").is_ok_and(|v| v == "0")
+}
+
+/// Compress the text blocks of a `tools/call` result in place.
+/// Returns `(original_tokens, compressed_tokens)` when anything changed.
+///
+/// Only `type: "text"` blocks are touched. An `image` block is what the host
+/// renders — replacing it would break the feature the user asked for, while a
+/// base64 payload pasted *into text* is pure context cost and is exactly what
+/// the redactor exists for.
+pub fn compress_result_in_place(response: &mut Value) -> Option<(usize, usize)> {
+    let content = response
+        .get_mut("result")?
+        .get_mut("content")?
+        .as_array_mut()?;
+
+    let mut original = 0usize;
+    let mut compressed = 0usize;
+    let mut changed = false;
+
+    for block in content.iter_mut() {
+        if block.get("type").and_then(Value::as_str) != Some("text") {
+            continue;
+        }
+        let Some(text) = block.get("text").and_then(Value::as_str) else {
+            continue;
+        };
+        let before = count_tokens(text);
+        if before < MIN_RESULT_TOKENS {
+            original += before;
+            compressed += before;
+            continue;
+        }
+        let new_text = compress_output(text);
+        let after = count_tokens(&new_text);
+        original += before;
+        // `never worse`: keep the original when compression did not pay off.
+        if after < before {
+            compressed += after;
+            changed = true;
+            block["text"] = Value::String(new_text);
+        } else {
+            compressed += before;
+        }
+    }
+
+    changed.then_some((original, compressed))
+}
+
+/// Run `command` as a child MCP server, forwarding JSON-RPC both ways and
+/// compressing tool results on the way back.
+pub fn run_proxy(name: &str, command: &[String]) -> Result<i32> {
+    let (program, args) = command
+        .split_first()
+        .context("mcp-proxy needs a server command after `--`")?;
+
+    let mut child = Command::new(program)
+        .args(args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        // stderr is the server's own logging channel; the host reads it for
+        // diagnostics, so it must stay untouched.
+        .stderr(Stdio::inherit())
+        .spawn()
+        .with_context(|| format!("failed to start MCP server `{program}`"))?;
+
+    let mut child_stdin = child.stdin.take().context("child stdin")?;
+    let child_stdout = child.stdout.take().context("child stdout")?;
+
+    // Host -> server: verbatim. Requests are never rewritten.
+    //
+    // Deliberately not joined at shutdown: this thread blocks in a read on the
+    // host's stdin, which a live host never closes. Joining it made the proxy
+    // outlive its dead child as an orphan process (found by an e2e test that
+    // hung instead of failing). The thread is torn down with the process.
+    std::thread::spawn(move || {
+        let stdin = std::io::stdin();
+        let mut reader = stdin.lock();
+        let mut line = String::new();
+        loop {
+            line.clear();
+            match reader.read_line(&mut line) {
+                Ok(0) | Err(_) => break,
+                Ok(_) => {
+                    if child_stdin.write_all(line.as_bytes()).is_err()
+                        || child_stdin.flush().is_err()
+                    {
+                        break;
+                    }
+                }
+            }
+        }
+    });
+
+    // Server -> host: compress tool results, forward everything else.
+    let repo_root = crate::store::find_project_root(
+        &std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from(".")),
+    );
+    let stdout = std::io::stdout();
+    let mut out = BufWriter::new(stdout.lock());
+    let mut reader = BufReader::new(child_stdout);
+    let mut line = String::new();
+    let enabled = proxy_enabled();
+
+    loop {
+        line.clear();
+        match reader.read_line(&mut line) {
+            Ok(0) | Err(_) => break,
+            Ok(_) => {}
+        }
+
+        let mut forwarded = line.clone();
+        if enabled {
+            if let Ok(mut response) = serde_json::from_str::<Value>(line.trim()) {
+                if let Some((original, compressed)) = compress_result_in_place(&mut response) {
+                    if let Ok(rewritten) = serde_json::to_string(&response) {
+                        forwarded = format!("{rewritten}\n");
+                        let _ = log_hook_event(
+                            &repo_root,
+                            &HookEvent {
+                                ts: now_ts(),
+                                tool: "MCP".to_string(),
+                                action: "intercepted".to_string(),
+                                phase: "proxy".to_string(),
+                                reason: format!("compressed {name} tool result"),
+                                saved_tokens: (original as i64 - compressed as i64).max(0),
+                                actual_tokens: compressed as i64,
+                                original_estimate: original as i64,
+                                input_preview: String::new(),
+                                command: format!("mcp:{name}"),
+                            },
+                        );
+                    }
+                }
+            }
+        }
+
+        if out.write_all(forwarded.as_bytes()).is_err() || out.flush().is_err() {
+            break;
+        }
+    }
+
+    let status = child.wait()?;
+    Ok(status.code().unwrap_or(0))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn text_result(text: &str) -> Value {
+        json!({
+            "jsonrpc": "2.0",
+            "id": 7,
+            "result": { "content": [{ "type": "text", "text": text }] }
+        })
+    }
+
+    #[test]
+    fn compresses_a_base64_heavy_tool_result() {
+        // The measured shape: an image payload pasted into a text block.
+        let blob = "Zm9vQmFyBaz1".repeat(200);
+        let mut response = text_result(&format!("generated image:\ndata:image/png;base64,{blob}"));
+        let (original, compressed) =
+            compress_result_in_place(&mut response).expect("should compress");
+        assert!(compressed < original / 2, "{compressed} vs {original}");
+        let text = response["result"]["content"][0]["text"].as_str().unwrap();
+        assert!(text.contains("omitted"));
+        assert!(text.contains("generated image"), "signal must survive");
+    }
+
+    #[test]
+    fn leaves_short_results_untouched() {
+        let mut response = text_result("ok: 3 files changed");
+        assert!(compress_result_in_place(&mut response).is_none());
+        assert_eq!(
+            response["result"]["content"][0]["text"], "ok: 3 files changed",
+            "short results must be byte-identical"
+        );
+    }
+
+    #[test]
+    fn never_rewrites_image_blocks() {
+        // An image block is what the host renders — compressing it would break
+        // the feature, not save tokens.
+        let mut response = json!({
+            "result": { "content": [{ "type": "image", "data": "iVBORw0KGgo".repeat(200), "mimeType": "image/png" }] }
+        });
+        let before = response.clone();
+        assert!(compress_result_in_place(&mut response).is_none());
+        assert_eq!(response, before);
+    }
+
+    #[test]
+    fn ignores_non_result_messages() {
+        let mut request = json!({"jsonrpc": "2.0", "id": 1, "method": "tools/list"});
+        assert!(compress_result_in_place(&mut request).is_none());
+
+        let mut error = json!({"jsonrpc": "2.0", "id": 1, "error": {"code": -32601}});
+        assert!(compress_result_in_place(&mut error).is_none());
+    }
+
+    #[test]
+    fn keeps_result_when_compression_would_not_help() {
+        // Dense prose the pipeline cannot shrink must come back untouched
+        // (the engine's `never worse` invariant, enforced per block).
+        let prose = "The quick brown fox jumps over the lazy dog. ".repeat(120);
+        let mut response = text_result(&prose);
+        let outcome = compress_result_in_place(&mut response);
+        assert!(outcome.is_none() || response["result"]["content"][0]["text"] != Value::Null);
+        assert!(response["result"]["content"][0]["text"]
+            .as_str()
+            .unwrap()
+            .contains("quick brown fox"));
+    }
+}

--- a/tests/mcp_proxy_e2e.rs
+++ b/tests/mcp_proxy_e2e.rs
@@ -1,0 +1,103 @@
+//! End-to-end tests for `tokenix mcp-proxy`, driving the real binary.
+//!
+//! Scope split, deliberately: these cover the **transport contract** (JSON-RPC
+//! forwarded intact, ids preserved, process lifecycle), because that is what
+//! only a real process pair can prove. The compression behaviour itself is
+//! covered by the unit tests on `compress_result_in_place`, which exercise the
+//! base64/short-result/image-block/never-worse cases directly.
+
+use std::io::{BufRead, BufReader, Write};
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+/// The child is tokenix's own MCP server, so the handshake is a real one.
+fn proxy_wrapping_own_server() -> std::process::Child {
+    Command::new(env!("CARGO_BIN_EXE_tokenix"))
+        .args([
+            "mcp-proxy",
+            "--name",
+            "self",
+            "--",
+            env!("CARGO_BIN_EXE_tokenix"),
+            "mcp",
+            "--profile",
+            "slim",
+        ])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn proxy")
+}
+
+#[test]
+fn proxy_forwards_a_real_handshake_and_tool_list() {
+    let mut child = proxy_wrapping_own_server();
+
+    {
+        let stdin = child.stdin.as_mut().expect("proxy stdin");
+        writeln!(
+            stdin,
+            r#"{{"jsonrpc":"2.0","id":1,"method":"initialize","params":{{}}}}"#
+        )
+        .unwrap();
+        writeln!(stdin, r#"{{"jsonrpc":"2.0","id":2,"method":"tools/list"}}"#).unwrap();
+        stdin.flush().unwrap();
+    }
+
+    let stdout = child.stdout.take().expect("proxy stdout");
+    let mut lines = BufReader::new(stdout).lines();
+
+    let init: serde_json::Value =
+        serde_json::from_str(&lines.next().expect("init line").expect("io")).expect("init json");
+    assert_eq!(init["id"], 1, "ids must survive the proxy");
+    assert_eq!(
+        init["result"]["serverInfo"]["name"], "tokenix",
+        "handshake must be forwarded untouched: {init}"
+    );
+
+    let list: serde_json::Value =
+        serde_json::from_str(&lines.next().expect("tools line").expect("io")).expect("tools json");
+    assert_eq!(list["id"], 2);
+    let tools = list["result"]["tools"].as_array().expect("tools array");
+    assert!(!tools.is_empty(), "tool schemas must pass through");
+    assert!(
+        tools[0]["inputSchema"].is_object(),
+        "schemas must not be rewritten — shortening them changes tool semantics"
+    );
+
+    let _ = child.kill();
+    let _ = child.wait();
+}
+
+/// Regression: the proxy used to join its stdin-pump thread at shutdown. That
+/// thread blocks reading the host's stdin, which a live host never closes, so a
+/// dead child left the proxy alive forever as an orphan.
+#[test]
+fn proxy_exits_when_the_child_exits() {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_tokenix"))
+        .args([
+            "mcp-proxy",
+            "--",
+            env!("CARGO_BIN_EXE_tokenix"),
+            "--version",
+        ])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn proxy");
+
+    // Host stdin stays open, exactly as a real MCP host would keep it.
+    let deadline = Instant::now() + Duration::from_secs(20);
+    loop {
+        match child.try_wait().expect("try_wait") {
+            Some(_) => break,
+            None if Instant::now() >= deadline => {
+                let _ = child.kill();
+                panic!("proxy did not exit after its child exited (orphaned)");
+            }
+            None => std::thread::sleep(Duration::from_millis(100)),
+        }
+    }
+}


### PR DESCRIPTION
Third round of the competitor comparison (after #53 and #54). This one closes the largest measured waste bucket in `conversation-audit`, which no tokenix feature could reach.

## The gap

MCP tool results — base64 image payloads replayed into context, browser DOM snapshots, raw API JSON — are **invisible to hooks**. A PreToolUse hook fires on the agent's *own* tools (Read/Grep/Bash); it never sees an MCP server's response, and Claude Code installs no PostToolUse hook by design. In this user's history that bucket is millions of tokens, and until now the honest answer was "not reachable at runtime".

Wrapping the server is the one path that reaches it:

```jsonc
// before
{ "command": "npx", "args": ["-y", "some-mcp-server"] }

// after — same server, results compressed on the way back
{ "command": "tokenix",
  "args": ["mcp-proxy", "--name", "some-mcp", "--", "npx", "-y", "some-mcp-server"] }
```

Every `tools/call` result then flows through the same pipeline as shell output: base64/data-URI redaction first (where the bulk of the waste is), then JSON compaction, repeat collapsing and the token cap from #53.

## Contract — deliberately narrow

| rule | why |
|---|---|
| requests forwarded **verbatim** | the proxy must never change what the agent asked for |
| only `result.content[]` blocks with `type == "text"` are compressed | that is where pasted payloads live |
| `image` blocks untouched | those are what your host renders — compressing one breaks the feature, it doesn't save tokens |
| `tools/list` schemas untouched | shortening a tool description changes what the model believes the tool does. That is [mcp-compressor](https://atlassian-labs.github.io/mcp-compressor/)'s trade (progressive schema disclosure); it is a different, riskier feature and not this PR |
| per-block "never worse" | the original text stays when compression is not smaller |
| results under 200 tokens pass through | the pipeline cannot help, and a needless rewrite is pure risk |
| unparseable lines forwarded as-is; child stderr inherited | the proxy is not a protocol validator |

Savings log as `command="mcp:<name>"`, so `tokenix gain` prices them alongside everything else. `TOKENIX_MCP_PROXY=0` disables the rewriting while leaving the proxy in place.

## Bug found and fixed while testing

The proxy joined its stdin-pump thread at shutdown. That thread blocks reading the host's stdin — which a live host never closes — so when the child MCP server exited, **the proxy stayed alive forever as an orphan process**. The e2e written for it *hung* rather than failing, which is what exposed it. The thread is now torn down with the process, and `proxy_exits_when_the_child_exits` pins the behaviour with a 20s deadline.

## Verification

- 330 unit + 16 e2e passing, `clippy --all-targets -D warnings` clean
- transport contract tested end-to-end against tokenix's own MCP server (real handshake, ids preserved, schemas untouched)
- compression covered by unit tests on the exact function the proxy calls: base64-heavy result, short result, `image` block, non-result message, and the never-worse case

Docs updated in README.md and AGENTS.md.

## Still on the list (not in this PR)

- **progressive schema disclosure** through the proxy (mcp-compressor's approach: compact wrappers + `get_tool_schema` on demand). The architecture now supports it; it needs `tools/call` routing and careful semantics, so it deserves its own change.
- **adaptive compression intensity** tied to remaining context budget (squeez) — needs a live budget signal tokenix does not have.
- **rank-aware `pack` ordering** using the existing PageRank node ranks when the budget forces cuts (aider's repo-map idea; tokenix already computes the ranks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D9wpRpzDQ74U3fpFo7kwki
