### PR TITLE
feat(docs): render README screenshots headlessly as SVG

### DIFF
--- a/.github/prints/doctor.svg
+++ b/.github/prints/doctor.svg
@@ -1,0 +1,39 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1008 612" width="1008" height="612" font-family="ui-monospace,'SF Mono','Cascadia Mono',Consolas,'DejaVu Sans Mono',monospace" font-size="14">
+<rect width="100%" height="100%" rx="6" fill="#0d1117"/>
+<text xml:space="preserve" x="0.00" y="13.60" fill="#e6edf3">┌ tokenix ─────────────────────────────────────────────────────────────────────────────────────────────────────────────┐</text>
+<text xml:space="preserve" x="0.00" y="31.60" fill="#e6edf3">│ Stats │ Filters │ Studio │ Gain │ Usage │ </text>
+<text xml:space="preserve" x="369.60" y="31.60" fill="#39c5cf" font-weight="bold">Doctor</text>
+<text xml:space="preserve" x="420.00" y="31.60" fill="#e6edf3"> │ Tokenmap │ Graph │ Discover │ Audit │ Secrets │ Egress            │</text>
+<text xml:space="preserve" x="0.00" y="49.60" fill="#e6edf3">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</text>
+<text xml:space="preserve" x="0.00" y="67.60" fill="#e6edf3">┌ doctor ──────────────────────────────────────────────────────────────────────────────────────────────────────────────┐</text>
+<text xml:space="preserve" x="0.00" y="85.60" fill="#e6edf3">│                                                                                                                      │</text>
+<text xml:space="preserve" x="0.00" y="103.60" fill="#e6edf3">│tokenix doctor                                                                                                        │</text>
+<text xml:space="preserve" x="0.00" y="121.60" fill="#e6edf3">│  environment &amp; acceleration diagnostics                                                                              │</text>
+<text xml:space="preserve" x="0.00" y="139.60" fill="#e6edf3">│                                                                                                                      │</text>
+<text xml:space="preserve" x="0.00" y="157.60" fill="#e6edf3">│Build                                                                                                                 │</text>
+<text xml:space="preserve" x="0.00" y="175.60" fill="#e6edf3">│  version:               0.62.1                                                                                       │</text>
+<text xml:space="preserve" x="0.00" y="193.60" fill="#e6edf3">│  gpu support compiled:  none — CPU-only build                                                                        │</text>
+<text xml:space="preserve" x="0.00" y="211.60" fill="#e6edf3">│                                                                                                                      │</text>
+<text xml:space="preserve" x="0.00" y="229.60" fill="#e6edf3">│GPU                                                                                                                   │</text>
+<text xml:space="preserve" x="0.00" y="247.60" fill="#e6edf3">│  nvidia gpu:            NVIDIA GeForce RTX 4060 Ti (driver 610.88)                                                   │</text>
+<text xml:space="preserve" x="0.00" y="265.60" fill="#e6edf3">│  cuda toolkit:          not found                                                                                    │</text>
+<text xml:space="preserve" x="0.00" y="283.60" fill="#e6edf3">│  cudnn:                 not found                                                                                    │</text>
+<text xml:space="preserve" x="0.00" y="301.60" fill="#e6edf3">│                                                                                                                      │</text>
+<text xml:space="preserve" x="0.00" y="319.60" fill="#e6edf3">│Embedding model                                                                                                       │</text>
+<text xml:space="preserve" x="0.00" y="337.60" fill="#e6edf3">│  active:                nomic-v1.5 (768d · English · quantized · default)                                            │</text>
+<text xml:space="preserve" x="0.00" y="355.60" fill="#e6edf3">│  this repo's index:     nomic-v1.5                                                                                   │</text>
+<text xml:space="preserve" x="0.00" y="373.60" fill="#e6edf3">│  int8 quantization:     1443/1443 embeddings                                                                         │</text>
+<text xml:space="preserve" x="0.00" y="391.60" fill="#e6edf3">│  available:             nomic-v1.5, bge-small, bge-base, minilm-l6, e5-small, jina-code                              │</text>
+<text xml:space="preserve" x="0.00" y="409.60" fill="#e6edf3">│  cache:                 ready (685 MB at C:\Users\jr_ac\AppData\Local\tokenix\models)                                │</text>
+<text xml:space="preserve" x="0.00" y="427.60" fill="#e6edf3">│                                                                                                                      │</text>
+<text xml:space="preserve" x="0.00" y="445.60" fill="#e6edf3">│Filters                                                                                                               │</text>
+<text xml:space="preserve" x="0.00" y="463.60" fill="#e6edf3">│  bundled:               528 filters · 1146 embedded golden cases                                                     │</text>
+<text xml:space="preserve" x="0.00" y="481.60" fill="#e6edf3">│  user/local filters:    231 loaded, no config issues                                                                 │</text>
+<text xml:space="preserve" x="0.00" y="499.60" fill="#e6edf3">│                                                                                                                      │</text>
+<text xml:space="preserve" x="0.00" y="517.60" fill="#e6edf3">│Recordings                                                                                                            │</text>
+<text xml:space="preserve" x="0.00" y="535.60" fill="#e6edf3">│  session:               none — start with `tokenix filter record start`                                              │</text>
+<text xml:space="preserve" x="0.00" y="553.60" fill="#e6edf3">│                                                                                                                      │</text>
+<text xml:space="preserve" x="0.00" y="571.60" fill="#e6edf3">│Daemon                                                                                                                │</text>
+<text xml:space="preserve" x="0.00" y="589.60" fill="#e6edf3">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</text>
+<text xml:space="preserve" x="0.00" y="607.60" fill="#e6edf3">←→: tab · ↑↓/PgUp/PgDn: scroll · r: refresh · q: quit                                                                   </text>
+</svg>

--- a/.github/prints/filters.svg
+++ b/.github/prints/filters.svg
@@ -1,0 +1,165 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1008 612" width="1008" height="612" font-family="ui-monospace,'SF Mono','Cascadia Mono',Consolas,'DejaVu Sans Mono',monospace" font-size="14">
+<rect width="100%" height="100%" rx="6" fill="#0d1117"/>
+<text xml:space="preserve" x="0.00" y="13.60" fill="#e6edf3">┌ tokenix ─────────────────────────────────────────────────────────────────────────────────────────────────────────────┐</text>
+<text xml:space="preserve" x="0.00" y="31.60" fill="#e6edf3">│ Stats │ </text>
+<text xml:space="preserve" x="84.00" y="31.60" fill="#39c5cf" font-weight="bold">Filters</text>
+<text xml:space="preserve" x="142.80" y="31.60" fill="#e6edf3"> │ Studio │ Gain │ Usage │ Doctor │ Tokenmap │ Graph │ Discover │ Audit │ Secrets │ Egress            │</text>
+<text xml:space="preserve" x="0.00" y="49.60" fill="#e6edf3">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</text>
+<text xml:space="preserve" x="0.00" y="67.60" fill="#39c5cf">┌ by tool  1/353 ────────┐</text>
+<text xml:space="preserve" x="218.40" y="67.60" fill="#e6edf3">┌ act  1/1 ────────────────────────────┐┌ sample input · act · 114 tokens ───────────────────┐</text>
+<text xml:space="preserve" x="0.00" y="85.60" fill="#39c5cf">│</text>
+<text xml:space="preserve" x="8.40" y="85.60" fill="#e6edf3">▸ act           1       </text>
+<text xml:space="preserve" x="210.00" y="85.60" fill="#39c5cf">│</text>
+<text xml:space="preserve" x="218.40" y="85.60" fill="#e6edf3">│▸ act                                 ││[CI/build] 🚀   Start image=node:20                  │</text>
+<text xml:space="preserve" x="0.00" y="103.60" fill="#39c5cf">│</text>
+<text xml:space="preserve" x="8.40" y="103.60" fill="#e6edf3">  actionlint    1       </text>
+<text xml:space="preserve" x="210.00" y="103.60" fill="#39c5cf">│</text>
+<text xml:space="preserve" x="218.40" y="103.60" fill="#e6edf3">│                                      ││[CI/build] ⭐  Run Set up job                        │</text>
+<text xml:space="preserve" x="0.00" y="121.60" fill="#39c5cf">│</text>
+<text xml:space="preserve" x="8.40" y="121.60" fill="#e6edf3">  airflow       1       </text>
+<text xml:space="preserve" x="210.00" y="121.60" fill="#39c5cf">│</text>
+<text xml:space="preserve" x="218.40" y="121.60" fill="#e6edf3">│                                      ││[CI/build]   ✅   Success - Set up job               │</text>
+<text xml:space="preserve" x="0.00" y="139.60" fill="#39c5cf">│</text>
+<text xml:space="preserve" x="8.40" y="139.60" fill="#e6edf3">  alembic       1       </text>
+<text xml:space="preserve" x="210.00" y="139.60" fill="#39c5cf">│</text>
+<text xml:space="preserve" x="218.40" y="139.60" fill="#e6edf3">│                                      ││[CI/build] ⭐  Run tests                             │</text>
+<text xml:space="preserve" x="0.00" y="157.60" fill="#39c5cf">│</text>
+<text xml:space="preserve" x="8.40" y="157.60" fill="#e6edf3">  alex          1       </text>
+<text xml:space="preserve" x="210.00" y="157.60" fill="#39c5cf">│</text>
+<text xml:space="preserve" x="218.40" y="157.60" fill="#e6edf3">│                                      ││[CI/build]   | &gt; app@1.0.0 test                     │</text>
+<text xml:space="preserve" x="0.00" y="175.60" fill="#39c5cf">│</text>
+<text xml:space="preserve" x="8.40" y="175.60" fill="#e6edf3">  ansible       4       </text>
+<text xml:space="preserve" x="210.00" y="175.60" fill="#39c5cf">│</text>
+<text xml:space="preserve" x="218.40" y="175.60" fill="#e6edf3">│                                      ││[CI/build]   | FAIL src/app.test.js                 │</text>
+<text xml:space="preserve" x="0.00" y="193.60" fill="#39c5cf">│</text>
+<text xml:space="preserve" x="8.40" y="193.60" fill="#e6edf3">  ant           2       </text>
+<text xml:space="preserve" x="210.00" y="193.60" fill="#39c5cf">│</text>
+<text xml:space="preserve" x="218.40" y="193.60" fill="#e6edf3">│                                      ││[CI/build]   | ● adds numbers                       │</text>
+<text xml:space="preserve" x="0.00" y="211.60" fill="#39c5cf">│</text>
+<text xml:space="preserve" x="8.40" y="211.60" fill="#e6edf3">  apk           1       </text>
+<text xml:space="preserve" x="210.00" y="211.60" fill="#39c5cf">│</text>
+<text xml:space="preserve" x="218.40" y="211.60" fill="#e6edf3">│                                      ││[CI/build]   |   Expected: 4                        │</text>
+<text xml:space="preserve" x="0.00" y="229.60" fill="#39c5cf">│</text>
+<text xml:space="preserve" x="8.40" y="229.60" fill="#e6edf3">  apt           1       </text>
+<text xml:space="preserve" x="210.00" y="229.60" fill="#39c5cf">│</text>
+<text xml:space="preserve" x="218.40" y="229.60" fill="#e6edf3">│                                      ││[CI/build]   |   Received: 3                        │</text>
+<text xml:space="preserve" x="0.00" y="247.60" fill="#39c5cf">│</text>
+<text xml:space="preserve" x="8.40" y="247.60" fill="#e6edf3">  argocd        1       </text>
+<text xml:space="preserve" x="210.00" y="247.60" fill="#39c5cf">│</text>
+<text xml:space="preserve" x="218.40" y="247.60" fill="#e6edf3">│                                      ││[CI/build]   |       at Object.&lt;anonymous&gt;          │</text>
+<text xml:space="preserve" x="0.00" y="265.60" fill="#39c5cf">│</text>
+<text xml:space="preserve" x="8.40" y="265.60" fill="#e6edf3">  artillery     1       </text>
+<text xml:space="preserve" x="210.00" y="265.60" fill="#39c5cf">│</text>
+<text xml:space="preserve" x="218.40" y="265.60" fill="#e6edf3">│                                      ││(src/app.test.js:5:19)                              │</text>
+<text xml:space="preserve" x="0.00" y="283.60" fill="#39c5cf">│</text>
+<text xml:space="preserve" x="8.40" y="283.60" fill="#e6edf3">  artisan       1       </text>
+<text xml:space="preserve" x="210.00" y="283.60" fill="#39c5cf">│</text>
+<text xml:space="preserve" x="218.40" y="283.60" fill="#e6edf3">│                                      ││[CI/build]   | Tests: 1 failed, 1 total             │</text>
+<text xml:space="preserve" x="0.00" y="301.60" fill="#39c5cf">│</text>
+<text xml:space="preserve" x="8.40" y="301.60" fill="#e6edf3">  astro         1       </text>
+<text xml:space="preserve" x="210.00" y="301.60" fill="#39c5cf">│</text>
+<text xml:space="preserve" x="218.40" y="301.60" fill="#e6edf3">│                                      ││[CI/build]   ❌   Failure - Run tests                │</text>
+<text xml:space="preserve" x="0.00" y="319.60" fill="#39c5cf">│</text>
+<text xml:space="preserve" x="8.40" y="319.60" fill="#e6edf3">  atlas         1       </text>
+<text xml:space="preserve" x="210.00" y="319.60" fill="#39c5cf">│</text>
+<text xml:space="preserve" x="218.40" y="319.60" fill="#e6edf3">│                                      │└────────────────────────────────────────────────────┘</text>
+<text xml:space="preserve" x="0.00" y="337.60" fill="#39c5cf">│</text>
+<text xml:space="preserve" x="8.40" y="337.60" fill="#e6edf3">  attw          1       </text>
+<text xml:space="preserve" x="210.00" y="337.60" fill="#39c5cf">│</text>
+<text xml:space="preserve" x="218.40" y="337.60" fill="#e6edf3">│                                      │</text>
+<text xml:space="preserve" x="554.40" y="337.60" fill="#d29922" font-weight="bold"> 114 </text>
+<text xml:space="preserve" x="596.40" y="337.60" fill="#e6edf3">→</text>
+<text xml:space="preserve" x="604.80" y="337.60" fill="#39c5cf" font-weight="bold"> 75 tokens </text>
+<text xml:space="preserve" x="697.20" y="337.60" fill="#3fb950" font-weight="bold">· 34.2% saved </text>
+<text xml:space="preserve" x="814.80" y="337.60" fill="#3fb950">█████░░░░░░░░░░░</text>
+<text xml:space="preserve" x="0.00" y="355.60" fill="#39c5cf">│</text>
+<text xml:space="preserve" x="8.40" y="355.60" fill="#e6edf3">  autoflake     1       </text>
+<text xml:space="preserve" x="210.00" y="355.60" fill="#39c5cf">│</text>
+<text xml:space="preserve" x="218.40" y="355.60" fill="#e6edf3">│                                      │</text>
+<text xml:space="preserve" x="554.40" y="355.60" fill="#39c5cf">┌ filtered output · 75 tokens ───────────────────────┐</text>
+<text xml:space="preserve" x="0.00" y="373.60" fill="#39c5cf">│</text>
+<text xml:space="preserve" x="8.40" y="373.60" fill="#e6edf3">  ava           1       </text>
+<text xml:space="preserve" x="210.00" y="373.60" fill="#39c5cf">│</text>
+<text xml:space="preserve" x="218.40" y="373.60" fill="#e6edf3">│                                      │</text>
+<text xml:space="preserve" x="554.40" y="373.60" fill="#39c5cf">│</text>
+<text xml:space="preserve" x="562.80" y="373.60" fill="#e6edf3">[CI/build]   | FAIL src/app.test.js                 </text>
+<text xml:space="preserve" x="999.60" y="373.60" fill="#39c5cf">│</text>
+<text xml:space="preserve" x="0.00" y="391.60" fill="#39c5cf">│</text>
+<text xml:space="preserve" x="8.40" y="391.60" fill="#e6edf3">  aws           3       </text>
+<text xml:space="preserve" x="210.00" y="391.60" fill="#39c5cf">│</text>
+<text xml:space="preserve" x="218.40" y="391.60" fill="#e6edf3">│                                      │</text>
+<text xml:space="preserve" x="554.40" y="391.60" fill="#39c5cf">│</text>
+<text xml:space="preserve" x="562.80" y="391.60" fill="#e6edf3">[CI/build]   | ● adds numbers                       </text>
+<text xml:space="preserve" x="999.60" y="391.60" fill="#39c5cf">│</text>
+<text xml:space="preserve" x="0.00" y="409.60" fill="#39c5cf">│</text>
+<text xml:space="preserve" x="8.40" y="409.60" fill="#e6edf3">  az            2       </text>
+<text xml:space="preserve" x="210.00" y="409.60" fill="#39c5cf">│</text>
+<text xml:space="preserve" x="218.40" y="409.60" fill="#e6edf3">│                                      │</text>
+<text xml:space="preserve" x="554.40" y="409.60" fill="#39c5cf">│</text>
+<text xml:space="preserve" x="562.80" y="409.60" fill="#e6edf3">[CI/build]   |   Expected: 4                        </text>
+<text xml:space="preserve" x="999.60" y="409.60" fill="#39c5cf">│</text>
+<text xml:space="preserve" x="0.00" y="427.60" fill="#39c5cf">│</text>
+<text xml:space="preserve" x="8.40" y="427.60" fill="#e6edf3">  bandit        1       </text>
+<text xml:space="preserve" x="210.00" y="427.60" fill="#39c5cf">│</text>
+<text xml:space="preserve" x="218.40" y="427.60" fill="#e6edf3">│                                      │</text>
+<text xml:space="preserve" x="554.40" y="427.60" fill="#39c5cf">│</text>
+<text xml:space="preserve" x="562.80" y="427.60" fill="#e6edf3">[CI/build]   |   Received: 3                        </text>
+<text xml:space="preserve" x="999.60" y="427.60" fill="#39c5cf">│</text>
+<text xml:space="preserve" x="0.00" y="445.60" fill="#39c5cf">│</text>
+<text xml:space="preserve" x="8.40" y="445.60" fill="#e6edf3">  basedpyright  2       </text>
+<text xml:space="preserve" x="210.00" y="445.60" fill="#39c5cf">│</text>
+<text xml:space="preserve" x="218.40" y="445.60" fill="#e6edf3">│                                      │</text>
+<text xml:space="preserve" x="554.40" y="445.60" fill="#39c5cf">│</text>
+<text xml:space="preserve" x="562.80" y="445.60" fill="#e6edf3">[CI/build]   |       at Object.&lt;anonymous&gt;          </text>
+<text xml:space="preserve" x="999.60" y="445.60" fill="#39c5cf">│</text>
+<text xml:space="preserve" x="0.00" y="463.60" fill="#39c5cf">│</text>
+<text xml:space="preserve" x="8.40" y="463.60" fill="#e6edf3">  bat           2       </text>
+<text xml:space="preserve" x="210.00" y="463.60" fill="#39c5cf">│</text>
+<text xml:space="preserve" x="218.40" y="463.60" fill="#e6edf3">│                                      │</text>
+<text xml:space="preserve" x="554.40" y="463.60" fill="#39c5cf">│</text>
+<text xml:space="preserve" x="562.80" y="463.60" fill="#e6edf3">(src/app.test.js:5:19)                              </text>
+<text xml:space="preserve" x="999.60" y="463.60" fill="#39c5cf">│</text>
+<text xml:space="preserve" x="0.00" y="481.60" fill="#39c5cf">│</text>
+<text xml:space="preserve" x="8.40" y="481.60" fill="#e6edf3">  bats          1       </text>
+<text xml:space="preserve" x="210.00" y="481.60" fill="#39c5cf">│</text>
+<text xml:space="preserve" x="218.40" y="481.60" fill="#e6edf3">│                                      │</text>
+<text xml:space="preserve" x="554.40" y="481.60" fill="#39c5cf">│</text>
+<text xml:space="preserve" x="562.80" y="481.60" fill="#e6edf3">[CI/build]   | Tests: 1 failed, 1 total             </text>
+<text xml:space="preserve" x="999.60" y="481.60" fill="#39c5cf">│</text>
+<text xml:space="preserve" x="0.00" y="499.60" fill="#39c5cf">│</text>
+<text xml:space="preserve" x="8.40" y="499.60" fill="#e6edf3">  bazel         1       </text>
+<text xml:space="preserve" x="210.00" y="499.60" fill="#39c5cf">│</text>
+<text xml:space="preserve" x="218.40" y="499.60" fill="#e6edf3">│                                      │</text>
+<text xml:space="preserve" x="554.40" y="499.60" fill="#39c5cf">│</text>
+<text xml:space="preserve" x="562.80" y="499.60" fill="#e6edf3">[CI/build]   ❌   Failure - Run tests                </text>
+<text xml:space="preserve" x="999.60" y="499.60" fill="#39c5cf">│</text>
+<text xml:space="preserve" x="0.00" y="517.60" fill="#39c5cf">│</text>
+<text xml:space="preserve" x="8.40" y="517.60" fill="#e6edf3">  behave        1       </text>
+<text xml:space="preserve" x="210.00" y="517.60" fill="#39c5cf">│</text>
+<text xml:space="preserve" x="218.40" y="517.60" fill="#e6edf3">│                                      │</text>
+<text xml:space="preserve" x="554.40" y="517.60" fill="#39c5cf">│</text>
+<text xml:space="preserve" x="562.80" y="517.60" fill="#e6edf3">[CI/build] exitcode '1': failure                    </text>
+<text xml:space="preserve" x="999.60" y="517.60" fill="#39c5cf">│</text>
+<text xml:space="preserve" x="0.00" y="535.60" fill="#39c5cf">│</text>
+<text xml:space="preserve" x="8.40" y="535.60" fill="#e6edf3">  biome         2       </text>
+<text xml:space="preserve" x="210.00" y="535.60" fill="#39c5cf">│</text>
+<text xml:space="preserve" x="218.40" y="535.60" fill="#e6edf3">│                                      │</text>
+<text xml:space="preserve" x="554.40" y="535.60" fill="#39c5cf">│</text>
+<text xml:space="preserve" x="999.60" y="535.60" fill="#39c5cf">│</text>
+<text xml:space="preserve" x="0.00" y="553.60" fill="#39c5cf">│</text>
+<text xml:space="preserve" x="8.40" y="553.60" fill="#e6edf3">  black         1       </text>
+<text xml:space="preserve" x="210.00" y="553.60" fill="#39c5cf">│</text>
+<text xml:space="preserve" x="218.40" y="553.60" fill="#e6edf3">│                                      │</text>
+<text xml:space="preserve" x="554.40" y="553.60" fill="#39c5cf">│</text>
+<text xml:space="preserve" x="999.60" y="553.60" fill="#39c5cf">│</text>
+<text xml:space="preserve" x="0.00" y="571.60" fill="#39c5cf">│</text>
+<text xml:space="preserve" x="8.40" y="571.60" fill="#e6edf3">  brew          1       </text>
+<text xml:space="preserve" x="210.00" y="571.60" fill="#39c5cf">│</text>
+<text xml:space="preserve" x="218.40" y="571.60" fill="#e6edf3">│                                      │</text>
+<text xml:space="preserve" x="554.40" y="571.60" fill="#39c5cf">│</text>
+<text xml:space="preserve" x="999.60" y="571.60" fill="#39c5cf">│</text>
+<text xml:space="preserve" x="0.00" y="589.60" fill="#39c5cf">└────────────────────────┘</text>
+<text xml:space="preserve" x="218.40" y="589.60" fill="#e6edf3">└──────────────────────────────────────┘</text>
+<text xml:space="preserve" x="554.40" y="589.60" fill="#39c5cf">└────────────────────────────────────────────────────┘</text>
+<text xml:space="preserve" x="0.00" y="607.60" fill="#e6edf3">←→: tab · Tab: pane · ↑↓: move · /: search · s: tool/source · q: quit                                                   </text>
+</svg>

--- a/.github/prints/graph.svg
+++ b/.github/prints/graph.svg
@@ -1,0 +1,39 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1008 612" width="1008" height="612" font-family="ui-monospace,'SF Mono','Cascadia Mono',Consolas,'DejaVu Sans Mono',monospace" font-size="14">
+<rect width="100%" height="100%" rx="6" fill="#0d1117"/>
+<text xml:space="preserve" x="0.00" y="13.60" fill="#e6edf3">┌ tokenix ─────────────────────────────────────────────────────────────────────────────────────────────────────────────┐</text>
+<text xml:space="preserve" x="0.00" y="31.60" fill="#e6edf3">│ Stats │ Filters │ Studio │ Gain │ Usage │ Doctor │ Tokenmap │ </text>
+<text xml:space="preserve" x="537.60" y="31.60" fill="#39c5cf" font-weight="bold">Graph</text>
+<text xml:space="preserve" x="579.60" y="31.60" fill="#e6edf3"> │ Discover │ Audit │ Secrets │ Egress            │</text>
+<text xml:space="preserve" x="0.00" y="49.60" fill="#e6edf3">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</text>
+<text xml:space="preserve" x="0.00" y="67.60" fill="#e6edf3">┌ graph ───────────────────────────────────────────────────────────────────────────────────────────────────────────────┐</text>
+<text xml:space="preserve" x="0.00" y="85.60" fill="#e6edf3">│# Repo graph — 1209 symbols, 3976 edges                                                                               │</text>
+<text xml:space="preserve" x="0.00" y="103.60" fill="#e6edf3">│                                                                                                                      │</text>
+<text xml:space="preserve" x="0.00" y="121.60" fill="#e6edf3">│## God nodes (most connected)                                                                                         │</text>
+<text xml:space="preserve" x="0.00" y="139.60" fill="#e6edf3">│- as_str (↑81 ↓1)  src/main.rs:121                                                                                    │</text>
+<text xml:space="preserve" x="0.00" y="157.60" fill="#e6edf3">│- Cmd (↑54 ↓2)  src/tui.rs:35                                                                                         │</text>
+<text xml:space="preserve" x="0.00" y="175.60" fill="#e6edf3">│- run (↑4 ↓52)  src/tui.rs:156                                                                                        │</text>
+<text xml:space="preserve" x="0.00" y="193.60" fill="#e6edf3">│- Cmd (↑55 ↓0)  src/tui.rs:26                                                                                         │</text>
+<text xml:space="preserve" x="0.00" y="211.60" fill="#e6edf3">│- Shell (↑2 ↓46)  src/tui.rs:204                                                                                      │</text>
+<text xml:space="preserve" x="0.00" y="229.60" fill="#e6edf3">│- start (↑38 ↓5)  src/recordings.rs:47                                                                                │</text>
+<text xml:space="preserve" x="0.00" y="247.60" fill="#e6edf3">│- main (↑2 ↓40)  src/main.rs:659                                                                                      │</text>
+<text xml:space="preserve" x="0.00" y="265.60" fill="#e6edf3">│- cmd_install_binary (↑2 ↓39)  src/main.rs:2336                                                                       │</text>
+<text xml:space="preserve" x="0.00" y="283.60" fill="#e6edf3">│- status (↑38 ↓2)  src/tui.rs:1880                                                                                    │</text>
+<text xml:space="preserve" x="0.00" y="301.60" fill="#e6edf3">│- format_num (↑39 ↓0)  src/benchmark.rs:1214                                                                          │</text>
+<text xml:space="preserve" x="0.00" y="319.60" fill="#e6edf3">│- format_num (↑39 ↓0)  src/cmd_filter.rs:54                                                                           │</text>
+<text xml:space="preserve" x="0.00" y="337.60" fill="#e6edf3">│- Status (↑38 ↓0)  src/mcp_audit.rs:98                                                                                │</text>
+<text xml:space="preserve" x="0.00" y="355.60" fill="#e6edf3">│- User (↑35 ↓3)  benchmark/samples/user_service.rs:18                                                                 │</text>
+<text xml:space="preserve" x="0.00" y="373.60" fill="#e6edf3">│- label (↑37 ↓0)  src/mcp_audit.rs:49                                                                                 │</text>
+<text xml:space="preserve" x="0.00" y="391.60" fill="#e6edf3">│- Tool (↑36 ↓0)  src/main.rs:69                                                                                       │</text>
+<text xml:space="preserve" x="0.00" y="409.60" fill="#e6edf3">│- User (↑34 ↓2)  benchmark/samples/database_client.ts:26                                                              │</text>
+<text xml:space="preserve" x="0.00" y="427.60" fill="#e6edf3">│- all (↑34 ↓2)  src/mcp_audit.rs:40                                                                                   │</text>
+<text xml:space="preserve" x="0.00" y="445.60" fill="#e6edf3">│- title (↑36 ↓0)  src/tui.rs:49                                                                                       │</text>
+<text xml:space="preserve" x="0.00" y="463.60" fill="#e6edf3">│- User (↑35 ↓0)  benchmark/samples/api_handler.go:207                                                                 │</text>
+<text xml:space="preserve" x="0.00" y="481.60" fill="#e6edf3">│- main (↑2 ↓30)  src/main.rs:659                                                                                      │</text>
+<text xml:space="preserve" x="0.00" y="499.60" fill="#e6edf3">│- Role (↑25 ↓6)  benchmark/samples/user_service.rs:39                                                                 │</text>
+<text xml:space="preserve" x="0.00" y="517.60" fill="#e6edf3">│- UserService (↑2 ↓29)  benchmark/samples/user_service.rs:136                                                         │</text>
+<text xml:space="preserve" x="0.00" y="535.60" fill="#e6edf3">│- count_tokens (↑30 ↓0)  src/chunker.rs:87                                                                            │</text>
+<text xml:space="preserve" x="0.00" y="553.60" fill="#e6edf3">│- Chunk (↑28 ↓0)  src/chunker.rs:71                                                                                   │</text>
+<text xml:space="preserve" x="0.00" y="571.60" fill="#e6edf3">│- Agent (↑27 ↓0)  src/mcp_audit.rs:32                                                                                 │</text>
+<text xml:space="preserve" x="0.00" y="589.60" fill="#e6edf3">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</text>
+<text xml:space="preserve" x="0.00" y="607.60" fill="#e6edf3">←→: tab · ↑↓: scroll · r: refresh · q: quit                                                                             </text>
+</svg>

--- a/.github/prints/stats.svg
+++ b/.github/prints/stats.svg
@@ -1,0 +1,69 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1008 612" width="1008" height="612" font-family="ui-monospace,'SF Mono','Cascadia Mono',Consolas,'DejaVu Sans Mono',monospace" font-size="14">
+<rect width="100%" height="100%" rx="6" fill="#0d1117"/>
+<text xml:space="preserve" x="0.00" y="13.60" fill="#e6edf3">┌ tokenix ─────────────────────────────────────────────────────────────────────────────────────────────────────────────┐</text>
+<text xml:space="preserve" x="0.00" y="31.60" fill="#e6edf3">│ </text>
+<text xml:space="preserve" x="16.80" y="31.60" fill="#39c5cf" font-weight="bold">Stats</text>
+<text xml:space="preserve" x="58.80" y="31.60" fill="#e6edf3"> │ Filters │ Studio │ Gain │ Usage │ Doctor │ Tokenmap │ Graph │ Discover │ Audit │ Secrets │ Egress            │</text>
+<text xml:space="preserve" x="0.00" y="49.60" fill="#e6edf3">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</text>
+<text xml:space="preserve" x="0.00" y="67.60" fill="#e6edf3">┌ stats ───────────────────────────────────────────────────────────────────────────────────────────────────────────────┐</text>
+<text xml:space="preserve" x="0.00" y="85.60" fill="#e6edf3">│</text>
+<text xml:space="preserve" x="8.40" y="85.60" fill="#39c5cf" font-weight="bold"> _        _              _      </text>
+<text xml:space="preserve" x="277.20" y="85.60" fill="#e6edf3">                                                                                      │</text>
+<text xml:space="preserve" x="0.00" y="103.60" fill="#e6edf3">│</text>
+<text xml:space="preserve" x="8.40" y="103.60" fill="#39c5cf" font-weight="bold">| |_ ___ | | _____ _ __ (_)_  __</text>
+<text xml:space="preserve" x="277.20" y="103.60" fill="#e6edf3">                                                                                      │</text>
+<text xml:space="preserve" x="0.00" y="121.60" fill="#e6edf3">│</text>
+<text xml:space="preserve" x="8.40" y="121.60" fill="#39c5cf" font-weight="bold">| __/ _ \| |/ / _ \ '_ \| \ \/ /</text>
+<text xml:space="preserve" x="277.20" y="121.60" fill="#e6edf3">                                                                                      │</text>
+<text xml:space="preserve" x="0.00" y="139.60" fill="#e6edf3">│</text>
+<text xml:space="preserve" x="8.40" y="139.60" fill="#39c5cf" font-weight="bold">| || (_) |   &lt;  __/ | | | |&gt;  &lt; </text>
+<text xml:space="preserve" x="277.20" y="139.60" fill="#e6edf3">                                                                                      │</text>
+<text xml:space="preserve" x="0.00" y="157.60" fill="#e6edf3">│</text>
+<text xml:space="preserve" x="8.40" y="157.60" fill="#39c5cf" font-weight="bold"> \__\___/|_|\_\___|_| |_|_/_/\_\</text>
+<text xml:space="preserve" x="277.20" y="157.60" fill="#e6edf3">                                                                                      │</text>
+<text xml:space="preserve" x="0.00" y="175.60" fill="#e6edf3">│</text>
+<text xml:space="preserve" x="8.40" y="175.60" fill="#d29922"> ($)  minimize LLM context, keep the signal</text>
+<text xml:space="preserve" x="369.60" y="175.60" fill="#e6edf3">                                                                           │</text>
+<text xml:space="preserve" x="0.00" y="193.60" fill="#e6edf3">│                                                                                                                      │</text>
+<text xml:space="preserve" x="0.00" y="211.60" fill="#e6edf3">│version   0.62.1                                                                                                      │</text>
+<text xml:space="preserve" x="0.00" y="229.60" fill="#e6edf3">│                                                                                                                      │</text>
+<text xml:space="preserve" x="0.00" y="247.60" fill="#e6edf3">│</text>
+<text xml:space="preserve" x="8.40" y="247.60" fill="#e6edf3" font-weight="bold">hooks</text>
+<text xml:space="preserve" x="50.40" y="247.60" fill="#e6edf3">                                                                                                                 │</text>
+<text xml:space="preserve" x="0.00" y="265.60" fill="#e6edf3">│</text>
+<text xml:space="preserve" x="8.40" y="265.60" fill="#3fb950">  ✓ </text>
+<text xml:space="preserve" x="42.00" y="265.60" fill="#e6edf3">Claude Code  global                                                                                               │</text>
+<text xml:space="preserve" x="0.00" y="283.60" fill="#e6edf3">│</text>
+<text xml:space="preserve" x="8.40" y="283.60" fill="#3fb950">  ✓ </text>
+<text xml:space="preserve" x="42.00" y="283.60" fill="#e6edf3">Copilot      global + local                                                                                       │</text>
+<text xml:space="preserve" x="0.00" y="301.60" fill="#e6edf3">│</text>
+<text xml:space="preserve" x="8.40" y="301.60" fill="#3fb950">  ✓ </text>
+<text xml:space="preserve" x="42.00" y="301.60" fill="#e6edf3">Codex        global                                                                                               │</text>
+<text xml:space="preserve" x="0.00" y="319.60" fill="#e6edf3">│</text>
+<text xml:space="preserve" x="8.40" y="319.60" fill="#e5534b">  ✗ </text>
+<text xml:space="preserve" x="42.00" y="319.60" fill="#e6edf3">OpenCode     not installed                                                                                        │</text>
+<text xml:space="preserve" x="0.00" y="337.60" fill="#e6edf3">│</text>
+<text xml:space="preserve" x="8.40" y="337.60" fill="#3fb950">  ✓ </text>
+<text xml:space="preserve" x="42.00" y="337.60" fill="#e6edf3">Antigravity  global                                                                                               │</text>
+<text xml:space="preserve" x="0.00" y="355.60" fill="#e6edf3">│                                                                                                                      │</text>
+<text xml:space="preserve" x="0.00" y="373.60" fill="#e6edf3">│</text>
+<text xml:space="preserve" x="8.40" y="373.60" fill="#e6edf3" font-weight="bold">index (this repo)</text>
+<text xml:space="preserve" x="151.20" y="373.60" fill="#e6edf3">                                                                                                     │</text>
+<text xml:space="preserve" x="0.00" y="391.60" fill="#e6edf3">│  files     115                                                                                                       │</text>
+<text xml:space="preserve" x="0.00" y="409.60" fill="#e6edf3">│  chunks    1443                                                                                                      │</text>
+<text xml:space="preserve" x="0.00" y="427.60" fill="#e6edf3">│  tokens    275,971                                                                                                   │</text>
+<text xml:space="preserve" x="0.00" y="445.60" fill="#e6edf3">│                                                                                                                      │</text>
+<text xml:space="preserve" x="0.00" y="463.60" fill="#e6edf3">│</text>
+<text xml:space="preserve" x="8.40" y="463.60" fill="#e6edf3" font-weight="bold">actions</text>
+<text xml:space="preserve" x="67.20" y="463.60" fill="#e6edf3">                                                                                                               │</text>
+<text xml:space="preserve" x="0.00" y="481.60" fill="#e6edf3">│</text>
+<text xml:space="preserve" x="8.40" y="481.60" fill="#39c5cf" font-weight="bold">▸ Index repository    </text>
+<text xml:space="preserve" x="193.20" y="481.60" fill="#e6edf3">reindex this repo (115 files)                                                                   │</text>
+<text xml:space="preserve" x="0.00" y="499.60" fill="#e6edf3">│  Install hooks (all) wire 1 missing agent(s) · writes config files                                                   │</text>
+<text xml:space="preserve" x="0.00" y="517.60" fill="#e6edf3">│  Install binary (PATH)already global · C:\Users\jr_ac\AppData\Local\tokenix\bin                                      │</text>
+<text xml:space="preserve" x="0.00" y="535.60" fill="#e6edf3">│  Generate ignore filescopy .gitignore to 14 agent ignore files                                                       │</text>
+<text xml:space="preserve" x="0.00" y="553.60" fill="#e6edf3">│                                                                                                                      │</text>
+<text xml:space="preserve" x="0.00" y="571.60" fill="#e6edf3">│                                                                                                                      │</text>
+<text xml:space="preserve" x="0.00" y="589.60" fill="#e6edf3">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</text>
+<text xml:space="preserve" x="0.00" y="607.60" fill="#e6edf3">←→: tab · ↑↓: action · PgUp/PgDn: scroll · Enter: run · q: quit                                                         </text>
+</svg>

--- a/.github/prints/tokenmap.svg
+++ b/.github/prints/tokenmap.svg
@@ -1,0 +1,39 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1008 612" width="1008" height="612" font-family="ui-monospace,'SF Mono','Cascadia Mono',Consolas,'DejaVu Sans Mono',monospace" font-size="14">
+<rect width="100%" height="100%" rx="6" fill="#0d1117"/>
+<text xml:space="preserve" x="0.00" y="13.60" fill="#e6edf3">┌ tokenix ─────────────────────────────────────────────────────────────────────────────────────────────────────────────┐</text>
+<text xml:space="preserve" x="0.00" y="31.60" fill="#e6edf3">│ Stats │ Filters │ Studio │ Gain │ Usage │ Doctor │ </text>
+<text xml:space="preserve" x="445.20" y="31.60" fill="#39c5cf" font-weight="bold">Tokenmap</text>
+<text xml:space="preserve" x="512.40" y="31.60" fill="#e6edf3"> │ Graph │ Discover │ Audit │ Secrets │ Egress            │</text>
+<text xml:space="preserve" x="0.00" y="49.60" fill="#e6edf3">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</text>
+<text xml:space="preserve" x="0.00" y="67.60" fill="#e6edf3">┌ tokenmap ────────────────────────────────────────────────────────────────────────────────────────────────────────────┐</text>
+<text xml:space="preserve" x="0.00" y="85.60" fill="#e6edf3">│                                                                                                                      │</text>
+<text xml:space="preserve" x="0.00" y="103.60" fill="#e6edf3">│tokenix (275,971 tokens)                                                                                              │</text>
+<text xml:space="preserve" x="0.00" y="121.60" fill="#e6edf3">│├──  [██████░░] src (200,064 tokens, 72.5%)                                                                           │</text>
+<text xml:space="preserve" x="0.00" y="139.60" fill="#e6edf3">││   ├──  [█░░░░░░░] main.rs (31,929 tokens, 11.6%)                                                                    │</text>
+<text xml:space="preserve" x="0.00" y="157.60" fill="#e6edf3">││   ├──  [█░░░░░░░] tui.rs (29,608 tokens, 10.7%)                                                                     │</text>
+<text xml:space="preserve" x="0.00" y="175.60" fill="#e6edf3">││   ├──  [█░░░░░░░] store.rs (18,162 tokens, 6.6%)                                                                    │</text>
+<text xml:space="preserve" x="0.00" y="193.60" fill="#e6edf3">││   ├──  [░░░░░░░░] filters.rs (16,737 tokens, 6.1%)                                                                  │</text>
+<text xml:space="preserve" x="0.00" y="211.60" fill="#e6edf3">││   ├──  [░░░░░░░░] graph.rs (13,304 tokens, 4.8%)                                                                    │</text>
+<text xml:space="preserve" x="0.00" y="229.60" fill="#e6edf3">││   ├──  [░░░░░░░░] chunker.rs (10,056 tokens, 3.6%)                                                                  │</text>
+<text xml:space="preserve" x="0.00" y="247.60" fill="#e6edf3">││   ├──  [░░░░░░░░] query.rs (9,492 tokens, 3.4%)                                                                     │</text>
+<text xml:space="preserve" x="0.00" y="265.60" fill="#e6edf3">││   ├──  [░░░░░░░░] benchmark.rs (9,347 tokens, 3.4%)                                                                 │</text>
+<text xml:space="preserve" x="0.00" y="283.60" fill="#e6edf3">││   ├──  [░░░░░░░░] mcp.rs (9,263 tokens, 3.4%)                                                                       │</text>
+<text xml:space="preserve" x="0.00" y="301.60" fill="#e6edf3">││   ├──  [░░░░░░░░] compress.rs (7,929 tokens, 2.9%)                                                                  │</text>
+<text xml:space="preserve" x="0.00" y="319.60" fill="#e6edf3">││   ├──  [░░░░░░░░] daemon.rs (7,623 tokens, 2.8%)                                                                    │</text>
+<text xml:space="preserve" x="0.00" y="337.60" fill="#e6edf3">││   ├──  [░░░░░░░░] hook.rs (7,062 tokens, 2.6%)                                                                      │</text>
+<text xml:space="preserve" x="0.00" y="355.60" fill="#e6edf3">││   ├──  [░░░░░░░░] cmd_filter.rs (6,545 tokens, 2.4%)                                                                │</text>
+<text xml:space="preserve" x="0.00" y="373.60" fill="#e6edf3">││   ├──  [░░░░░░░░] mcp_audit.rs (6,245 tokens, 2.3%)                                                                 │</text>
+<text xml:space="preserve" x="0.00" y="391.60" fill="#e6edf3">││   ├──  [░░░░░░░░] indexer.rs (5,898 tokens, 2.1%)                                                                   │</text>
+<text xml:space="preserve" x="0.00" y="409.60" fill="#e6edf3">││   ├──  [░░░░░░░░] memory.rs (3,384 tokens, 1.2%)                                                                    │</text>
+<text xml:space="preserve" x="0.00" y="427.60" fill="#e6edf3">││   ├──  [░░░░░░░░] doctor.rs (2,150 tokens, 0.8%)                                                                    │</text>
+<text xml:space="preserve" x="0.00" y="445.60" fill="#e6edf3">││   ├──  [░░░░░░░░] embed.rs (2,019 tokens, 0.7%)                                                                     │</text>
+<text xml:space="preserve" x="0.00" y="463.60" fill="#e6edf3">││   ├──  [░░░░░░░░] recordings.rs (1,980 tokens, 0.7%)                                                                │</text>
+<text xml:space="preserve" x="0.00" y="481.60" fill="#e6edf3">││   └──  [░░░░░░░░] gain.rs (1,331 tokens, 0.5%)                                                                      │</text>
+<text xml:space="preserve" x="0.00" y="499.60" fill="#e6edf3">│├──  [█░░░░░░░] assets (23,518 tokens, 8.5%)                                                                          │</text>
+<text xml:space="preserve" x="0.00" y="517.60" fill="#e6edf3">││   └──  [█░░░░░░░] filters (23,518 tokens, 8.5%)                                                                     │</text>
+<text xml:space="preserve" x="0.00" y="535.60" fill="#e6edf3">││       ├──  [░░░░░░░░] xcodebuild.toml (934 tokens, 0.3%)                                                            │</text>
+<text xml:space="preserve" x="0.00" y="553.60" fill="#e6edf3">││       ├──  [░░░░░░░░] fnm.toml (863 tokens, 0.3%)                                                                   │</text>
+<text xml:space="preserve" x="0.00" y="571.60" fill="#e6edf3">││       ├──  [░░░░░░░░] liquibase.toml (762 tokens, 0.3%)                                                             │</text>
+<text xml:space="preserve" x="0.00" y="589.60" fill="#e6edf3">└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘</text>
+<text xml:space="preserve" x="0.00" y="607.60" fill="#e6edf3">←→: tab · ↑↓/PgUp/PgDn: scroll · r: refresh · q: quit                                                                   </text>
+</svg>

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,118 +1,106 @@
 # AGENTS.md — tokenix
 
-## Project
+Rust CLI that gives AI coding agents compact repository context: local ONNX
+embeddings + SQLite index, tree-sitter symbol graph, deterministic output filters,
+and `PreToolUse` hooks for Claude Code / Copilot / Codex / OpenCode / Antigravity.
+User-facing docs live in `README.md`; this file is the engineering contract.
 
-**tokenix** — Rust CLI for token-efficient codebase exploration. Builds a local SQLite index with in-process embeddings (fastembed/ONNX), then exposes semantic search, compact file reads, and AI-tool hook integration.
-
-Stack: Rust · SQLite · fastembed (ONNX, in-process) · Claude Code `PreToolUse` hook · background daemon (TCP)
-
-Reduces token usage 60–90% by intercepting large reads and replacing them with focused context.
-
-## Build & Install
+## Build & test
 
 ```bash
-cargo build
 cargo build --release
-cargo install --path .   # installs to ~/.cargo/bin
-tokenix --help
+cargo test --bin tokenix          # 379 unit + golden tests
+cargo fmt --check                 # CI runs fmt FIRST — run it before pushing
+cargo clippy --bin tokenix --all-features
 ```
 
-## Key Files
+## Key files
 
-| File | Purpose |
+| File | Role |
 |---|---|
-| `src/main.rs` | CLI entry (clap), command dispatch, `install-hook`/`remove-hook` helpers (including Antigravity global install/uninstall through `agy plugin`, repo-local OpenCode native `opencode.json` MCP registration/removal, and local `.agents/plugins/tokenix`), `install-binary` (copies the running exe to `global_bin_dir()` — `%LOCALAPPDATA%\tokenix\bin` / `~/.local/bin` — and persists the Windows user PATH via PowerShell `[Environment]::SetEnvironmentVariable`, never `setx`). `banner()` = neon "tokenix" wordmark + tagline; `help_catalog()` = audience-grouped command list (AI agent vs human) + examples, wired via custom `HELP_TEMPLATE` (`before_help`/`after_help`); bare `tokenix` prints this help |
-| `src/chunker.rs` | Symbol-aware heuristic chunking, `generate_outline()`, token counting. Tree-sitter for Rust/Python/TS/JS/Go/C++; `chunk_by_symbol_lines()` line-scanning chunkers for grammar-less languages — VB6/VBA (`Sub`/`Function`/`Property`/`Attribute VB_Name`) and SQL (`CREATE [OR REPLACE] <object>`) |
-| `src/embed.rs` | fastembed ONNX — `embed_documents()`, `embed_query()`. Model **registry** (`MODELS`, `spec_for`) + thread-local active model (`set_active_model`/`active_model_id`) + per-id loaded-model cache. Per-model query/doc prefixes; query cache keyed by model |
-| `src/store.rs` | SQLite schema, CRUD, cosine similarity search (int8-quantized vectors + legacy f32 fallback, `quantize_q8`/`backfill_quantized_embeddings`), import graph (`graph_imports`, `file_imports`), hook log I/O + 5 MB rotation, PID index lock, branch-aware DB paths |
-| `src/indexer.rs` | File walk + incremental index pipeline. Runs at below-normal OS priority (`lower_process_priority()`, opt-out `--no-low-priority`/`TOKENIX_FOREGROUND`). `decode_text()` handles UTF-16 BOMs (SSMS-saved `.sql`) and skips binary files (NUL in first 8 KiB). Embeds in batches (default 16) with a progress bar; each batch commits to the embedding cache so a killed run resumes via cache hits |
-| `src/query.rs` | Hybrid semantic/lexical ranking (FTS5 + BM25 + RRF), strict `context` modes, budget enforcement, cross-project search |
-| `src/pack.rs` | `tokenix pack` — budgeted repo map + focused context, changed-file packs, token maps, and safety report. `order_by_priority` decides what survives the budget: reason first (`changed` > `semantic` > filler), then per-file PageRank centrality (`store::get_file_graph_ranks`), then path. Iterating the `BTreeSet` directly used to cut files **alphabetically**, so a changed file could lose its slot to filler that merely sorted earlier; filler selection is likewise rank-first instead of largest-file-first |
-| `src/graph.rs` | Symbol graph with PageRank, cycle detection (Tarjan's SCC, homonym-filtered, `path:line`-annotated), tree-sitter references, incremental repair (`update_symbol_graph_incremental` — FTS-narrowed inbound-edge restore; `rebuild-graph` = full escape hatch), file-level import graph (`rebuild_import_graph`, per-language import extraction + path resolution), HTML + Mermaid export. Repo-wide overview (`tokenix graph`): `repo_hotspots` (degree + transitive-dependent blast radius, trivial-symbol filtered), `format_repo_report` (god nodes / bottlenecks / blast-radius leaders), `format_edges_dot` (Graphviz of the top subgraph) |
-| `src/artifacts.rs` | Context artifacts — index non-code files (schemas, API specs, docs) via `.tokenix/artifacts.json` |
-| `src/hook.rs` | `run_hook()` — called by PreToolUse hook. Tries daemon first for Grep. Thresholds (Read 200 lines / Grep 3 words) overridable via `[hook]` in `.tokenix.toml` (`read_min_lines`, `grep_min_words`). Read intercept `is_code` set is kept in sync with `chunker::detect_lang` (Rust/Py/TS/JS/Go/**C·C++·VB·SQL**); a large file in a supported-but-unlisted language used to pass through full. `try_grep_cap`/`grep_cap_input` + `input_rewrite_output` bound a lexical `output_mode="content"` Grep that carries no `head_limit` (`TOKENIX_GREP_HEAD_LIMIT`, default 100) — called both on the non-intercept path and inside the stale-index gate, since capping needs no index |
-| `src/daemon.rs` | Background TCP server (port 47392). Holds model + int8-quantized embedding cache (LRU, max 3 projects, content cap 1000). Bounded to 4 handler threads. Protocol: `search`/`health`/`status`; CLI `tokenix daemon status\|stop\|restart` |
-| `src/compress.rs` | Legacy `PostToolUse` compatibility compression + `tokenix run` command-output compression: ANSI strip, emoji removal, blank-line collapse, repeat grouping (identical lines **and** repeated 2–12 line blocks via `group_repeated_blocks`), a hard `enforce_token_budget` ceiling applied to every return path including the `compact_json` early return and the TOML-filter result (`TOKENIX_MAX_OUTPUT_TOKENS`, default 8000, `0` disables), JSON compaction, base64/data-URI blob redaction (`redact_base64_blobs` = `strip_base64_blobs` for single-line/data-URI runs ≥512 chars + `strip_wrapped_base64` for line-wrapped blocks — ≥5 pure-base64 lines ≥60 wide, e.g. PEM certs/keys/MIME; PEM `-----BEGIN/END-----` markers survive; `[<kind> omitted: N chars]` typed by decoded magic — `png image base64`/`jpeg image base64`/`pdf base64`/…, keeps any `data:<mime>;base64,` prefix; a run only redacts if `looks_like_base64` — mixed-case or a `+/=-_` symbol — so single-case pure-hex/all-digit runs like `.sha256` manifests or numeric columns are NOT eaten), cargo/git-log heuristics. `tokenix run` only applies command-specific filters to stderr when `filter_stderr=true`; otherwise stderr uses safe generic compression so errors are not turned into success sentinels. `run_hook_post` also processes **non-shell** tool results (e.g. MCP image-generation output) for base64-only redaction in dialects that can replace the result (Copilot); Claude/Codex post stays a no-op |
-| `src/filters.rs` | `FilterDef` (TOML schema), active filter listing, `load_user_filters()`, `load_bundled_filters()` (rust-embed), `apply_filter()`. `find_filter()` matches via `derive_command_candidates()`, which unwraps shell runners, strips `cd`/env prefixes, and `split_on_operators()` splits compound commands quote-aware on `&&`/`\|\|`/`;`/`\|` so anchored `match_command` patterns match a base command in any segment/position. **Hot path (hook / `tokenix run`) uses `load_filters_for_command()`, not `load_all_filters()`** — see "Filter resolution cost" below |
-| `src/cmd_filter.rs` | `tokenix filter list/active/generate` + `filter record start/stop/status` subcommands. `generate` prefers `recordings::read_samples` over a re-run, invokes a detected AI CLI, and saves to `~/.tokenix/filters/`; reused by the TUI Studio tab as a foreground drop-out |
-| `src/tui.rs` | Interactive ratatui shell — the **only** human interface. Entered by a bare `tokenix` or by any human report command on a TTY (see "One interface" below); `run_entry(Entry)` seeds the opening tab and its scope, `should_open()` is the single TTY/`--no-tui` gate, and `new_shell()` builds the state (split out so the shell is unit-testable). `switch_tab` calls `disarm()` so an armed destructive confirmation (redact / delete filter / install) can never survive a tab change; Studio generate/delete call `reload_filters()` so the Filters tab never lists a filter that no longer exists. Tab bar (`←`/`→`): **Stats** dashboard (wordmark + version + hook status + index summary, with selectable Index / Install hooks / Install binary actions — Index runs in the foreground with live progress, the two install actions confirm before writing; Install binary self-execs `tokenix install-binary`), **Filters** (3-pane groups · filters · live `apply_filter` input→output preview with a `chunker::count_tokens` gauge line showing `X → Y tokens · % saved` between the panes), **Studio** (surfaces the record→preview→generate filter loop: `r`/`s` arm/stop a `recordings::start`/`stop` session, left column is a unified candidate list from `cmd_filter::suggest_filters` — recordings unioned with the tokens-wasted ranking, badged `⚠` unfiltered sink (biggest waste first) / `✓` already filtered / `●` recorded-only — plus saved `~/.tokenix/filters/*.toml`, right pane previews a `recordings::read_samples` head with a live `apply_filter` before→after `chunker::count_tokens` delta when an active filter matches the base command; `g` sets `request_generate` to run `cmd_filter::cmd_filter_generate` as a foreground drop-out — same pattern as Index — then resumes the TUI; `x` deletes a saved filter with confirm; `Tab` switches pane), **Gain** (native colored render of `gain::compute_gain`: tokens-saved headline with ≈USD at the ★ reference model's input rate, savings-by-source split — semantic index vs command filters — and numbered by command / by project tables with share %, toggles `c`/`a`), **Usage** (self-exec captured `tokenix usage` via dynamic argv: `s` cycles daily/model/blocks/project/session, `a` toggles all-projects, `r` refresh), **Doctor**/**Tokenmap** (self-exec captured output), **Graph** (self-exec captured `tokenix graph` repo overview — god nodes / bottlenecks / blast radius; `r` refresh), **Secrets** (background-threaded `secrets_scan::scan_findings` with spinner; dedup by distinct value + count; `v` reveal, `c` copy raw value to system clipboard via `clip`/`pbcopy`/`wl-copy`/`xclip`/`xsel`, `x` write `[REDACTED]`), **Egress** (background-threaded `egress_scan::scan_findings` with the same 3-pane pattern as Secrets: groups · destinations · occurrence detail; `s` cycles host/rule/agent/file grouping; `r` rescans; host reputation colors: green safe, red dangerous, yellow unknown). Both Secrets and Egress open scoped to the current repo (cwd) and `g` toggles a global all-repos view; scoping filters the raw scan by each finding's attributed `repo` (`is_local` matches exact `cwd` paths plus Claude `~slug:`/Gemini `~dir:` fallback markers against the project root). **Loading is standardized:** every data-loading tab (Gain, Usage, Doctor, Tokenmap, Graph, Secrets, Egress) loads on a background thread behind one shared panel (`draw_loading` + `spinner_frame`, single `SPINNER_FRAMES`) so the shell never blocks and the braille spinner animates; the event loop polls at 120ms whenever any `*_rx` is in flight. Only Index still runs as a foreground drop-out (it needs the child's own live progress bar) |
-| `src/ui.rs` | Shared terminal-UI vocabulary for human-facing CLI output (`box_header`, `bar`, `section`/`kv`, `format_num`, `table` via `tabled`); LLM/JSON output deliberately does not route through it |
-| `src/gain.rs` | `compute_gain()`/`compute_global_gain()`, `GainStats` (incl. `index_saved`/`filter_saved` source split: empty `command` = semantic-index intercept, non-empty = command filter; pre-phase Bash/PowerShell rewrite markers are excluded from `filter_calls`), `MODELS` pricing table (Anthropic/OpenAI/Google, with `input`/`output`/`cache_read`/`cache_write` per-1M rates; `price_for` name/prefix match + `usage_cost` per-record helper reused by `tokenix usage`). Grep semantic intercepts are logged as neutral usage, not claimed savings, because native grep output is not measured before interception |
-| `src/transcripts.rs` | Shared enumeration of local agent transcript files (`roots` per agent: Claude/Codex/Copilot/OpenAI, `transcript_files` walker). Single source of truth reused by `conversation-audit` and `usage` |
-| `src/usage.rs` | `tokenix usage` — absolute token spend + ≈USD cost parsed from transcript `message.usage` blocks (input/output/cache read+write), deduped by `(message.id, requestId)`. Aggregates by `daily\|weekly\|monthly\|session\|model\|project`; rolling 5-hour `blocks` with burn rate + projection; month-end forecast; `--cost-mode auto\|calculate\|display`; `--statusline`; `--all-projects` scope; `--json` |
-| `src/mcp.rs` | MCP server. `--profile full` exposes all tools; `--profile slim` exposes context/search/call meta-tools for progressive discovery |
-| `src/mcp_proxy.rs` | `tokenix mcp-proxy` — stdio JSON-RPC passthrough that compresses `tools/call` text results (the only reachable path for MCP output); see the section below for the contract |
-| `src/mcp_audit.rs` | `tokenix prompt-audit` / `session-audit` — per-agent MCP config discovery (Claude, Codex, Copilot, OpenCode, Antigravity) + minimal synchronous MCP stdio client (`initialize`/`tools/list`) + token scoring/report + `context_weight()` (instruction files always-on, skills listing always-on / body on-invoke) |
-| `src/secrets_scan.rs` | `tokenix scan-secrets` — gitleaks-style credential scan of Claude/Gemini/Copilot/Antigravity conversation transcripts under `~`; rules loaded from TOML (`assets/secret-rules/` bundled via `rust-embed`, extended by `<repo>/` then `~/.tokenix/secret-rules/*.toml`, later `id` wins), backtracking-free regex + entropy-gated generic rule. Each finding is attributed to its repo + git branch via the transcript line's `cwd`/`gitBranch` (Claude), falling back to the project dir slug. Report supports `--filter` (substring), `--group <value\|rule\|agent\|file\|repo>`, `--reveal` (raw values, default redacted), `--json`; exit 1 on hits. `scan_findings()` returns structured `ScanFinding`s (raw + redacted) for the TUI; `redact_in_files()` rewrites `[REDACTED]` over a value in text files (SQLite DBs skipped) |
-| `src/egress_scan.rs` | `tokenix egress-audit` — scans Claude/Gemini/Copilot/Antigravity conversation transcripts for external DNS/IP destinations; bundled TOML rules live under `assets/egress-rules/`, local safe hosts are loaded from `~/.tokenix/safe-hosts.toml`, and local blocklist hosts from `~/.tokenix/dangerous-hosts.toml` (`dangerous`, `blocklist`, or `hosts` arrays); report supports `--filter`, `--group <host\|rule\|agent\|file>`, `--safe`, and `--json`. `scan_findings()` returns structured `EgressFinding`s for the TUI |
-| `src/discover.rs` | `tokenix discover` — scans agent transcripts (Claude `tool_use`/`tool_result`, Codex/OpenAI `function_call`/`function_call_output`, argv-array commands) and REPLAYS the current filter set over historical command outputs: measured recoverable savings (filter exists, hook wasn't active) + uncovered commands ranked by waste. Memoizes command→filter matches |
-| `assets/filters/` | 528 TOML output filters embedded via `rust-embed`, each homologated with ≥2 golden `[[tests]]` cases (realistic success + failure-path inputs; the failure case must prove errors are never masked). 1146 cases run through the real `apply_filter` pipeline in `bundled_filters_pass_embedded_golden_tests`; `verbose_real_output_compresses_at_least_70pct` proves ≥70% reduction on realistic verbose output and `match_command_resolves_many_invocation_variants` homologates wrapper/shell/global-opt command variants. User filters in `~/.tokenix/filters/` take priority |
+| `chunker.rs` | Symbol-aware chunking, `count_tokens`, outline generation, `enforce_token_cap` |
+| `indexer.rs` | Walks + indexes files. `filter_entry` (dirs) vs `should_index` (files) are separate on purpose |
+| `embed.rs` | ONNX via fastembed; `MODELS` registry, custom HF models, int8 quantization |
+| `store.rs` | SQLite access, `index_staleness`, graph tables, hook log |
+| `query.rs` | Semantic + lexical retrieval, RRF fusion, budgeting |
+| `graph.rs` | Symbol graph, PageRank, Tarjan SCC cycles, import graph, repo hotspots |
+| `hook.rs` | `PreToolUse` handler — the interception decision tree |
+| `compress.rs` | Generic output compression, base64 redaction, token ceiling, EOL preservation |
+| `filters.rs` | `FilterDef` schema, filter resolution, `apply_filter_with_exit` |
+| `cmd_filter.rs` | `filter list/active/generate/verify` + recording |
+| `pack.rs` | `tokenix pack` — budgeted repo map, `order_by_priority` (reason → PageRank → path) |
+| `recall.rs` | Stash/retrieve of clipped output, re-read suppression |
+| `gain.rs` | Savings analytics, `MODELS` pricing table |
+| `usage.rs` | Spend + cost from agent transcripts (`message.usage`, incl. cache fields) |
+| `mcp.rs` / `mcp_proxy.rs` | MCP server (`--profile slim\|full`) / stdio passthrough that compresses results |
+| `mcp_audit.rs` | `prompt-audit` / `session-audit`, `context_weight()` |
+| `secrets_scan.rs` / `egress_scan.rs` | Transcript forensics — credentials and outbound destinations |
+| `discover.rs` | Replays current filters over historical agent output |
+| `transcripts.rs` | Per-agent history roots and parsers |
+| `tui.rs` | Ratatui shell — the only human interface |
+| `daemon.rs` | Background embedding server, port 47392 |
 
-## SQLite Schema
+## SQLite schema
 
 ```sql
-files(id, path TEXT UNIQUE, mtime REAL, content_hash TEXT)
+files(id, path UNIQUE, mtime, content_hash)
 chunks(id, file_id, path, start_line, end_line, symbol, kind, content, token_count)
-chunks_fts(rowid, content, symbol, path)   -- FTS5 virtual table for keyword search
+chunks_fts(rowid, content, symbol, path)     -- FTS5
 embeddings(chunk_id PK, embedding BLOB, scale REAL)
-  -- scale NOT NULL → int8-quantized vector (1 byte/dim); scale NULL → legacy
-  -- float32 LE blob. Search branches per row; the scale cancels out of the
-  -- cosine, so q8 search needs only the raw bytes. Legacy rows are migrated
-  -- (re-encode only) by backfill_quantized_embeddings() at index time + VACUUM.
+  -- scale NOT NULL → int8-quantized (1 byte/dim); NULL → legacy float32 LE.
+  -- Scale cancels out of the cosine, so q8 search needs only raw bytes.
 embedding_cache(content_hash PK, embedding BLOB, updated_at)  -- stays float32 so
   -- model switches and quantization changes never force a re-embed
 graph_nodes(chunk_id PK, file_id, path, name, kind, start_line, end_line, rank)
 graph_edges(id, caller_chunk_id, callee_chunk_id, reference, edge_kind)
-graph_imports(id, source_path, target, resolved_path, kind, line)
-  -- file-level import edges; resolved_path NULL = external dependency
-meta(key PK, value)                        -- 'indexed_at', git fingerprint
+graph_imports(id, source_path, target, resolved_path, kind, line)  -- NULL = external
+meta(key PK, value)                          -- 'indexed_at', git fingerprint
 ```
 
-`meta` stores `indexed_at` and a Git fingerprint (worktree root + branch + HEAD). Hooks and `--if-stale` treat a different fingerprint as stale so branch switches don't reuse stale context.
+`meta` holds `indexed_at` plus a Git fingerprint (worktree root + branch + HEAD);
+a different fingerprint counts as stale so branch switches never reuse context.
 
-Query paths open old DBs without running migrations — SELECTs must degrade when the `scale` column is missing (`embeddings_have_scale()` probe selects `NULL` instead).
+**Query paths open old DBs without migrating** — SELECTs must degrade when `scale`
+is missing (`embeddings_have_scale()` probes by selecting `NULL`).
 
-Hook log: `~/.tokenix/<project-id>.log` — NDJSON, one `HookEvent` per line. Rotates at 5 MB to `<project-id>.log.1` (one generation kept); `read_hook_log()` reads both. Fallback when the home dir is unavailable is repo-local `.tokenix/hook.log`.
+Hook log: `~/.tokenix/<project-id>.log`, NDJSON, one `HookEvent` per line, rotates
+at 5 MB (one generation). Fallback is repo-local `.tokenix/hook.log`.
 
-## Intercept Logic
+## Intercept logic
 
 ```
-Read tool:
-  file < 200 lines OR offset/limit set → exit 0 (pass through)
-  file ≥ 200 lines, no offset/limit   → return outline, exit 2 (intercept)
+Read:  < 200 lines OR offset/limit set → exit 0 (pass)
+       ≥ 200 lines, no offset/limit    → outline, exit 2 (intercept)
 
-Grep tool:
-  pattern < 3 words → not semantic; symbol lookup if identifier-like, else:
-      output_mode="content" without head_limit → PreToolUse updatedInput injects
-      head_limit (TOKENIX_GREP_HEAD_LIMIT, default 100, 0 disables); logged with
-      saved_tokens=0 because the unbounded output never ran
-      otherwise → exit 0 (pass)
-  pattern ≥ 3 words → return semantic results, exit 2 (intercept); gain records this as neutral usage, not saved tokens
+Grep:  < 3 words → not semantic; symbol lookup if identifier-like, else
+         output_mode="content" without head_limit → updatedInput injects
+         head_limit (TOKENIX_GREP_HEAD_LIMIT, default 100, 0 disables);
+         logged saved_tokens=0 because the unbounded output never ran
+       ≥ 3 words → semantic results, exit 2; gain records neutral usage
 
-Bash / PowerShell tools:
-  command matches a bundled/user filter → rewrite to `tokenix run` (PowerShell
-  uses `& 'exe' run --shell pwsh '<cmd>'`, re-executed under pwsh with UTF-8)
-  otherwise → exit 0 (pass)
+Bash / PowerShell: matches a filter → rewrite to `tokenix run`
+       (PowerShell: `& 'exe' run --shell pwsh '<cmd>'`, re-executed under pwsh)
+       otherwise → exit 0
 
 Index stale → Grep still gets its head_limit cap, then exit 0 for every tool.
-  Staleness is NOT age-based: `store::index_staleness` flags a missing DB, a
-  missing `indexed_at`, an explicitly requested different embedding model, or a
-  changed git fingerprint (auto-updated when HEAD moved but the code is
-  identical).
 ```
 
-Matcher (installer): `^(Read|Grep|Bash|PowerShell|grep_search|run_in_terminal)$`.
-Claude Code's dedicated `PowerShell` tool (exact name) takes the pwsh path; the
-generic lowercase `powershell` from Copilot/Antigravity stays on the bash path.
+Staleness is **not** age-based: missing DB, missing `indexed_at`, an explicitly
+requested different embedding model, or a changed git fingerprint.
 
-`get_effective_command` normalizes a command before matching so filters anchored
-on the bare tool still hit: it strips shell wrappers, `cd`/env prefixes, package
-runners (`uv run`, `python -m`, `npx`, `bunx`, `pnpm exec/dlx`, `yarn dlx`,
-`bun x`, `deno run/task`), and tool-global options (`git -C`, `kubectl -n`,
-`docker -H`, `cargo +tc`). Verified against Codex/Antigravity histories where
-`uv run pytest`, `python -m ruff`, `bunx biome` were bypassing their filters.
+Installer matcher: `^(Read|Grep|Bash|PowerShell|grep_search|run_in_terminal)$`.
+Claude Code's exact-name `PowerShell` tool takes the pwsh path; the lowercase
+`powershell` from Copilot/Antigravity stays on the bash path.
 
-Both thresholds are per-project tunable via `.tokenix.toml`:
+`get_effective_command` normalizes before matching so filters anchored on the bare
+tool still hit: strips shell wrappers, `cd`/env prefixes, package runners
+(`uv run`, `python -m`, `npx`, `bunx`, `pnpm exec/dlx`, `yarn dlx`, `bun x`,
+`deno run/task`) and tool-global options (`git -C`, `kubectl -n`, `docker -H`,
+`cargo +tc`). Verified against real histories where `uv run pytest` and
+`bunx biome` were bypassing their filters. `split_on_operators` splits compound
+commands quote-aware on `&&`/`||`/`;`/`|`.
+
+Per-project tuning in `.tokenix.toml`:
 
 ```toml
 [hook]
@@ -120,569 +108,169 @@ read_min_lines = 120   # default 200
 grep_min_words = 3     # default 3
 ```
 
-## Critical Rules
+## Critical rules
 
-**Never lose content.** The chunker must store 100% of every indexed file. Generic files (.md, .txt, .yaml, .json) use `clean_generic_text()` — full content with formatting stripped. Truncated previews are forbidden. Only code files use symbol-based outlines stored in full in SQLite.
+**Never lose content.** The chunker stores 100% of every indexed file. Generic
+files (.md, .txt, .yaml, .json) use `clean_generic_text()` — full content,
+formatting stripped. Truncated previews are forbidden.
 
-**Never break hook fallback.** `run_hook()` must always `exit(0)` on any error — missing index, stale index, parse failures, embed errors. Breaking Claude Code sessions is worse than missing a token-saving opportunity.
+**Never break hook fallback.** `run_hook()` must `exit(0)` on any error — missing
+index, stale index, parse failure, embed error. Breaking a session is worse than
+missing a saving.
 
-**Hook exit codes:** `0` = pass through (original tool runs) · `2` = block tool (hook stderr becomes Claude's context). Never exit `1`.
+**Hook exit codes:** `0` = pass through · `2` = block tool (stderr becomes the
+agent's context). Never exit `1`.
 
-**Daemon is optional.** If `tokenix serve` is not running, `handle_grep()` auto-starts it and retries once (800ms wait). If autostart fails, falls back to direct in-process embed.
+**Never mask a failure.** Non-zero exit suppresses success sentinels
+(`match_output`, `on_empty`). A filter that can empty a failure payload must keep
+failure markers (`(?i)error|fail|fatal`) or set `passthrough_when_emptied`.
+Measured elsewhere: an over-aggressive log filter scored *below* passing the raw
+output through, because it destroyed the root cause.
 
-**Directory filtering in indexer:** `filter_entry` for directories uses ONLY `IGNORED_DIRS`. Do NOT call `should_index()` on directories — it returns false for dirs without extensions and breaks traversal. Keep `should_index` / `filter_entry` separation intact.
+**Preserve line endings.** Every transform splits with `.lines()` (which consumes
+`\r\n`) and rejoins with `"\n"`. `compress_output` and `apply_filter_with_exit`
+detect the dominant terminator (`compress::dominant_eol`, CRLF wins when
+`crlf * 2 > lf`) and restore it on the way out (`compress::restore_eol`,
+idempotent). Without this a CRLF file on Windows comes back LF-only and every line
+differs from disk by one byte — fatal when the agent quotes it into an exact-match
+edit, which has zero fuzz tolerance.
 
-**Cross-platform paths:** `tokenix_bin_path()` normalizes to forward slashes for shell/JSON config strings. Preserve for Windows compatibility.
+**Compress at write time, never rewrite history.** Reducing an observation before
+it enters the conversation leaves an already-cached prefix intact. Retroactively
+rewriting earlier turns invalidates the prompt cache from that point, and cache
+write costs ~12.5× a cache read.
 
-**Hook log format:** Do not change `~/.tokenix/<project-id>.log` away from NDJSON without updating `gain.rs`.
+**Directory filtering:** `filter_entry` for directories uses ONLY `IGNORED_DIRS`.
+Do NOT call `should_index()` on directories — it returns false for dirs without
+extensions and breaks traversal.
 
-**Token count is approximate.** `count_tokens()` = `(len + 3) / 4`. Intentional — no tiktoken dep.
+**Daemon is optional.** If `tokenix serve` is not running, `handle_grep()`
+autostarts it and retries once (800 ms), then falls back to in-process embed.
 
-**Keep docs in sync.** Every new or changed user-facing feature MUST update both `README.md` (Features table, Commands Reference, Usage, Architecture) and `AGENTS.md` (Key Files + relevant section) in the same change.
+**Cross-platform paths:** `tokenix_bin_path()` normalizes to forward slashes for
+shell/JSON config strings.
 
-## Daemon
+**Hook log format:** do not move away from NDJSON without updating `gain.rs`.
+
+**Token count is approximate.** `count_tokens()` = `chars / 4` rounded up —
+**chars, not bytes**, so non-ASCII is not charged 2–4×. Deliberate approximation;
+a real BPE tokenizer is roadmap, not a dependency yet.
+
+**`gain` reports tokens, not money.** Tokens removed from a payload is a token
+measurement. Published work found token reduction and provider-billed cost are
+close to uncorrelated (r = 0.15) because cache traffic dominates a real bill. Do
+not add a savings-in-dollars headline until cache-aware accounting lands. See
+`docs/research/2026-08-token-economy.md`.
+
+**Keep docs in sync.** Every new or changed user-facing feature MUST update both
+`README.md` (Commands, and any affected section) and this file in the same change.
+
+## Output filters
+
+Resolution: `<repo>/.tokenix/filters` (trust-gated) → `~/.tokenix/filters` →
+bundled. Currently **528 filters / 1,146 golden cases**.
+
+**Hot path uses `load_filters_for_command()`, not `load_all_filters()`.** A
+prefilter narrows candidates before any regex compiles; `find_filter` matches via
+`derive_command_candidates()`. Measured on Windows with 528 bundled + 231 user
+filters, the hook stays in single-digit milliseconds.
+
+Engine invariants: `never_worse` (a filtered result never costs more bytes than
+raw) · `head_lines`+`tail_lines` form a first+last window with an inline
+`[... N lines omitted ...]` marker · `priority_lines` survive every sizing cut ·
+`category_caps` bound repetitive classes with a count marker · `apply_filter_with_exit`
+honors per-filter `on_failure = "passthrough"|"tail:N"` · `FilterDef` is
+`deny_unknown_fields` so typo'd keys fail loudly.
+
+`on_empty` and `passthrough_when_emptied` **compose** — 94 bundled filters ship
+both, and that is the recommended shape for a silent-on-success tool. The
+`apply_filter_with_exit` fallback is gated on `!output.trim().is_empty()`, so
+passthrough only takes over when filtering emptied *non-empty* output.
+
+Repo-local filters are trust-gated (`tokenix trust`, SHA-256 in
+`~/.tokenix/trusted_filters.json`) and skipped until approved. Failed commands
+with clipped output tee raw text to `~/.tokenix/tee/` with a `[full output: path]`
+hint (`TOKENIX_TEE=0` disables). `TOKENIX_DISABLED=1` bypasses the hook for one
+command (logged as `action="bypassed"`).
+
+**Adding a filter:** create `assets/filters/<slug>.toml` with **≥2 embedded
+`[[tests.<name>]]` golden cases** (enforced by
+`bundled_filters_require_minimum_tests`). rust-embed picks it up automatically.
+Homologate with `cargo test --bin tokenix filters::tests::` — golden, ≥70% economy,
+never-mask-failure, and no-inflate all run there.
+
+Full per-filter homologation (slower, opt-in):
 
 ```bash
-tokenix serve            # start daemon (blocks; use & or detached)
-tokenix serve --port 9999
-tokenix stop             # stop daemon (reads ~/.tokenix/daemon.pid)
-tokenix daemon status    # pid, port, uptime, model, cached projects + RAM
-tokenix daemon restart   # stop (if running) + detached respawn
-
-# Health check
-echo '{"type":"health"}' | nc 127.0.0.1 47392
-# → {"ok":true,"cached_projects":1,"chunks":197}
-# Status over the same socket: {"type":"status"}
+cargo test --release --bin tokenix homologate -- --ignored --nocapture
 ```
 
-Warm Grep calls via daemon: ~80ms vs ~430ms cold in-process. Daemon auto-starts on first Grep hook call.
-
-**Resource limits (prevents freeze under parallel hooks):**
-- Max **4 concurrent handler threads** — unbounded spawning was the primary Windows freeze trigger
-- **Spawn lock** (`daemon.pid.spawning`) + PID liveness check — prevents N parallel hooks from each spawning a separate 130 MB daemon process
-- **Content cache capped at 1000 entries** per project
-
-## Output Filters
-
-Legacy `hook-post` compression flows through (in order):
-1. User TOML filters (`~/.tokenix/filters/*.toml`) — highest priority
-2. Bundled TOML filters (`assets/filters/*.toml`, rust-embed)
-3. Built-in heuristics in `compress.rs` — cargo, git-log, generic head/tail
-
-`compress_output()` order: `redact_base64_blobs` → `compact_json` (early return,
-**also capped**) → `strip_ansi` → `remove_emojis` → `collapse_blank_lines` →
-`group_repeated_blocks` → `group_repeated_lines` → `generic_aggressive_compress`
-→ `enforce_token_budget`. The last two are the newer backstops:
-- `group_repeated_blocks` collapses a 2–12 line stanza repeated 3+ times
-  (`[block of N lines repeated Kx]`); `group_repeated_lines` only ever saw runs
-  of *identical adjacent lines*, so poll/watch loops slipped through (one
-  monitoring session measured ~617k tokens this way). Skipped above 100k lines.
-- `enforce_token_budget` clips anything over `TOKENIX_MAX_OUTPUT_TOKENS`
-  (default 8000, `0` disables) to a 75% head + 25% tail window at char
-  boundaries. It is the only cap that covers single-giant-line output and the
-  `compact_json` early return, both of which bypass every line-count cap.
-  `preserved_identifiers` scans the dropped range for things a caller cannot
-  re-derive — git SHAs (hex, 7–40, mixed letters+digits so "decade"/"facade"
-  and plain numbers are excluded), UUIDs, http(s) URLs, `E0308`-style codes —
-  and appends up to 12 of them (≤240 chars) as `[ids kept from the omitted
-  range: …]`.
-
-## MCP proxy (`src/mcp_proxy.rs`)
-
-`tokenix mcp-proxy [--name X] -- <server cmd>` wraps a stdio MCP server. This is
-the **only** path that reaches MCP tool output: PreToolUse fires on the agent's
-own tools, and Claude Code ships no PostToolUse
-([[project_claude_no_posttooluse_by_design]] in memory) — so an image-generation
-or browser-snapshot result was previously unreachable, which is where
-`conversation-audit`'s largest bucket (image-blob, millions of tokens) lives.
-
-Contract, deliberately narrow:
-- requests are forwarded **verbatim** — the proxy never rewrites what the agent asks for;
-- only `result.content[]` blocks with `type == "text"` are compressed, via
-  `compress_output` (base64 redaction → JSON compaction → repeat collapse → cap);
-- `image` blocks are never touched (the host renders them);
-- `tools/list` schemas are never touched (a shortened description changes what
-  the model believes the tool does — that is mcp-compressor's trade, not ours);
-- per-block `never worse`: the original text stays when compression is not smaller;
-- results under `MIN_RESULT_TOKENS` (200) pass through untouched;
-- anything unparseable is forwarded as-is; child stderr is inherited.
-
-Savings log as `tool="MCP"`, `phase="proxy"`, `command="mcp:<name>"`, so `gain`
-counts them under command filters. `TOKENIX_MCP_PROXY=0` disables the rewriting.
-
-## Recall (`src/recall.rs`)
-
-Content-addressed stash + dedup, ported from what competitors do well (squeez's
-reversible compression + cross-call dedup; read-once / semantic-cache-MCP's
-re-read suppression). FNV-1a digest, no new dependency.
-
-| Store | Path | Cap |
-|---|---|---|
-| blobs (raw + compressed bodies) | `~/.tokenix/blobs/<digest>.txt` | 60 files, oldest pruned |
-| command output index | `~/.tokenix/recent_outputs.json` | 24 entries |
-| full-read index | `~/.tokenix/recent_reads.json` | 24 entries |
-
-- **`tokenix retrieve <key>`** prints a stashed body. Keys are validated as
-  ASCII-alphanumeric, so a key echoed by the model can never traverse out of the
-  blob directory.
-- **Cross-call dedup** (`find_identical` in `run_command_and_compress`): only on
-  **exit 0** — a repeated failure still needs its error text — only above
-  `TOKENIX_DEDUP_MIN_TOKENS` (200), and only when the marker is shorter than the
-  output. Every hit is verified against the stored blob, so a hash collision or
-  a pruned blob degrades to "no match" rather than a wrong collapse.
-  `TOKENIX_DEDUP=0` disables.
-- **Re-read suppression** (`find_recent_read` in `handle_read`): remembers only
-  reads that delivered the **full content**. A read answered with an outline is
-  deliberately *not* remembered — otherwise the agent could never get past the
-  outline. TTL `TOKENIX_READ_DEDUP_TTL` (900s) bounds the context-compaction
-  risk; `TOKENIX_READ_DEDUP_MIN_TOKENS` (1500) keeps small files verbatim;
-  `TOKENIX_READ_DEDUP=0` disables. Recovery is exact via the stash key.
-
-`apply_filter()` pipeline: `match_output` short-circuit → `strip_ansi` → `strip_lines_matching` → `keep_lines_matching` → `head/tail/max_lines` → `truncate_lines_at` → `on_empty`. Opt-in `passthrough_when_emptied`: when the pipeline reduces *non-empty* output to nothing (an unrecognized output shape, not a genuinely empty command), emit a bounded view of the real output instead of `on_empty` — set on `git-log`/`git-diff` so `--oneline`/`--stat` don't report a false "no commits"/"no changes". The same bounded fallback fires **automatically** (no opt-in) whenever the original output matches `output_has_failure_signal()` (a strict, case/anchor-tuned `error`/`fatal`/`panic`/`FAILED`/`exit code N` probe) — so a failed build/test/deploy whose error text isn't matched by the tool's `keep_lines_matching` is never masked as the success `on_empty`. Guarded by `bundled_filters_never_mask_generic_failure`.
-
-**Filter design rule: never use `on_empty` — use `passthrough_when_emptied = true` instead.** `on_empty` fabricates a static string when real output is filtered to nothing; `passthrough_when_emptied` returns the original unfiltered output. Filters must only filter, never invent responses. `match_output` is the only valid short-circuit (it fires only when a confirmed pattern exists in the real output). Tests must not assert on fabricated strings.
-
-```toml
-[filters.my-cmd]
-match_command  = "^my-cmd\\b"
-passthrough_when_emptied = true
-strip_ansi     = true
-strip_lines_matching  = ["^\\s+Downloading"]
-match_output   = [{ pattern = "Success", message = "ok" }]
-max_lines      = 30
-```
-
-## One interface: direct commands open the shell
-
-There is exactly one human-facing rendering, the ratatui shell. A human report
-command run on a terminal **redirects to its own tab** instead of printing a
-second, divergent view of the same data:
-
-| Command | Tab | Seeded state |
-|---|---|---|
-| `tokenix` (bare) | Stats | — |
-| `stats` | Stats | — |
-| `doctor` | Doctor | — |
-| `tokenmap` | Tokenmap | — |
-| `graph` | Graph | — |
-| `discover` | Discover | — |
-| `prompt-audit` | Audit | — |
-| `gain` | Gain | `--global`, `--cost-estimate` |
-| `usage [group]` | Usage | group (daily/model/blocks/project/session), `--all-projects` |
-| `scan-secrets` | Secrets | opens all-repos (the CLI scan is not repo-scoped) |
-| `egress-audit` | Egress | opens all-repos |
-| `filter`, `filter active` | Filters | — |
-| `filter list` | Studio | — |
-
-`main.rs::tui_target()` is the single decision table; `tui_entry_for()` adds the
-gate `tui::should_open()`. **The table must stay pure and testable** — the
-`tests::{human_report_commands_target_their_tab, machine_and_unrepresentable_invocations_keep_printing, agent_facing_commands_never_open_the_shell, scoping_flags_are_carried_into_the_tab}` cases lock it down.
-
-Plain output is kept whenever:
-- stdout is not a terminal (pipe, CI, capture);
-- `--no-tui` (global flag) or `TOKENIX_NO_TUI=1`;
-- the invocation asked for something a tab cannot represent: `--json`,
-  `--statusline`, `--format html|dot`, `--output <file>`, `--since/--until`,
-  `--filter`, `--reveal`, `gain --history/--economics`, `--top`/`--since-days`
-  other than the default (`graph`, `discover`), `prompt-audit
-  --recommend/--profile-impact`, `usage weekly|monthly`, `filter list <index>`,
-  or a `--path` pointing outside the current repo (the shell always reports on
-  the repo it was opened in).
-
-**Agent-facing commands are never redirected** — `hook`, `hook-post`,
-`hook-antigravity`, `run`, `mcp`, `query`, `context`, `read`, `symbols`,
-`pack`, `index`, `serve`, `retrieve`, `install-hook`, `prompt-audit`,
-`discover`, `benchmark`. A terminal UI in those paths would break the product.
-
-The shell's own self-exec captures (`capture()`, `run_index_foreground()`) set
-`TOKENIX_NO_TUI=1` on the child so a report tab can never spawn another shell.
-
-## Per-filter homologation
-
-Aggregate green is not per-filter green. `homologate_each_filter` (ignored by
-default — `cargo test --release --bin tokenix homologate -- --ignored
---nocapture`) emits one TSV row per bundled filter: golden verdict, raw→filtered
-tokens and %, whether a golden case carries a failure signal, whether that case
-is masked, byte inflation, sentinel shape, prefilter class, and whether the
-filter fabricates its `on_empty` sentinel over unrecognized output.
-
-Status of the 528 bundled filters at the last full pass:
-
-| Property | Result |
-|---|---|
-| Golden cases byte-exact | 528/528 (1,146 cases) |
-| Never inflates non-empty output (`never_worse`) | 528/528 |
-| Never masks a failure signal | 528/528 |
-| Median per-filter token economy | 32% (mean 33%, max 88%) |
-| Fabricates a sentinel over unrecognized output | **36** (was 141) |
-| Golden cases include a failure-path input | 204/528 |
-
-**Engine-level guarantee (since the 2026-08 audit).** The masking rules above are
-no longer carried by per-filter opt-ins alone:
-
-- `match_output` and `uniform_success` are suppressed whenever the raw output
-  matches `output_has_failure_signal()`, not only on a known-nonzero exit. A
-  filter without `unless` can no longer answer a failing run with a success
-  sentinel.
-- An unparseable `unless` regex **fails closed** (the sentinel is skipped)
-  instead of silently dropping the guard.
-- The bounded-fallback path no longer requires `on_empty` to be set: any filter
-  that empties output carrying a failure signal falls back to a bounded view of
-  the real text.
-- Invalid regexes in a filter are reported on stderr instead of making the
-  filter a silent no-op.
-
-`unless` remains worth writing — it is more precise than the generic signal —
-but it is now a refinement, not the only line of defence.
-
-Two related engine changes from the same audit:
-
-- **Source precedence is real.** Local > user > bundled is resolved by group
-  (`load_filter_groups_for_command` + `find_filter_ranked`); the
-  longest-`match_command` tie-break now only applies *within* a source, so a
-  long bundled pattern can no longer outrank a user filter written to override
-  it.
-- **`semantic_filter` embeds in one batch** via `embed_documents` instead of one
-  round-trip per line.
-
-Two findings from that pass are worth carrying forward:
-
-1. **The 89 filters fixed.** A filter whose sentinel only ever answers a
-   genuinely empty run (a silent linter) was answering *unrecognized non-empty*
-   output with the same "all clear". Adding `passthrough_when_emptied = true`
-   is behavior-preserving for every golden case (proven: the whole suite stayed
-   green) and replaces the lie with a bounded view of the real output.
-   `on_empty_sentinel_never_answers_unrecognized_output` locks this in.
-2. **The summary filters (52 → 40).** These legitimately collapse *recognized*
-   verbose output into a summary (proven by a golden case with non-empty
-   input), so passthrough alone would destroy their compression. The fix is
-   **positive evidence**, borrowed from rtk's `basedpyright` filter: pair a
-   `match_output` on the tool's own success marker with
-   `passthrough_when_emptied = true`. `match_output` short-circuits first, so
-   the clean run still collapses to one line; unrecognized output now falls
-   through to the real text instead of a fabricated "all clear".
-
-   ```toml
-   match_output = [
-     { pattern = "didn't find any unused dependencies",
-       message = "cargo-machete: no unused dependencies",
-       unless = "(?i)\\b(error|fatal|failed)\\b" },
-   ]
-   passthrough_when_emptied = true
-   ```
-
-   **For per-item tools that rule does not apply** — a `match_output` on
-   `PASS` fires on a run where item 3 failed. That is what `uniform_success`
-   exists for: it collapses only when EVERY significant line matches the pass
-   shape and at least one did, so a single dissenting line disqualifies the
-   whole run, and `{n}` reports the real item count.
-
-   ```toml
-   passthrough_when_emptied = true
-   uniform_success = { pattern = "^PASS - ", message = "conftest: {n} policies passed" }
-   ```
-
-   Converting a filter this way *promotes* it out of the summary group: with
-   the summary job handled by evidence, its `on_empty` only answers a genuinely
-   empty run, so `passthrough_when_emptied` becomes behavior-preserving.
-   Applied to conftest, kubeconform, prowler and lychee (40 → 36). Verified
-   end-to-end through the real binary, not just fixtures: uniform run →
-   `conftest: 3 policies passed`; one `FAIL` line → real output kept;
-   unrecognized output → real output kept.
-
-   Applied to the 12 whose marker is a whole-run summary (cargo-machete,
-   cargo-outdated, cargo-udeps, attw, dart-analyze, ggshield, istioctl, nuclei,
-   osv-scanner, atlas, flux, sequelize) — golden stayed green and mean economy
-   did not move. **The remaining 40 are deliberately untouched**: their marker
-   is per-item (`PASS`, `ok 1`, `[200]`, `is valid`), so a `match_output` on it
-   would short-circuit a run where *other* items failed. They need a
-   whole-run assertion, not a line marker. `report_sentinel_evidence_candidates`
-   (ignored test) prints the fixture that already contains each one's evidence.
-
-**Coverage note:** 324 filters have no failure-path golden case of their own.
-That is a corpus documentation gap, not a live hole —
-`bundled_filters_never_mask_generic_failure` feeds *every* bundled filter a
-synthetic failure payload and asserts a failure marker survives, so the
-guarantee holds for all 528 regardless.
-
-## Filter resolution cost (hook hot path)
-
-The `PreToolUse` hook is a fresh process on **every** Bash/PowerShell call, so
-filter resolution is latency, not throughput. Three mechanisms keep it cheap;
-all three are "skip work only" — none may change which filter is selected.
-
-1. **Prefilter (`prefilter_for`)** — a cheap NECESSARY condition derived from
-   the raw pattern text: `^cargo\s+test` → candidate must *start with* `cargo`;
-   `\bactionlint\b` / `^(npx\s+)?eslint\b` → candidate must *contain* the first
-   mandatory literal (case-folded for a leading `(?i)`). Unrecognized shapes
-   (mandatory alternation, nested groups) return `None` = always evaluate.
-   `literal_run` stops at `.` and `+` because those are metacharacters, and a
-   **top-level `|` alternation returns `None`** — only the first branch carries
-   the leading literal, so no single literal is mandatory (3 bundled patterns;
-   `select-string` is the one that was actually unsound). Guarded by
-   `prefilter_never_rejects_a_real_match`, which asserts
-   `regex matches ⇒ prefilter allows` over every bundled/user pattern against a
-   corpus of each filter's own literal **plus every `command` recorded in the
-   golden cases** — that corpus is what surfaced the alternation hole.
-2. **Lazy loading (`load_filters_for_command`)** — the bundled corpus is
-   indexed once per process by scanning each embedded file's `match_command`
-   off the raw text (`scan_bundled_anchors`, no TOML parse); only files whose
-   prefilter allows a candidate are parsed. `parse_filter_file_named` also cuts
-   the content at the first `[[tests]]` block (~60% of the bytes) and falls
-   back to a full parse if that head does not parse. Homologated by
-   `lazy_load_matches_full_load_for_commands` and
-   `scanned_anchor_never_overshoots_parsed_pattern`.
-3. **User filter index** — `~/.tokenix/filters/.prefilter-index.json` caches
-   per-file prefilters, validated against the directory listing (name + mtime +
-   size); any drift rebuilds the whole index. Without it, a user with hundreds
-   of generated filters pays ~15 ms of file I/O per hook call.
-
-Regexes are compiled at most once per process (`cached_regex`), including
-inside `apply_filter` — compiling per call made the TUI preview and
-`tokenix discover`'s replay loop recompile the same patterns thousands of
-times.
-
-Measured on Windows (528 bundled + 231 user filters), `tokenix hook` for a
-Bash command: **~59 ms → ~28 ms** end-to-end; `apply_filter` 1.28 ms → 0.07 ms.
-
-## Prompt Audit (MCP/tool/context weight)
-
-`tokenix prompt-audit` estimates the variable cost of the effective system prompt
-per agent. The base system prompt is internal and **cannot be read or intercepted
-via hooks** — this measures the next-largest levers instead: MCP tool-definition
-JSON plus the context an agent loads before doing anything. All logic lives in
-`src/mcp_audit.rs`.
-
-Context weight (`context_weight()` → `ContextWeight`), added because a measured
-history showed a single skill body costing ~198k tokens while the audit reported
-only MCP schemas:
-
-| Source | Agents | Counted as |
-|---|---|---|
-| `CLAUDE.md`, `AGENTS.md`, `.github/copilot-instructions.md`, `~/.claude/CLAUDE.md`, `~/.codex/AGENTS.md` | per-agent path list | always-on (full file) |
-| `<repo>/.claude/skills/*/SKILL.md`, `~/.claude/skills/*/SKILL.md`, `~/.claude/plugins/**/skills/*/SKILL.md` (depth ≤ 4) | Claude Code only | always-on = frontmatter `name`+`description`; body reported separately as on-invoke |
-
-Only always-on tokens enter the per-agent total and `combined_tokens`; bodies
-≥ `HEAVY_SKILL_TOKENS` (5k) are listed as "loaded on invoke". `aggregate()` takes
-the `ContextWeight` as a parameter (not the cwd) so tests aggregate against a
-known-empty context instead of the developer's real home directory.
-
-Per-agent MCP config sources (one `ConfigSource` each, ausente = silently skipped):
-
-| Agent | Path(s) | Format |
-|---|---|---|
-| Claude Code | `<repo>/.mcp.json` + `~/.claude.json` (`mcpServers` + `projects[<cwd>]`) | JSON |
-| Codex | `~/.codex/config.toml` → `[mcp_servers.<name>]` | TOML (`toml` dep) |
-| OpenCode | `<repo>/opencode.json` (`mcp`) | JSON |
-| Antigravity | `~/.gemini/antigravity-cli/mcp_config.json` (`mcp_config_path()`) | JSON |
-| Copilot | `.vscode/mcp.json` (`servers`) + VS Code user `mcp.json` | JSON, best-effort |
-
-Pipeline: discover → dedupe stdio transports → `introspect_stdio()` (spawn, JSON-RPC
-`initialize`/`tools/list`, 5s timeout via reader thread + `recv_timeout`, kill on
-done) → tokenize schemas with `count_tokens` → add static `Agent::native_tokens()`
-baseline → compare to thresholds (`TOKENIX_AUDIT_WARN_{TOKENS,SERVERS,TOOLS}`).
-`TOKENIX_BRANCH_AWARE=true` suffixes SQLite DB with git branch name to isolate indexes per branch.
-HTTP/SSE servers are not introspected (shown `unknown`). CLI-only — no hooks, no
-settings.json changes.
-
-`--recommend` adds conservative reduction advice. `--profile-impact` estimates
-the tokenix full-vs-slim MCP schema delta. `tokenix session-audit` reuses the
-same summary and combines it with index freshness plus hook-log evidence;
-`--cache-hygiene` also reports stable-prefix/cache-risk hints.
-
-`tokenix mcp --profile slim` is the token-saving MCP mode: it advertises only
-`tokenix_context`, `tokenix_search_tools`, and `tokenix_call`. Keep `full` as
-the default for compatibility with hosts that do not support progressive tool
-discovery.
-
-## Repository Pack
-
-`tokenix pack` emits a budgeted repo map for non-hook AI tools. Modes/profiles:
-`plan`, `debug`, `audit`, `security`, `review`. Formats: `markdown`, `xml`,
-`json`. `--changed` and `--since <ref>` produce review-sized packs; `--token-map`
-adds per-file token/reason metadata.
-It uses indexed context, file token counts, and symbol outlines; it must skip
-obvious secrets, credentials, `.env`, key files, `.git`, and build output by
-default. Do not turn `pack` into a raw full-repo dump.
-
-## Benchmark
-
-`tokenix benchmark` measures tokenix against a plain **vanilla** baseline only —
-no external tools. It prints read-only token reduction, targeted
-outline+symbol workflows, semantic Hit@1/Hit@3, context homologation (vanilla
-full file vs tokenix budgeted context), and command-output compression. Flags:
-`--budget N`, `--refresh-index`, `--cases FILE`, `--json`.
-
-**Fairness contract (do not regress).** Benchmark is tokenix-vs-vanilla only —
-do not add competitor/market comparison arms. Vanilla and tokenix are scored on
-identical input counted with the same `count_tokens`. Semantic Hit@1/Hit@3 are
-reported as measured (misses included), never filtered to flatter tokenix.
-Default scenarios span Rust/TS/Go/Python plus SQLite vector search and command
-output (cargo, git, npm, docker compose). Verdict logic is unit-tested in
-`benchmark.rs`.
-
-**Windows caveat:** `npx`/`uvx` run via `cmd /C`; `child.kill()` kills the wrapper
-but a `node` grandchild may linger briefly until stdin EOF. Kill-the-tree
-(`taskkill /T`) is a possible hardening follow-up.
-
-## Common Tasks
-
-**Add a language:** `chunker.rs` — add extension to `INDEXED_EXTS`, add `Lang` variant, map in `detect_lang()`, implement `chunk_<lang>()` following `chunk_rust()` pattern (tree-sitter), or `chunk_by_symbol_lines()` with a `<lang>_symbol_of()` line matcher when no grammar is bundled (see VB6/SQL). Also add the new `Lang` arms in `graph.rs` (`extract_references_tree_sitter`, `extract_file_imports`). Do NOT add to `INDEXED_EXTS` without a symbol-aware chunker.
-
-**Add a bundled filter:** create `assets/filters/<slug>.toml` with **≥2 embedded `[[tests.<name>]]` golden cases** (input/expected — enforced by `bundled_filters_require_minimum_tests`). `on_empty` and `passthrough_when_emptied` **compose — they do not conflict** (an earlier note here claimed otherwise; the code disagrees and 94 bundled filters ship with both, golden-green). The fallback in `apply_filter_with_exit` is gated on `!output.trim().is_empty()`, so passthrough only takes over when filtering emptied *non-empty* output; a genuinely empty run still gets the sentinel. Setting both is the recommended shape for a silent-on-success tool. Any filter that can empty a failure payload must keep failure markers (`(?i)error|fail|fatal`) or set `passthrough_when_emptied` — else `bundled_filters_never_mask_generic_failure` fails. Rebuild — rust-embed includes it automatically. Homologate with `cargo test --bin tokenix filters::tests::` (golden + 70% economy + never-mask + no-inflate). Currently 528 filters · 1146 golden cases. Engine invariants: `never_worse` guarantees the filtered result never costs more bytes than the raw output (longer sentinel/notice → raw wins); `head_lines`+`tail_lines` together form a first+last window with an inline `[... N lines omitted ...]` middle marker; `apply_filter_with_exit` suppresses success sentinels on nonzero exit and honors per-filter `on_failure = "passthrough"|"tail:N"`; `priority_lines` survive every sizing cut; `category_caps` bound repetitive classes with a count marker; `FilterDef` is `deny_unknown_fields` (typo'd keys fail loudly — `tokenix filter verify` runs user/project golden tests from the installed binary). Repo-local `.tokenix/filters` are trust-gated (`tokenix trust`, SHA-256 in `~/.tokenix/trusted_filters.json`) and skipped until approved. Failed commands with clipped output tee the raw to `~/.tokenix/tee/` with a `[full output: path]` hint (TOKENIX_TEE=0 disables). `TOKENIX_DISABLED=1` prefix bypasses the hook per command (logged as action="bypassed").
-
-**`filter record` token-economy preview:** `recordings::economy()` reconstructs each captured command's raw output (stripping the `$ cmd`/`--- stderr ---`/truncation scaffold), resolves the bundled filter via the real `find_filter`+`apply_filter` path, and reports `raw→filtered` tokens. `record stop`/`status` render it as a per-command compression bar + total via `print_economy_table` in `cmd_filter.rs`.
-
-**Change intercept threshold:** `hook.rs` constants — `MIN_LINES_FOR_OUTLINE`, `MIN_QUERY_WORDS` (both overridable per project via `[hook]` in `.tokenix.toml`). Index staleness lives in `store::index_staleness` and is fingerprint-based, not age-based.
-
-**Extend hook to a new tool:**
-1. Add variant to `Tool` enum in `main.rs`
-2. Implement `install_<tool>()` and `remove_<tool>()`
-3. Add match arms in `cmd_install_hook()` and `cmd_remove_hook()`
-4. Update `hook.rs` only if the tool has a real hook protocol
-5. Document in `README.md`
-
-**Add an agent to `prompt-audit`:** `mcp_audit.rs` — add an `Agent` variant (with `label`/`key`/`native_tokens`), a `discover_<agent>()` config source, and an `AuditAgent` value + mapping in `main.rs`. Reuse `parse_json_map` for JSON `mcpServers`-style configs.
-
-**Add a `scan-secrets` rule:** no Rust change needed — append a `[[rules]]` block (`id`, `pattern`, optional `capture`/`min_entropy`) to `assets/secret-rules/default.toml` (or a new bundled `*.toml`), or to `~/.tokenix/secret-rules/*.toml` / `<repo>/.tokenix/secret-rules/*.toml` at runtime. Patterns use the backtracking-free `regex` crate (no lookaround). `secrets_scan.rs::compile_rules` dedups by `id` (later source wins) and skips invalid regexes with a stderr warning.
-
-**Change token budget:** `query.rs` — `DEFAULT_BUDGET` constant, or pass `--budget` flag.
-
-**Embedding model (flexible):** `embed.rs` `MODELS` registry maps a friendly id → `EmbeddingModel` + query/doc prefixes. Default is `nomic-v1.5` (existing indexes keep working). Select with `tokenix index --model <id>` or `TOKENIX_EMBED_MODEL=<id>`. The chosen model is **stamped in the index `meta` (`embed_model`)**; query/hook/daemon read it back via `store::index_model_id` and `embed::set_active_model` so query vectors always match the indexed docs. The model is **sticky** (a plain re-index keeps it); an explicit switch forces a full re-embed. `index_staleness` only flags a model change when `TOKENIX_EMBED_MODEL` is explicitly set. The embedding cache key (`chunk_embedding_key`) and the persistent query cache are namespaced by model id. Add a built-in model: append a `ModelSpec` with `ModelSource::BuiltIn(EmbeddingModel::…)` (use the non-quantized variant if the Qdrant-Q ONNX fails ORT's `SkipLayerNormalization`). Add a **custom** model (one fastembed does not ship, e.g. code-specialized): `ModelSource::Custom { hf_repo, onnx_file, pooling }` — `build_custom_embedding` downloads the onnx + tokenizer files (`reqwest`) into `<model_cache>/custom/<id>/` and loads them via fastembed's `UserDefinedEmbeddingModel`. `jina-code` (jinaai/jina-embeddings-v2-base-code, mean pooling) is the first such model. `tokenix doctor` lists available + active + this-repo's model, and validates user/local filters' `semantic_filter` config (`filters::semantic_filter_issues`); an unknown `semantic_filter.model` also warns at apply time before falling back to the default.
-
-**Update pricing table:** `gain.rs` — edit `MODELS` constant and bump `PRICING_COLLECTED_AT`. Fields: `name`, `input_per_1m` (USD), `reference` (marks ★ model — used for the Gain tab's ≈USD headline).
-
-## Testing the Hook
+## MCP proxy contract
+
+`tokenix mcp-proxy [--name X] -- <server cmd>` wraps a stdio MCP server and
+compresses **only** `tools/call` text results — the sole reachable path for MCP
+output.
+
+`tools/list` schemas are **never touched**. That is deliberate: the client, not
+the proxy, serializes `inputSchema` into the prompt, so schema re-serialization is
+not implementable here; Claude Code already defers MCP tool schemas by default;
+and collapsing many tools behind one meta-tool would destroy per-tool permissions
+and human-in-the-loop review. Schema compression is `mcp-compressor`'s trade, not
+ours.
+
+## Recall
+
+Clipped output is stashed so nothing is unrecoverable: `tokenix retrieve <key>`
+prints the exact original body a compressed run saved. Keys are validated and come
+from a `[tokenix: ...]` marker in the compressed output. Re-read suppression uses
+**exact hashes only** — fuzzy/similarity dedup is refused on purpose, because
+hiding *altered* output makes the agent act on a reality that no longer exists.
+
+## One interface
+
+A bare `tokenix` or any human report command on a TTY opens the ratatui shell on
+that command's tab. `should_open()` is the single TTY/`--no-tui` gate;
+`run_entry(Entry)` seeds the tab and scope. Piping, `--json`, `--statusline`,
+`--format`, `--output`, and any flag a tab cannot represent keep plain output.
+Agent-facing commands (`hook`, `run`, `mcp`, `query`, `read`, `pack`) never open a
+UI. Every data-loading tab loads on a background thread behind one shared spinner
+(`draw_loading` / `spinner_frame`); only Index runs as a foreground drop-out
+because it needs the child's own progress bar.
+
+## Common tasks
+
+**New tree-sitter language:** `Lang` enum + `detect_lang` + `is_<lang>_symbol()` +
+dispatch in `chunker.rs`, reference arm in `graph.rs`, fixture tests. Watch
+per-grammar identifier node kinds (`constant` Ruby, `name` PHP,
+`simple_identifier` Kotlin/Swift) in `find_first_identifier`.
+
+**New embedding model:** append a `ModelSpec` to `embed.rs::MODELS`. Built-in uses
+`ModelSource::BuiltIn`; custom uses `ModelSource::Custom { hf_repo, onnx_file, pooling }`
+(downloaded to `<model_cache>/custom/<id>/`). The active model is **stamped in the
+index `meta`** and read back by query/hook/daemon, so vectors always match. It is
+sticky across re-indexes; an explicit switch forces a full re-embed. Cache keys are
+namespaced by model id.
+
+**New secret rule:** `assets/secret-rules/*.toml`, `[[rules]]` with `id`,
+`pattern`, optional `capture` / `min_entropy`. **`min_entropy` must be reachable at
+the pattern's minimum match length** — Shannon entropy over the observed
+distribution is bounded by `log2(n)`, so a floor above `log2(min_len)` silently
+disables the rule. Ship a true-positive *and* a near-miss negative test.
+
+## Testing the hook
 
 ```bash
 tokenix index .
-
-# Should intercept (exit 2) — large file
-echo '{"tool_name":"Read","tool_input":{"file_path":"src/main.rs"}}' | tokenix hook; echo $?
-
-# Should pass through (exit 0) — small file
-echo '{"tool_name":"Read","tool_input":{"file_path":"Cargo.toml"}}' | tokenix hook; echo $?
-
-# Should intercept (exit 2) — semantic query (auto-starts daemon)
-echo '{"tool_name":"Grep","tool_input":{"pattern":"how does embedding work"}}' | tokenix hook; echo $?
-
-# Copilot-style input
-echo '{"toolName":"view","toolArgs":"{\"path\":\"src/main.rs\"}"}' | tokenix hook; echo $?
-
-# PostToolUse compression — bundled filter short-circuit
-echo '{"tool_name":"Bash","tool_input":{"command":"uv sync"},"tool_response":{"output":"Resolved 42 packages in 123ms\nAudited 42 packages in 0.05ms\n"}}' | tokenix hook-post; echo $?
-
+echo '{"tool_name":"Read","tool_input":{"file_path":"src/main.rs"}}' | tokenix hook; echo $?   # 2
+echo '{"tool_name":"Read","tool_input":{"file_path":"Cargo.toml"}}' | tokenix hook; echo $?    # 0
+echo '{"tool_name":"Grep","tool_input":{"pattern":"how does embedding work"}}' | tokenix hook  # 2
+echo '{"toolName":"view","toolArgs":"{\"path\":\"src/main.rs\"}"}' | tokenix hook              # Copilot shape
 tokenix gain --history
-```
-
-## Claude Code Integration Setup
-
-After `cargo install --path .`, configure Claude Code globally:
-
-### 1. Hooks (`~/.claude/settings.json` or project `.claude/settings.local.json`)
-
-Add to the `hooks` key — merging with any existing entries:
-
-```json
-{
-  "hooks": {
-    "PreToolUse": [
-      {
-        "matcher": "^(Read|Grep|Bash)$",
-        "hooks": [{ "type": "command", "command": "tokenix hook", "timeout": 10 }]
-      }
-    ]
-  }
-}
-```
-
-`PreToolUse` intercepts large reads and semantic Grep queries, and rewrites noisy Bash commands so they execute through tokenix before the model sees the output.
-
-### 2. Behavioral instruction (`~/.claude/CLAUDE.md`)
-
-Add a section so Claude prefers tokenix over raw Grep/Glob/Read for codebase searches:
-
-```markdown
-## Tokenix Indexed Search (Token Economy)
-- `tokenix` is indexed and available in PATH.
-- For any codebase search, PREFER tokenix over Grep/Glob/Read:
-  - Symbol by name: `tokenix symbols <name>`
-  - Semantic query: `tokenix query "<question>"`
-  - Callers of a function: `tokenix callers <symbol>`
-  - Callees: `tokenix callees <symbol>`
-  - Impact graph: `tokenix impact <symbol>`
-  - Focused context for a task: `tokenix context "<task description>"`
-  - Explore related: `tokenix explore <symbol>`
-- Fall back to Grep/Glob/Read only when tokenix returns no results or for exact literal matches.
-```
-
-### 3. Index the project
-
-```bash
-cd <project>
-tokenix index .
-tokenix stats      # verify file/chunk count
-```
-
-The daemon auto-starts on first Grep hook call. Run `tokenix serve` manually only to pre-warm it.
-
-## Tool Integration Model
-
-### Claude Code
-- Config: `PreToolUse` in `~/.claude/settings.json` or project `.claude/settings.local.json` (see setup above)
-- Input: `{"tool_name":"Read","tool_input":{"file_path":"src/main.rs"}}`
-
-### GitHub Copilot
-- Config: `.github/copilot-instructions.md` + VS Code-compatible `.github/hooks/hooks.json`
-- Input: `{"toolName":"view","toolArgs":"{\"path\":\"src/main.rs\"}"}`
-- tokenix normalizes `view`/`read` → `Read`
-
-### OpenAI Codex CLI
-- Config: `~/.codex/hooks.json` for `PreToolUse` Bash rewrites + optional shell helpers under `~/.codex/`
-
-### OpenCode
-- Config: repo-local `opencode.json` native `mcp` block
-- Shape: `{"mcp":{"tokenix":{"type":"local","command":["tokenix","mcp"]}}}`
-- Note: tokenix does **not** install `experimental.hook`; OpenCode support is native MCP registration only
-
-### Antigravity
-- Global config: `~/.gemini/config/plugins/tokenix/`, installed and registered through `agy plugin install`
-- Local config: `<repo>/.agents/plugins/tokenix/`, validated through `agy plugin validate`
-- Input: `{"toolCall":{"name":"read_file","args":{"path":"src/main.rs"}}}`
-- Output: native `decision: allow|deny`; command rewrites use `overwrite`. Do not install `PostToolUse` for compression because Antigravity cannot replace the original output there.
-
-## Agent Workflow (when working on this repo)
-
-Before opening a large or unfamiliar file:
-
-```bash
-tokenix query "what you need to understand"
-tokenix read <file>
-```
-
-Narrow context with:
-
-```bash
-tokenix read <file> --symbol <name>
-tokenix read <file> --lines N-M
-tokenix read <file> --mode signatures      # signatures only (no bodies)
-tokenix read <file> --mode diff            # outline + uncommitted hunks
-tokenix read <file> --mode density:40      # keep ~40% highest-entropy lines
-```
-
-Only read a full file directly when tokenix shows it is small.
-
-Inspect the symbol graph and spend with:
-
-```bash
-tokenix graph                 # repo-wide god nodes / bottlenecks / blast radius
-tokenix graph --format dot    # Graphviz of the top subgraph
-tokenix usage                 # absolute token spend + ≈USD cost (daily)
-tokenix usage blocks          # rolling 5-hour billing blocks + burn rate
 ```
 
 ## Release
 
-Releases are automated via GitHub Actions (`.github/workflows/release.yml`). Pushing to `main` auto-creates a version tag and GitHub Release with pre-built binaries for Linux, macOS, and Windows.
-
-To trigger manually: push a commit to `main` — the workflow reads version from `Cargo.toml`.
+`feat:` / `fix:` / `perf:` on `main` auto-cuts a public GitHub release and bumps
+`Cargo.toml`. Use `test:` / `ci:` / `chore:` to avoid one. CI runs `cargo fmt`
+first, so an unformatted push fails before anything else. Never quote GitHub's
+auto-skip phrase in a commit body — it skips every workflow.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <div align="center">
   <img src=".github/prints/logo.jpg" alt="tokenix logo" style="max-height: 450px;" />
 
-  <p><strong>Local semantic search, symbol graphs, secrets scanning, output filters, and CLI hooks that save 60-90% LLM tokens.</strong></p>
+  <p><strong>Local semantic search, symbol graphs, secrets scanning, output filters, and CLI hooks for AI coding agents.</strong></p>
 
   <p>
     <a href="https://github.com/juninmd/tokenix/releases"><img src="https://img.shields.io/github/v/release/juninmd/tokenix?style=flat-square&color=orange&label=release" alt="Latest Release" /></a>
@@ -9,7 +9,6 @@
     <a href="https://crates.io/crates/tokenix"><img src="https://img.shields.io/crates/d/tokenix?style=flat-square&color=orange&label=downloads" alt="crates.io downloads" /></a>
     <a href="https://github.com/juninmd/tokenix/stargazers"><img src="https://img.shields.io/github/stars/juninmd/tokenix?style=flat-square&color=yellow" alt="GitHub stars" /></a>
     <a href="https://github.com/juninmd/tokenix/actions/workflows/rust.yml"><img src="https://img.shields.io/github/actions/workflow/status/juninmd/tokenix/rust.yml?branch=main&style=flat-square&label=CI" alt="CI" /></a>
-    <a href="https://github.com/juninmd/tokenix/actions/workflows/supply-chain.yml"><img src="https://img.shields.io/github/actions/workflow/status/juninmd/tokenix/supply-chain.yml?branch=main&style=flat-square&label=supply%20chain" alt="Supply Chain" /></a>
     <a href="https://scorecard.dev/viewer/?uri=github.com/juninmd/tokenix"><img src="https://img.shields.io/ossf-scorecard/github.com/juninmd/tokenix?style=flat-square&label=scorecard" alt="OpenSSF Scorecard" /></a>
     <a href="https://github.com/juninmd/tokenix/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue?style=flat-square" alt="License" /></a>
     <a href="https://www.rust-lang.org/"><img src="https://img.shields.io/badge/built%20with-Rust-orange?style=flat-square&logo=rust" alt="Built with Rust" /></a>
@@ -17,104 +16,66 @@
   </p>
 
   <p>
-    <a href="#-quick-install">Install</a> ·
-    <a href="#-homologation--does-it-actually-save">Proof</a> ·
-    <a href="#-interactive-dashboard">Dashboard</a> ·
-    <a href="#-how-it-works">How it Works</a> ·
-    <a href="#-usage">Usage</a> ·
+    <a href="#-install">Install</a> ·
+    <a href="#-what-we-measure-and-what-we-dont">What we measure</a> ·
+    <a href="#-dashboard">Dashboard</a> ·
     <a href="#-setup-by-tool">Setup</a> ·
-    <a href="#-commands-reference">Commands</a> ·
+    <a href="#-commands">Commands</a> ·
     <a href="CONTRIBUTING.md">Contributing</a>
   </p>
 </div>
 
 ---
 
-> **tokenix** is a local-first Rust CLI that helps AI coding agents understand a repository without dumping huge files into the prompt. It indexes your code, finds relevant chunks by meaning, returns compact file outlines, and can hook into AI tools to replace noisy reads and command output with smaller, more useful context. Works with Claude Code, GitHub Copilot, OpenAI Codex CLI, OpenCode, Gemini, and any MCP client. **No Ollama or external server required.**
+> **tokenix** is a local-first Rust CLI that helps AI coding agents understand a repository without dumping huge files into the prompt. It indexes your code, finds relevant chunks by meaning, returns compact file outlines, and hooks into AI tools to replace noisy reads and command output with smaller, more useful context. Works with Claude Code, GitHub Copilot, OpenAI Codex CLI, OpenCode, Antigravity, and any MCP client. **No Ollama, no Python, no external services.**
 
 ```
 Without tokenix:  Read(src/hook.rs)        → 1,518 lines → 13,498 tokens
-With tokenix:     tokenix read src/hook.rs → symbol outline →  2,395 tokens   (-82.3%)
+With tokenix:     tokenix read src/hook.rs → symbol outline →  2,395 tokens
 ```
 
-Those two numbers are measured, not illustrative — they come from `tokenix benchmark` run on this repository (see [Homologation](#-homologation--does-it-actually-save)). Savings depend on codebase size, AI behavior, and file sizes. Run `tokenix gain` to see measured Read and command-filter savings on *your* machine; semantic Grep context is logged as usage, not counted as saved tokens.
-
 ---
 
-## 🖥 Interactive Dashboard
+## 📏 What we measure — and what we don't
 
-Run bare `tokenix` to open a terminal dashboard — twelve tabs, zero flags. `←`/`→` switch tabs, `↑`/`↓` move, `q` quits. Piped or non-TTY falls back to `--help`.
+Most tools in this category advertise a savings percentage. We want to be precise
+about what ours means, because the distinction turns out to matter a great deal.
 
-**There is only one human interface.** Typing a report command on a terminal opens the dashboard on that command's tab instead of printing a second, separate rendering of the same data — `tokenix doctor` lands on Doctor, `tokenix usage model --all-projects` on Usage with that breakdown already selected, `tokenix scan-secrets` on Secrets, `tokenix filter list` on Studio. Everything scriptable is untouched: piping, `--json`, `--statusline`, `--format html|dot`, `--output <file>`, and any flag a tab cannot represent keep the plain text output, and `--no-tui` (or `TOKENIX_NO_TUI=1`) forces it explicitly. Agent-facing commands — `hook`, `run`, `mcp`, `query`, `read`, `pack`, … — never open a UI.
+**Everything below is a count of tokens removed from a payload before it reaches
+the model.** It is measured, reproducible, and it is *not* a claim about your
+bill.
 
-<table>
-<tr>
-<td width="50%"><img src=".github/prints/stats.png" alt="Stats tab" /><br /><sub><b>Stats</b> — wordmark, version, per-agent hook status, index summary, and one-key actions: <i>index repo</i> · <i>install hooks</i> · <i>install binary on PATH</i>.</sub></td>
-<td width="50%"><img src=".github/prints/gain.png" alt="Gain tab" /><br /><sub><b>Gain</b> — tokens saved with a reduction bar, split by source and by command/tool. <code>c</code> adds the ≈USD cost table · <code>a</code> all-projects · <code>r</code> refresh.</sub></td>
-</tr>
-<tr>
-<td colspan="2"><sub><b>Usage</b> — absolute token spend and ≈USD cost read from agent transcripts (the spend-side counterpart to Gain). <code>s</code> cycles the breakdown (daily · model · 5-hour blocks · project · session), <code>a</code> toggles this-repo vs all-projects, <code>r</code> refreshes. The active 5-hour block shows burn rate and a projected cost.</sub></td>
-</tr>
-<tr>
-<td colspan="2"><sub><b>Graph</b> — repo-wide symbol-graph overview: <i>god nodes</i> (most connected), <i>bottlenecks</i> (high fan-in / low fan-out), and <i>blast-radius leaders</i> (most transitive dependents). <code>r</code> refreshes.</sub></td>
-</tr>
-<tr>
-<td><img src=".github/prints/filters.png" alt="Filters tab" /><br /><sub><b>Filters</b> — browse all 528 bundled filters by tool with a live <i>input → output</i> preview and a per-filter <code>X → Y tokens · % saved</code> gauge.</sub></td>
-<td><img src=".github/prints/secrets.png" alt="Secrets tab" /><br /><sub><b>Secrets</b> — credentials leaked across agent transcripts, grouped by rule and attributed to repo + branch. Starts scoped to the current repo; <code>g</code> toggles all repos. <code>v</code> reveal · <code>c</code> copy · <code>x</code> redact.</sub></td>
-</tr>
-<tr>
-<td><img src=".github/prints/tokenmap.png" alt="Tokenmap tab" /><br /><sub><b>Tokenmap</b> — the repository as a tree weighted by token count, heaviest paths first.</sub></td>
-<td><img src=".github/prints/doctor.png" alt="Doctor tab" /><br /><sub><b>Doctor</b> — build/GPU support, detected GPU + CUDA/cuDNN status, active embedding model & cache, and bundled-filter inventory, all on one screen.</sub></td>
-</tr>
-<tr>
-<td colspan="2"><sub><b>Discover</b> — replays the current filter set over your agents' historical command output: savings you could have had, plus the uncovered commands wasting the most tokens. <code>r</code> refreshes.</sub></td>
-</tr>
-<tr>
-<td colspan="2"><sub><b>Audit</b> — MCP/tool weight of the effective system prompt per agent, plus always-on context (instruction files and skills). <code>r</code> refreshes.</sub></td>
-</tr>
-<tr>
-<td colspan="2"><sub><b>Egress</b> — external DNS/IP destinations found in agent transcripts, with local reputation validation: safe hosts green, dangerous hosts red, unknown hosts yellow. Three-pane style like Secrets: group · destination · occurrence detail. Starts scoped to the current repo; <code>g</code> toggles all repos. <code>s</code> rotates host/rule/agent/file grouping · <code>r</code> rescans.</sub></td>
-</tr>
-<tr>
-<td colspan="2"><sub><b>Studio</b> — record → preview → generate output filters without leaving the dashboard. The command list ranks the biggest <b>unfiltered token sinks</b> first (<code>⚠</code> + tokens wasted), marks commands that already have a filter (<code>✓</code>), and shows captured recordings (<code>●</code>) — so you always know what to filter next. <code>r</code> arms recording (capture needs the tokenix hook installed; run your commands in your agent, then come back), <code>s</code> stops. The right pane previews a recorded sample with a live <i>before → after</i> token delta when a filter matches. <code>g</code> generates a filter from the selected command (drops to the interactive <code>filter generate</code> flow, then returns) · <code>x</code> deletes a saved filter · <code>Tab</code> switches pane.</sub></td>
-</tr>
-</table>
-
----
-
-## What Is tokenix?
-
-AI coding agents often waste context on the wrong shape of information: entire files, long grep output, repeated build logs, and directory listings that are much larger than the useful signal inside them. tokenix is a context layer between the agent and your repository.
-
-It does four jobs:
-
-| Job | What tokenix does | Why it matters |
-|---|---|---|
-| **Index the repository** | Walks source files, splits them into symbol-aware chunks, and stores local embeddings in SQLite | The agent can search by intent instead of opening files blindly |
-| **Read files compactly** | Returns outlines, symbols, or line ranges instead of full files when possible | Large files stop consuming thousands of unnecessary tokens |
-| **Intercept assistant tools** | Hooks into supported tools before large reads and rewrites noisy command output | Optimization happens automatically during normal AI sessions |
-| **Measure savings** | Logs hook decisions and reports measured token/cost reduction where the original output is known | You can see whether it is actually helping on your codebase |
-
-tokenix is not a cloud service, not a vector database server, and not a replacement for your AI assistant. It is a local repository index plus a set of CLI and hook integrations that make the assistant's context smaller and more targeted.
-
----
-
-## 📊 Homologation — does it actually save?
-
-Every number below is reproducible from this repository with the command in the
-last column. Nothing here is an estimate.
-
-| What | Baseline → tokenix | Saved | Reproduce |
+| What | Baseline → tokenix | Tokens removed | Reproduce |
 |---|---|---|---|
-| **Real sessions** (7,807 hook calls) | 475,360 → 169,175 tokens | **67.4%** | `tokenix gain` |
-| Read interception, 31 real files | 346,892 → 58,154 tokens | **83.2%** | `tokenix benchmark` |
-| Task context vs reading the full file | 86,291 → 8,630 tokens | **90.0%** | `tokenix benchmark` |
-| Outline + targeted symbol workflow | 55,020 → 17,384 tokens | **68.4%** | `tokenix benchmark` |
-| Command filters, realistic verbose output | 1,891 → 369 tokens | **80.5%** | `cargo test verbose_real_output -- --nocapture` |
-| Command filters, full golden corpus (1,146 cases) | 47,237 → 27,836 tokens | **41.1%** | `cargo test filters_deliver_aggregate_token_savings -- --nocapture` |
+| Real sessions (7,807 hook calls) | 475,360 → 169,175 | **67.4%** | `tokenix gain` |
+| Read interception, 31 real files | 346,892 → 58,154 | **83.2%** | `tokenix benchmark` |
+| Task context vs reading the full file | 86,291 → 8,630 | **90.0%** | `tokenix benchmark` |
+| Outline + targeted symbol workflow | 55,020 → 17,384 | **68.4%** | `tokenix benchmark` |
+| Command filters, verbose output | 1,891 → 369 | **80.5%** | `cargo test verbose_real_output -- --nocapture` |
+| Command filters, full golden corpus (1,146 cases) | 47,237 → 27,836 | **41.1%** | `cargo test filters_deliver_aggregate_token_savings -- --nocapture` |
 
-**Quality is measured alongside the savings, not assumed.** Compression is worth
-nothing if the agent then answers wrong, so the same benchmark checks retrieval:
+### Why we don't convert those into a dollar figure
+
+Published work measuring *provider-billed* cost for hook-based compressors on
+Claude Code found that token reduction and cost reduction are close to
+uncorrelated ([arXiv:2607.12161](https://arxiv.org/abs/2607.12161), 2,848 paired
+runs): one arm removed 38.4% of tool-output tokens and billed **6.8% more**, with
+a per-task correlation of r = 0.15. The reason is that prompt-cache traffic
+dominates a real bill, so tokens removed from a fresh payload are not the tokens
+you are mostly paying for. An independent 425-trial study of a competing tool
+measured a **+7.6%** cost increase while that tool's own analytics reported 96
+million tokens saved.
+
+We have not yet measured tokenix against provider-billed cost. Until we have,
+this README will report tokens and call them tokens. Cache-aware cost accounting
+is the top item on the roadmap; see
+[`docs/research/2026-08-token-economy.md`](docs/research/2026-08-token-economy.md)
+for the full evidence review that led to this position.
+
+### Quality is measured alongside the savings
+
+Compression is worth nothing if the agent then answers wrong, so the same
+benchmark checks retrieval:
 
 | Check | Result |
 |---|---|
@@ -123,28 +84,65 @@ nothing if the agent then answers wrong, so the same benchmark checks retrieval:
 | Budgeted context still contained the expected file | **8/8**, 0 budget violations |
 | Golden filter cases reproducing byte-exact expected output | **1,146/1,146** |
 
-### Reading these numbers honestly
+### Reading the numbers honestly
 
-- **67.4% is the one that matters.** It is this machine's actual hook log —
-  7,807 real tool calls across real sessions — not a synthetic scenario.
-- **The 41.1% corpus figure is deliberately pessimistic.** Half the golden
-  corpus is failure-path cases that a filter must pass through *unfiltered*, so
-  errors are never masked as success. Filters are not supposed to compress
-  those. On realistic verbose output the same filters cut 80.5% (per-command:
-  `pip install` 97%, `npm install` 96%, `cargo test` 95%, `cargo build` 91%).
-- **`tokenix benchmark`'s own command arm reports a low ~26%** because its
-  sample commands emit trivial output (27–148 tokens each, and `npm`/`docker`
-  may not even be installed on the machine running it). Compression has nothing
-  to work with there. Judge the command filters by the two rows above instead.
-- **Semantic Grep is never counted as savings.** The native grep output is
-  unknown before interception, so `tokenix gain` logs it as neutral usage. The
-  reduction figure only counts cases where the original size is known.
-- Hardware/repo affect the numbers. Run the commands above on your own
-  repository — that is the point of shipping them.
+- **The 41.1% corpus figure is deliberately pessimistic.** Half the golden corpus
+  is failure-path cases a filter must pass through *unfiltered*, so errors are
+  never masked as success. Filters are not supposed to compress those.
+- **`tokenix benchmark`'s own command arm reports a low ~26%** because its sample
+  commands emit trivial output (27–148 tokens each). Compression has nothing to
+  work with there.
+- **Semantic Grep is never counted as savings.** The native grep output is unknown
+  before interception, so `tokenix gain` logs it as neutral usage.
+- **Savings depend on your codebase, file sizes, and agent behavior.** Run
+  `tokenix gain` to see measured numbers on your machine rather than ours.
 
 ---
 
-## ⚡ Quick Install
+## 🖥 Dashboard
+
+Run bare `tokenix` to open a terminal dashboard — twelve tabs, zero flags.
+`←`/`→` switch tabs, `↑`/`↓` move, `q` quits. Piped or non-TTY falls back to
+`--help`.
+
+**There is only one human interface.** Typing a report command on a terminal opens
+the dashboard on that command's tab instead of printing a second rendering of the
+same data — `tokenix doctor` lands on Doctor, `tokenix scan-secrets` on Secrets,
+`tokenix filter list` on Studio. Everything scriptable is untouched: piping,
+`--json`, `--statusline`, `--format`, `--output`, and any flag a tab cannot
+represent keep the plain text output. `--no-tui` (or `TOKENIX_NO_TUI=1`) forces it
+explicitly. Agent-facing commands — `hook`, `run`, `mcp`, `query`, `read`, `pack` —
+never open a UI.
+
+| Tab | What it shows |
+|---|---|
+| **Stats** | Version, per-agent hook status, index summary, and one-key actions: index repo · install hooks · install binary on PATH |
+| **Gain** | Tokens removed with a reduction bar, split by source and by command. `c` adds a ≈USD table at list input rates · `a` all-projects · `r` refresh |
+| **Usage** | Absolute token spend and ≈USD cost read from agent transcripts. `s` cycles daily · model · 5-hour blocks · project · session |
+| **Filters** | All 528 bundled filters by tool, with a live input → output preview and a per-filter token gauge |
+| **Studio** | Record → preview → generate filters. Ranks the biggest unfiltered token sinks first (`⚠`), marks filtered commands (`✓`) and recordings (`●`) |
+| **Secrets** | Credentials found in agent transcripts, grouped by rule, attributed to repo + branch. `v` reveal · `c` copy · `x` redact |
+| **Egress** | External DNS/IP destinations in transcripts, validated against local reputation lists |
+| **Graph** | Repo-wide symbol-graph overview: god nodes, bottlenecks, blast-radius leaders |
+| **Tokenmap** | The repository as a tree weighted by token count, heaviest paths first |
+| **Discover** | Replays the current filter set over historical agent output: savings you could have had, plus uncovered commands |
+| **Audit** | MCP/tool weight of the effective system prompt per agent, plus always-on instruction files and skills |
+| **Doctor** | Build/GPU support, detected GPU + CUDA/cuDNN status, active embedding model, bundled-filter inventory |
+
+<table>
+<tr>
+<td width="50%"><img src=".github/prints/stats.png" alt="Stats tab" /></td>
+<td width="50%"><img src=".github/prints/gain.png" alt="Gain tab" /></td>
+</tr>
+<tr>
+<td><img src=".github/prints/filters.png" alt="Filters tab" /></td>
+<td><img src=".github/prints/secrets.png" alt="Secrets tab" /></td>
+</tr>
+</table>
+
+---
+
+## ⚡ Install
 
 ### Pre-built binary (recommended)
 
@@ -164,415 +162,112 @@ so you never pin a version.
 Each release also publishes `sha256sums.txt` and SLSA build-provenance
 attestations — see [SECURITY.md](SECURITY.md) for how to verify a download.
 
-**macOS / Linux** — swap the asset for your platform from the table:
-
 ```bash
+# macOS / Linux — swap the asset for your platform
 curl -fsSL https://github.com/juninmd/tokenix/releases/latest/download/tokenix-linux-x86_64 -o tokenix
 chmod +x tokenix && sudo mv tokenix /usr/local/bin/tokenix
 tokenix doctor   # verify
 ```
 
-**Windows (PowerShell):**
-
 ```powershell
+# Windows
 irm https://github.com/juninmd/tokenix/releases/latest/download/tokenix-windows-x86_64.exe -OutFile tokenix.exe
 ```
 
-> **🤖 For AI agents / LLMs:** prefer this prebuilt binary over `cargo install` (no Rust
-> toolchain, no compile step). Always fetch the version-less URL
-> `https://github.com/juninmd/tokenix/releases/latest/download/tokenix-<platform>` — it
-> redirects to the latest release, so **never hard-code a version**. Detect the platform,
-> download the matching asset from the table, mark it executable, then run `tokenix doctor`
-> to confirm. The embedding model downloads automatically on first use.
+> **🤖 For AI agents / LLMs:** prefer the prebuilt binary over `cargo install` (no
+> Rust toolchain, no compile step). Always fetch the version-less URL — it
+> redirects to the latest release, so **never hard-code a version**. Detect the
+> platform, download the matching asset, mark it executable, then run
+> `tokenix doctor`. The embedding model downloads automatically on first use.
 
-### From crates.io
+### From crates.io or source
 
 ```bash
 cargo install tokenix --locked
 ```
 
-### From source
-
 ```bash
-git clone https://github.com/juninmd/tokenix
-cd tokenix
+git clone https://github.com/juninmd/tokenix && cd tokenix
 cargo install --path . --locked
 ```
 
-> **Use `--locked`.** It builds against the committed `Cargo.lock`; without it `cargo install` re-resolves dependencies and can pull an incompatible `ureq` into the `ort-sys` build script.
+> **Use `--locked`.** It builds against the committed `Cargo.lock`; without it
+> `cargo install` re-resolves dependencies and can pull an incompatible `ureq`
+> into the `ort-sys` build script.
 
-> **Requirements:** a recent stable [Rust](https://www.rust-lang.org/tools/install) toolchain (edition 2021). No Ollama, no Python, no external services.
+> **Requirements:** a recent stable [Rust](https://www.rust-lang.org/tools/install)
+> toolchain (edition 2021). The embedding model (`nomic-embed-text-v1.5`, ~130 MB)
+> is downloaded automatically on first use and cached locally.
 
-The embedding model (`nomic-embed-text-v1.5`, ~130 MB) is downloaded automatically on first use and cached locally.
+### Get started
 
----
-
-## ✨ Features
-
-| Feature | Description |
-|---|---|
-| **Semantic search** | Find relevant code by meaning, not just keywords (`tokenix query`); cross-project with `--link` |
-| **Context artifacts** | `tokenix artifacts` indexes non-code schemas, API docs, and specs via `.tokenix/artifacts.json` |
-| **Hybrid ranking** | FTS5 BM25 + vector cosine + RRF fusion for ranked results |
-| **Exact search** | Regex/literal search over indexed content, no embedding (`tokenix grep`) |
-| **One-call task context** | `tokenix context` combines semantic search, entry points, and compact outlines with strict budget modes (`plan`, `debug`, `audit`, `security`, `review`) |
-| **Graph-aware explore** | `tokenix explore` returns related symbols, relationship maps, and grouped source in one capped call |
-| **Repository pack** | `tokenix pack` emits a budgeted, secret-safe repo map with changed-file packs, token maps, and safety reporting. When the budget forces cuts, files are kept by *why they are there* (changed > semantic hit > filler) and then by PageRank centrality — never by filename order |
-| **Symbol graph** | `tokenix symbols` (`--kind` filters by symbol type), `callers`, `callees`, `impact`, `flow`, and `cycles` trace relationships, call-flow, and circular deps between indexed symbols |
-| **Import graph** | `tokenix deps FILE` shows file-level import dependencies (`--reverse` for importers, `--transitive` to follow the chain); external deps are tracked too |
-| **Int8-quantized embeddings** | Vectors are stored int8-quantized (4x smaller DB + daemon RAM, near-identical recall); legacy f32 indexes migrate automatically on the next `tokenix index` |
-| **JSON output** | `--json` on `query`, `context`, `explore`, `read`, `symbols`, `callers`, `callees`, `deps` (+ `impact --format json`) for scripts and agent pipelines |
-| **PC-friendly indexing** | `tokenix index` runs at below-normal OS priority by default so long index runs never starve the machine (`--no-low-priority` opts out) |
-| **Interactive HTML/Mermaid graphs** | `tokenix impact --format html\|mermaid` exports vis.js / Mermaid flowcharts; `tokenix flow --format mermaid` traces call flow |
-| **Repo graph overview** | `tokenix graph` ranks god nodes, bottlenecks, and blast-radius leaders across the whole symbol graph (`--format text\|dot\|json`, `--top N`) |
-| **Cycle detection** | `tokenix cycles` finds circular dependencies via Tarjan's strongly-connected components algorithm, dropping same-name (homonym) false positives and annotating each node with `path:line` |
-| **Token map** | `tokenix tokenmap` shows a directory tree with token counts per file/folder |
-| **Preference memory** | `tokenix memory add/list` stores global and project preferences in editable Markdown; context/explore include saved preferences |
-| **Dynamic language detection** | Map custom file extensions to any built-in parser via a project `.tokenix.toml` — no recompile needed |
-| **Legacy VB6 + SQL sources** | `.bas`/`.cls`/`.ctl`/`.frm`/`.vbp` and `.sql`/`.fnc`/`.trg`/`.pkg`/`.prc`/`.tab`/`.vw` indexed with symbol-aware heuristic chunking (`Sub`/`Function`/`Property`, `CREATE` objects); UTF-16 SQL files decoded via BOM; binary files (e.g. `.frx`) skipped by a NUL sniff |
-| **Symbol-aware chunking** | AST Tree-sitter parsers for Rust, Python, TypeScript, JavaScript, Go, C/C++ |
-| **Multi-agent safe index** | PID-based index lock prevents concurrent reindex; embeddings are committed per batch, so a killed index run resumes from the last completed batch |
-| **Smart file reader** | Outlines large files; supports `--symbol` and `--lines` reads, plus `--mode full\|outline\|signatures\|diff\|density:X` (signatures-only, changed-hunks, or entropy-filtered reads) |
-| **Hook-based interception** | `PreToolUse` intercepts large reads and rewrites noisy Bash **and PowerShell** commands before execution; thresholds tunable via `[hook]` in `.tokenix.toml` |
-| **Structural output compression** | Fuzzy grouping, compact `git`/`cargo` filters, NDJSON/JSON compaction, ANSI/Emoji stripping, and typed base64/data-URI blob redaction — single-line and line-wrapped (PEM certs/keys, MIME), embedded PNG/JPEG images, PDF/tar/binary dumps, also on non-shell/MCP results |
-| **Local project filters** | Drop `.toml` files in `.tokenix/filters/` for project-scoped compression rules — highest priority over user and bundled filters |
-| **Output filters** | 528 TOML output filters embedded in the binary (homologated against 1,146 embedded golden cases) — auto-applied to Bash/PowerShell output for `uv`, `cargo`, `terraform`, `ansible`, `docker`, `kubectl`, `git`, `npm`, `pnpm`, `bun`, `deno`, `vite`, `pip`, `poetry`, `go`, `rust`, `helm`, `apt`, `journalctl`, `trivy`, `semgrep`, `bazel`, `ctest`, `tox`, `conda`, `pulumi`, `dnf`/`yum`, `pacman`, `apk`, `pip-audit`, `ng test`, `bru`, `ps`, `cargo tree`, `npm ls`, `kubectl explain`, `lsof`, `ss`, `netstat`, `ip`, `systemctl list-*`, and more |
-| **Filter generation** | `tokenix filter generate` writes a TOML filter for a command; `tokenix filter record` captures real output for richer generation, with a per-command **token-economy preview** (raw→filtered tokens, % saved, compression bar) shown by `record stop`/`status` |
-| **GPU acceleration (opt-in)** | Build with `--features directml` (Windows) or `--features cuda` to run embeddings on GPU; GPU is used by default at runtime with automatic CPU fallback, or force CPU with `--only-cpu` |
-| **Environment diagnostics** | `tokenix doctor` reports the compiled backend, detected GPU, CUDA/cuDNN status, model cache, and daemon |
-| **Branch-aware indexing** | `TOKENIX_BRANCH_AWARE=true` isolates indexes per git branch |
-| **In-memory daemon** | `tokenix serve` keeps model + index in RAM so repeated hook calls avoid reloading the model each invocation; `tokenix daemon status\|stop\|restart` manages it |
-| **Graceful fallback** | Exits `0` on errors — your AI session is never broken |
-| **Token budget** | Results fit within a configurable token budget (default `1200`) |
-| **Savings analytics** | `tokenix gain` — token summary, savings split by source (semantic index vs command filters), and by-tool histogram; `--cost-estimate` adds a per-model cost table (10 reference models across Anthropic / OpenAI / Google) |
-| **Spend analytics** | `tokenix usage` — absolute token spend and ≈USD cost read from agent transcripts, by `daily\|weekly\|monthly\|session\|model\|project\|blocks`; rolling 5-hour blocks with burn rate, month-end forecast, `--cost-mode auto\|calculate\|display`, `--statusline`, and `--json` |
-| **Slim MCP profile** | `tokenix mcp --profile slim` exposes 3 meta-tools instead of the full tool surface for hosts that support progressive discovery |
-| **MCP/prompt weight audit** | `tokenix prompt-audit --recommend --profile-impact` connects to configured MCP servers, tokenizes tool schemas, weighs the always-on context (CLAUDE.md/AGENTS.md/copilot-instructions.md + the skill listing) and the on-invoke cost of heavy skills, and shows full-vs-slim MCP savings |
-| **Global output cap** | Every compressed output is bounded by a hard token ceiling (`TOKENIX_MAX_OUTPUT_TOKENS`, default `8000`) that also covers one-line giants and compacted JSON, plus repeated-*block* collapsing for watch/poll loops |
-| **Uncapped grep guard** | A lexical `Grep` asking for match content with no `head_limit` is rewritten with one (`TOKENIX_GREP_HEAD_LIMIT`, default `100`) instead of dumping every match into context |
-| **Reversible compression** | Every compressed run stashes its raw output content-addressed; `tokenix retrieve <key>` returns the exact bytes, so recovery is never a re-run |
-| **Cross-call dedup** | A successful command whose output is byte-identical to a recent call collapses to a one-line marker pointing at the earlier call and its stash key (`TOKENIX_DEDUP=0` to disable) |
-| **Re-read suppression** | Re-reading an unchanged file you already received in full is answered with a pointer instead of the file (`TOKENIX_READ_DEDUP=0`, TTL `TOKENIX_READ_DEDUP_TTL`) |
-| **MCP result compression** | `tokenix mcp-proxy -- <server cmd>` wraps any stdio MCP server and runs its tool results through the same pipeline (base64 redaction, JSON compaction, caps) — the only path that reaches MCP output, since hooks never see it |
-| **Session audit** | `tokenix session-audit --cache-hygiene` combines index freshness, hook history, MCP/tool weight, and prompt-cache stability risks |
-| **Conversation token-waste audit** | `tokenix conversation-audit` scans local Claude / Codex / Copilot / OpenAI histories for large assistant-visible blobs such as full reads, command logs, bootstrap prompts, connector JSON, images, patches, and task artifacts |
-| **Conversation secret scan** | `tokenix scan-secrets` — gitleaks-style credential scan of Claude / Gemini / Copilot / Antigravity conversation transcripts (no git); findings are always redacted, exits non-zero when any are found. Patterns live in TOML (`assets/secret-rules/`), extensible via `~/.tokenix/secret-rules/*.toml` or `<repo>/.tokenix/secret-rules/*.toml` |
-| **Conversation egress audit** | `tokenix egress-audit` — scans AI agent transcripts for external DNS/IP destinations, groups by host/rule/agent/file, validates host reputation from local safe/dangerous lists, and colors safe/dangerous/unknown hosts in the TUI |
-| **Local-first, no dependencies** | fastembed ONNX in-process — no Ollama, no server, no internet after first run |
-
----
-
-## 🔌 Supported AI Tools
-
-| Tool | Integration |
-|---|---|
-| [Claude Code](https://code.claude.com/docs) | `PreToolUse` hooks in `~/.claude/settings.json` or project `.claude/settings.local.json` |
-| [GitHub Copilot](https://docs.github.com/en/copilot) | `.github/copilot-instructions.md` + VS Code-compatible `.github/hooks/hooks.json` |
-| [OpenAI Codex CLI](https://developers.openai.com/codex/cli) | `~/.codex/hooks.json` for `PreToolUse` Bash rewrites + optional shell helpers |
-| OpenCode | `tokenix install-hook --tool opencode` — registers `tokenix mcp` in a native `opencode.json` `mcp` block |
-| Antigravity | `tokenix install-hook --tool antigravity` — installs and validates a native `PreToolUse` plugin through `agy plugin` |
-| Any MCP client | `tokenix mcp` — Model Context Protocol server over stdin/stdout (`--tool mcp`) |
-
----
-
-## 🚀 How It Works
-
-tokenix has two modes:
-
-1. **Manual mode**: run `tokenix query`, `tokenix read`, `tokenix context`, etc. directly when you want compact context.
-2. **Hook mode**: install hooks so supported AI tools call tokenix automatically before large reads and before noisy Bash commands execute.
-
-In hook mode you never type a tokenix command — the agent's own tool calls are intercepted before they run:
-
-```mermaid
-sequenceDiagram
-    autonumber
-    actor You
-    participant CC as Claude Code
-    participant TX as tokenix PreToolUse hook
-    participant Idx as Local SQLite index
-
-    You->>CC: "fix the login refresh bug"
-
-    CC->>TX: Read(src/auth/middleware.rs)
-    alt file ≥ 200 lines, no line range
-        TX->>Idx: symbol outline
-        TX-->>CC: outline instead of file (exit 2)
-    else small file or explicit --lines
-        TX-->>CC: pass through untouched (exit 0)
-    end
-
-    CC->>TX: Grep("how does refresh rotation work")
-    TX->>Idx: hybrid search (BM25 + int8 vectors + RRF)
-    TX-->>CC: ranked chunks inside the token budget
-
-    CC->>TX: Bash("cargo test")
-    TX-->>CC: rewritten to `tokenix run` → filtered output + stash key
-
-    CC-->>You: answer, built from less context
-
-    Note over You,TX: tokenix gain / the dashboard report what was actually saved;<br/>tokenix retrieve KEY returns any compressed output verbatim
+```bash
+tokenix index .          # index the repo
+tokenix install-hook     # wire up your agents
+tokenix                  # open the dashboard
 ```
 
-Every branch fails open: on a missing index, a parse error, or any internal failure the hook exits `0` and the original tool runs untouched.
+---
+
+## 🚀 How it works
+
+tokenix is a context layer between the agent and your repository. It does four
+jobs:
+
+| Job | What tokenix does | Why it matters |
+|---|---|---|
+| **Index the repository** | Walks source files, splits them into symbol-aware chunks, stores local embeddings in SQLite | The agent searches by intent instead of opening files blindly |
+| **Read files compactly** | Returns outlines, symbols, or line ranges instead of full files when possible | Large files stop consuming thousands of unnecessary tokens |
+| **Intercept assistant tools** | Hooks in before large reads and rewrites noisy command output | Optimization happens automatically during normal sessions |
+| **Measure** | Logs hook decisions and reports token reduction where the original is known | You can see whether it helps on your codebase |
+
+tokenix is not a cloud service, not a vector database server, and not a
+replacement for your AI assistant.
+
+### Interception
+
+The `PreToolUse` hook sees each tool call before it runs:
+
+- **Large file reads** → replaced with a symbol outline, with the full content
+  recoverable on demand.
+- **Semantic-looking Grep queries** → answered from the local index instead of a
+  literal scan.
+- **Noisy commands** → rewritten to run through `tokenix run`, which applies the
+  matching output filter.
+
+Everything else passes through untouched.
 
 ### Output compression
 
-tokenix includes structural output-filtering logic. It doesn't just truncate output; it understands the structure of common CLI tools.
+Command output is compressed **at write time** — before it enters the
+conversation — so an already-cached prefix is never rewritten. Filters are
+deterministic TOML rules, never a model. Engine guarantees:
 
-- **Fuzzy grouping:** collapses hundreds of `Compiling…` or `Removing…` lines into a single summary line.
-- **Structural compaction:** compacts pretty-printed JSON and NDJSON into single-line formats.
-- **Signal preservation:** keeps error messages and summaries even when the middle of a log is truncated.
-
----
-
-## 🛠 Usage
-
-### 1. Index your repository
-
-```bash
-cd my-project
-tokenix index .
-```
-
-> **First run:** the model (~130 MB) is downloaded automatically. Subsequent runs use the local cache.
-
-### 2. Search
-
-```bash
-tokenix query "how does JWT validation work"      # semantic
-tokenix query "database connection pooling" --budget 2000
-tokenix grep "fn validate_token" --ignore-case    # exact regex/literal
-```
-
-### 3. One-call task context
-
-```bash
-tokenix context "fix login refresh token bug"
-tokenix context "how does the indexer batch embeddings" --mode debug --budget 2000
-tokenix context "review this auth change" --mode review --budget 1200
-tokenix explore "run_hook hook_post compression" --budget 4000
-```
-
-### 4. Repository pack
-
-```bash
-tokenix pack --mode plan --budget 8000 --format markdown --token-map
-tokenix pack --mode review --changed --budget 4000
-tokenix pack --mode security --format json --output tokenix-security-pack.json
-```
-
-`pack` builds a stable repo map plus focused context for tools that cannot call
-tokenix directly. It respects the index, skips obvious secrets and build output,
-and supports `plan`, `debug`, `audit`, `security`, and `review` modes. Use
-`--changed` or `--since <ref>` for compact review packs.
-
-### 5. Smart file reader
-
-```bash
-tokenix read src/auth/middleware.rs                           # symbol outline
-tokenix read src/auth/middleware.rs --symbol validate_token   # targeted
-tokenix read src/auth/middleware.rs --lines 45-80             # line range
-tokenix read src/auth/middleware.rs --mode signatures         # signatures only
-tokenix read src/auth/middleware.rs --mode diff               # outline + changed hunks
-tokenix read src/auth/middleware.rs --mode density:40         # keep ~40% highest-entropy lines
-```
-
-### 6. Symbol graph & maps
-
-```bash
-tokenix symbols validate_token
-tokenix symbols Token --kind struct          # filter by symbol kind
-tokenix callers validate_token
-tokenix callees run_hook
-tokenix impact update_user --depth 2
-tokenix impact update_user --format html --output update_user.html   # vis.js graph
-tokenix deps src/indexer.rs                  # file-level import dependencies
-tokenix deps src/store.rs --reverse          # who imports this file
-tokenix deps src/daemon.rs --transitive      # follow the import chain
-tokenix graph                                # repo-wide hotspots / blast radius
-tokenix graph --format dot --top 20 -o graph.dot   # Graphviz of the top subgraph
-tokenix tokenmap                                                     # token tree
-tokenix rebuild-graph   # recompute relationships without re-embedding
-```
-
-Most retrieval commands accept `--json` for machine-readable output:
-
-```bash
-tokenix query "jwt validation" --json | jq '.[0].path'
-tokenix callers run_hook --json
-```
-
-### 7. Token savings analytics
-
-```bash
-tokenix gain                  # token summary + by-tool histogram
-tokenix gain --history        # include per-call history
-tokenix gain --cost-estimate  # add the per-model cost table
-tokenix usage                 # absolute spend (daily) + ≈USD cost
-tokenix usage model           # spend by model · also: weekly|monthly|session|project|blocks
-tokenix usage blocks          # rolling 5-hour billing blocks + burn rate
-tokenix usage --statusline    # compact one-liner for a status bar
-tokenix session-audit         # index + hook + MCP token-economy health
-```
-
-`tokenix gain` shows a `BY SOURCE` section splitting measured savings between
-large Read intercepts answered with outlines and command filters (Bash/PowerShell
-output compression), so you can see which half of tokenix is earning its keep.
-Semantic Grep intercepts can add useful indexed context, but the native grep
-output is not known before interception, so they are logged as neutral usage
-instead of claimed savings. `tokenix gain --cost-estimate` prices the savings
-against 10 reference models across Anthropic, OpenAI, and Google. Prices are
-shown with their collection date (currently `2026-06-11`) so the numbers stay
-auditable.
-
-### 8. Audit MCP / tool / context weight
-
-```bash
-tokenix prompt-audit                  # every agent with MCP config, instruction files or skills
-tokenix prompt-audit --agent claude   # one agent (claude|codex|copilot|opencode|antigravity)
-tokenix prompt-audit --json           # machine-readable
-tokenix prompt-audit --recommend      # include practical reduction advice
-tokenix conversation-audit            # scan agent histories for token-waste blobs
-tokenix conversation-audit --generate # + ready-to-run filter commands for the fixable waste
-tokenix conversation-audit --agent codex --json
-```
-
-Discovers the MCP servers configured for each agent, connects to each one live
-(`initialize` + `tools/list`), tokenizes the returned tool schemas, and warns
-when too many servers/tools inflate the effective system prompt. The base system
-prompt itself cannot be read by tools, so this is a **relative bloat estimate**:
-the native-tool baseline is approximate and HTTP/SSE servers are shown as
-`unknown`. Thresholds are overridable via `TOKENIX_AUDIT_WARN_TOKENS`,
-`TOKENIX_AUDIT_WARN_SERVERS`, and `TOKENIX_AUDIT_WARN_TOOLS`.
-
-MCP schemas are not the only variable weight, so the audit also measures the
-**context** an agent loads before doing anything:
-
-- instruction files (`CLAUDE.md`, `AGENTS.md`, `.github/copilot-instructions.md`)
-  — read in full on every session;
-- skills (`<repo>/.claude/skills`, `~/.claude/skills`, plugin `skills/` trees) —
-  their `name`+`description` entry is always on, and the whole `SKILL.md` body is
-  pulled in on invoke. Skills whose body exceeds ~5k tokens are listed with that
-  on-invoke cost so a heavy skill stops being invisible.
-
-Only the always-on part counts toward the per-agent total; skill bodies are
-reported separately so the estimate is not inflated by content that may never
-load.
-
-### Compressing MCP tool results
-
-`prompt-audit` measures what MCP *schemas* cost. The other half — what MCP tools
-*return* — is invisible to hooks: a PreToolUse hook fires on the agent's own
-tools (Read/Grep/Bash), never on an MCP server's response, and Claude Code
-installs no PostToolUse hook. A browser snapshot or an image-generation result
-therefore reaches the model at full price.
-
-Wrapping the server is the one path that reaches it:
-
-```jsonc
-// before
-{ "command": "npx", "args": ["-y", "some-mcp-server"] }
-
-// after — same server, results compressed on the way back
-{ "command": "tokenix",
-  "args": ["mcp-proxy", "--name", "some-mcp", "--", "npx", "-y", "some-mcp-server"] }
-```
-
-The proxy forwards JSON-RPC in both directions untouched and only rewrites the
-`text` blocks of `tools/call` results, through the same pipeline as shell output
-(base64/data-URI redaction first, then JSON compaction, repeat collapsing and
-the token cap). It never rewrites requests, never touches `tools/list` schemas
-(shrinking a tool description changes what the model believes the tool does),
-never touches `image` blocks (those are what your host renders), and leaves a
-block untouched when compression would not make it smaller. Savings are logged
-as `mcp:<name>` so `tokenix gain` prices them alongside everything else.
-`TOKENIX_MCP_PROXY=0` turns the rewriting off while leaving the proxy in place.
-
-For MCP hosts that support progressive discovery, run `tokenix mcp --profile slim`.
-The slim profile advertises only `tokenix_context`, `tokenix_search_tools`, and
-`tokenix_call`, reducing tool-schema tokens while preserving access to the full
-tokenix capability set through the meta-tool path.
-
-`tokenix conversation-audit` walks local Claude (`~/.claude/projects`), Codex
-(`~/.codex/sessions`), Copilot (`~/.copilot/session-state,logs` plus the VS Code
-Copilot chat store when present), and OpenAI (`~/.openai`) histories. It
-classifies the largest assistant-visible strings by waste scenario and reports
-the matching tokenix mitigation: add an output filter, use indexed file reads,
-trim hook payloads, slim MCP/tool schemas, or avoid replaying image/connector
-payloads into context.
-
-### 9. Benchmark
-
-```bash
-tokenix benchmark
-tokenix benchmark --json
-```
-
-`tokenix benchmark` measures tokenix against a plain **vanilla** baseline using
-the actual index/search code — no external tools involved. It reports read-only
-token reduction on large files, targeted outline+symbol workflows, semantic
-search Hit@1/Hit@3, context homologation (vanilla full file vs tokenix budgeted
-context), and command-output compression. Scenarios span Rust/TS/Go/Python,
-SQLite vector search, and common command output (cargo, git, npm, docker
-compose); misses are included as measured. Pass `--refresh-index` to re-embed
-first, `--cases FILE` for project-specific cases, and `--json` for a
-machine-readable summary.
-
-### 10. Scan conversations for exposed secrets
-
-```bash
-tokenix scan-secrets                          # all agents, redacted, exit 1 on hits
-tokenix scan-secrets --group value            # one block per distinct secret
-tokenix scan-secrets --group repo             # group by the repo it leaked from
-tokenix scan-secrets --filter telegram        # filter rule/agent/file/value/repo/branch
-tokenix scan-secrets --agent claude --json    # machine-readable
-tokenix scan-secrets --filter aws --reveal    # print raw values (warns on stderr)
-```
-
-Like `gitleaks --no-git`, but it walks each AI agent's **conversation transcripts**
-(Claude `~/.claude/projects`, Gemini `~/.gemini/tmp,history`, Copilot
-`~/.copilot/session-state,logs`, Antigravity `~/.gemini/antigravity`) for pasted
-credentials. Every finding is **redacted by default** and attributed to the
-**repository + git branch** it was exposed in (from each Claude message's
-`cwd`/`gitBranch`, falling back to the project directory). Detection patterns are
-TOML `[[rules]]` in `assets/secret-rules/`, extensible without a rebuild via
-`~/.tokenix/secret-rules/*.toml` or `<repo>/.tokenix/secret-rules/*.toml`.
-
-### 11. Audit outbound destinations in conversations
-
-```bash
-tokenix egress-audit                         # all agents, grouped by host
-tokenix egress-audit --group rule            # group by detection rule
-tokenix egress-audit --filter openai         # filter host/rule/agent/file
-tokenix egress-audit --safe                  # mark known-safe hosts
-tokenix egress-audit --agent claude --json   # machine-readable
-```
-
-This scans local AI agent transcripts for external DNS/IP destinations, so
-unexpected outbound domains pasted into sessions are visible without opening raw
-history files. The TUI Egress tab uses the same three-pane pattern as Secrets:
-group list, distinct destination list, and occurrence detail with agent, file,
-repo, and branch when known. Both the Secrets and Egress tabs open scoped to the
-current repository (cwd); press `g` to toggle a global view across all repos.
-
-Host reputation is local and explicit. Put trusted domains in
-`~/.tokenix/safe-hosts.toml` and suspicious domains in
-`~/.tokenix/dangerous-hosts.toml`; `www.` is ignored and subdomains inherit the
-parent verdict. The TUI paints safe hosts green, dangerous hosts red, and unknown
-hosts yellow. Example:
-
-```toml
-# ~/.tokenix/safe-hosts.toml
-safe = ["api.openai.com", "github.com"]
-
-# ~/.tokenix/dangerous-hosts.toml
-dangerous = ["example-malware.test"]
-```
+- **Failures are never masked.** A non-zero exit suppresses success sentinels, and
+  a filter that could empty a failure payload must preserve failure markers.
+- **Never worse.** A filtered result never costs more bytes than the raw output.
+- **Line endings are preserved.** CRLF input comes back CRLF, so content the agent
+  may quote into an exact-match edit still matches the bytes on disk.
+- **Repo-local filters are trust-gated.** `.tokenix/filters` is skipped until
+  `tokenix trust` pins its SHA-256, so a cloned repo cannot rewrite what the agent
+  sees.
 
 ---
 
-## 🔧 Setup by Tool
+## 🔌 Supported AI tools
+
+| Tool | Integration |
+|---|---|
+| **Claude Code** | Native `PreToolUse` hook |
+| **GitHub Copilot** | `.github/copilot-instructions.md` + `.github/hooks/hooks.json` |
+| **OpenAI Codex CLI** | Shell helpers (`tx-read`, `tx-query`); on Windows also `hooks.json` |
+| **OpenCode** | MCP server registration in `opencode.json` |
+| **Antigravity** | Native plugin with `toolCall` payload handling |
+| **Any MCP client** | `tokenix mcp` (`--profile slim` advertises a reduced tool surface) |
+
+---
+
+## 🔧 Setup by tool
 
 ### Claude Code
 
@@ -580,15 +275,16 @@ dangerous = ["example-malware.test"]
 tokenix install-hook --tool claude-code
 ```
 
-Writes a `PreToolUse` hook to `~/.claude/settings.json` (or `.claude/settings.local.json` with `--local`). Large reads, semantic greps, and noisy Bash commands are intercepted automatically — no changes to your prompts needed. `hook-post` (`PostToolUse`) remains a compatibility handler, not a default Claude install, because it cannot replace the original tool output.
+Writes a `PreToolUse` hook to `~/.claude/settings.json` (or
+`.claude/settings.local.json` with `--local`). Large reads, semantic greps, and
+noisy Bash commands are intercepted automatically — no prompt changes needed.
 
 ### GitHub Copilot
 
 ```bash
 cd my-project
 tokenix install-hook --tool copilot
-git add .github/
-git commit -m "chore: add tokenix context instructions"
+git add .github/ && git commit -m "chore: add tokenix context instructions"
 ```
 
 Creates `.github/copilot-instructions.md` and `.github/hooks/hooks.json`.
@@ -597,13 +293,14 @@ Creates `.github/copilot-instructions.md` and `.github/hooks/hooks.json`.
 
 ```bash
 tokenix install-hook --tool codex
-# bash / zsh
-echo 'source ~/.codex/tokenix-init.sh' >> ~/.bashrc
-# PowerShell
-echo '. ~/.codex/tokenix-init.ps1' >> $PROFILE
+echo 'source ~/.codex/tokenix-init.sh' >> ~/.bashrc   # bash / zsh
+echo '. ~/.codex/tokenix-init.ps1' >> $PROFILE        # PowerShell
 ```
 
-Then use `tx-read` and `tx-query` as shell helpers. On Windows this also installs `~/.codex/hooks.json` and a PowerShell wrapper that forwards `PreToolUse` intercepts for Bash-like terminal tools (`Bash`, `run_in_terminal`) and normalizes `grep_search` to the same semantic path as `Grep`.
+Then use `tx-read` and `tx-query` as shell helpers. On Windows this also installs
+`~/.codex/hooks.json` and a PowerShell wrapper that forwards `PreToolUse`
+intercepts for Bash-like terminal tools (`Bash`, `run_in_terminal`) and normalizes
+`grep_search` to the same semantic path as `Grep`.
 
 ### OpenCode
 
@@ -611,35 +308,21 @@ Then use `tx-read` and `tx-query` as shell helpers. On Windows this also install
 tokenix install-hook --tool opencode
 ```
 
-Writes a native `opencode.json` entry for `mcp.tokenix` in the current repository root:
-
-```json
-{
-  "mcp": {
-    "tokenix": {
-      "type": "local",
-      "command": ["tokenix", "mcp"]
-    }
-  }
-}
-```
-
-This integration is MCP-only. tokenix does **not** install OpenCode `experimental.hook` entries and does **not** emulate Claude-style `PreToolUse` / `PostToolUse` hooks in OpenCode. The generated config expects `tokenix` to be available on `PATH`; run `tokenix install-binary` first if needed.
+Writes an `mcp.tokenix` entry to `opencode.json` in the repository root. This
+integration is **MCP-only** — tokenix does not install OpenCode
+`experimental.hook` entries and does not emulate Claude-style hooks there. The
+config expects `tokenix` on `PATH`; run `tokenix install-binary` first if needed.
 
 ### Antigravity
 
 ```bash
 tokenix install-hook --tool antigravity
-# workspace-only:
-tokenix install-hook --tool antigravity --local
+tokenix install-hook --tool antigravity --local   # workspace-only
 ```
 
-Global installation uses `agy plugin install`, validates the result, and stores it under
+Global installation uses `agy plugin install` and stores the plugin under
 `~/.gemini/config/plugins/tokenix/`. Workspace installation writes
 `.agents/plugins/tokenix/` and validates it with `agy plugin validate`.
-The native hook handles Antigravity's `toolCall.name/args` payload and returns
-`decision: allow|deny`; Bash savings use a `PreToolUse` `overwrite`. Antigravity
-`PostToolUse` cannot replace tool output, so tokenix does not install a no-op post hook.
 
 ### All tools at once
 
@@ -647,16 +330,14 @@ The native hook handles Antigravity's `toolCall.name/args` payload and returns
 tokenix install-hook --tool all
 ```
 
-`--tool all` intentionally skips OpenCode. Use `tokenix install-hook --tool opencode` explicitly when you want tokenix to write a repo-local `opencode.json` MCP registration.
+`--tool all` intentionally skips OpenCode — request it explicitly when you want a
+repo-local `opencode.json` MCP registration.
 
 ---
 
-## 📖 Commands Reference
+## 📖 Commands
 
-> Run bare `tokenix` (or `tokenix --help`) for an audience-grouped
-> command catalog with examples. The reference below mirrors that grouping:
-> **AI agent commands** (the LLM/hooks drive these for token-lean retrieval) vs
-> **human commands** (setup, ops & analytics you run yourself).
+> Run bare `tokenix` (or `tokenix --help`) for the same catalog with examples.
 
 ### 🤖 AI agent commands
 
@@ -668,329 +349,211 @@ tokenix install-hook --tool all
 | `tokenix grep PATTERN` | Exact regex/literal search over indexed content (no embedding) |
 | `tokenix read FILE` | Smart reader — outline for large files, full for small (`--symbol`, `--lines`, `--mode full\|outline\|signatures\|diff\|density:X`) |
 | `tokenix symbols QUERY` | Find indexed symbols by name or path (`--kind` filters by symbol type) |
-| `tokenix callers SYMBOL` | Show symbols that call/reference a symbol |
-| `tokenix callees SYMBOL` | Show symbols called/referenced by a symbol |
+| `tokenix callers SYMBOL` | Symbols that call/reference a symbol |
+| `tokenix callees SYMBOL` | Symbols called/referenced by a symbol |
 | `tokenix deps FILE` | File-level import dependencies (`--reverse`, `--transitive`, `--json`) |
-| `tokenix impact SYMBOL` | Bidirectional impact graph (`--format html\|mermaid` for vis.js graph or Mermaid flowchart) |
-| `tokenix flow SYMBOL` | Forward call-flow trace from a symbol (`--depth`, `--format text\|mermaid`) |
-| `tokenix graph` | Repo-wide symbol-graph overview — god nodes, bottlenecks, blast-radius leaders (`--format text\|dot\|json`, `--top N`, `--output`) |
+| `tokenix impact SYMBOL` | Bidirectional impact graph (`--format html\|mermaid`) |
+| `tokenix flow SYMBOL` | Forward call-flow trace (`--depth`, `--format text\|mermaid`) |
+| `tokenix graph` | Repo-wide symbol-graph overview — god nodes, bottlenecks, blast-radius leaders (`--format text\|dot\|json`, `--top N`) |
 | `tokenix pack` | Budgeted repo pack for non-hook AI tools (`--mode/--profile`, `--changed`, `--token-map`) |
-| `tokenix memory add TEXT` | Save a preference (`--global` or `--project`) for future context |
-| `tokenix memory list` | List global and project preferences |
-| `tokenix memory remove TEXT` | Remove preferences matching text |
-| `tokenix memory edit TEXT` | Replace preferences matching text |
+| `tokenix memory add\|list\|remove\|edit` | Save preferences (`--global` / `--project`) for future context |
 
 ### 🧑 Human commands
 
 | Command | Description |
 |---|---|
-| `tokenix` (no args) | Open the [interactive dashboard](#-interactive-dashboard) — Stats · Filters · Studio · Gain · Usage · Doctor · Tokenmap · Graph · Discover · Audit · Secrets · Egress tabs; piped/non-TTY falls back to help |
-| `tokenix filter` (no args) | Open the dashboard on the Filters tab; piped falls back to `filter list` |
+| `tokenix` (no args) | Open the [dashboard](#-dashboard); piped/non-TTY falls back to help |
 | `tokenix index [PATH]` | Index the repo at PATH (default `.`) |
-| `tokenix install-hook` | Install assistant hook/instructions (default `--tool all`) |
-| `tokenix remove-hook` | Remove assistant hook/instructions (default `--tool all`) |
-| `tokenix install-binary` | Copy the running executable to a per-user global bin dir (`%LOCALAPPDATA%\tokenix\bin` on Windows, `~/.local/bin` on Linux/macOS) and ensure it is on PATH (Windows: user PATH updated automatically; Linux/macOS: prints the shell-profile line) |
-| `tokenix doctor` | Diagnose embedding backend, GPU availability, model cache, daemon, bundled filter inventory (filter + golden-case counts), active recording session, and user/local filter config (unknown `semantic_filter.model`, bad threshold) |
-| `tokenix serve` | Start the background embedding daemon (keeps model + index in RAM) |
-| `tokenix stop` | Stop the background daemon |
+| `tokenix install-hook` / `remove-hook` | Install or remove assistant hooks/instructions (default `--tool all`) |
+| `tokenix install-binary` | Copy the running executable to a per-user bin dir and ensure it is on PATH |
+| `tokenix doctor` | Diagnose embedding backend, GPU, model cache, daemon, filter inventory, and filter config |
+| `tokenix serve` / `stop` | Start or stop the background embedding daemon |
 | `tokenix daemon status\|stop\|restart` | Inspect (pid, port, uptime, model, cache RAM) or control the daemon |
-| `tokenix gain` | Token savings analytics with a by-source split — measured Read savings vs command filters; semantic Grep is neutral usage (`--cost-estimate` adds a per-model cost table; `--economics` prices savings against **your own** transcript spend mix instead of list prices) |
-| `tokenix discover` | Scan agent transcript history for missed savings: replays the current filters over historical command outputs — **measured**, not estimated — and ranks recoverable waste (filter exists, hook wasn't active) plus uncovered commands worth a new filter (`--agent`, `--top`, `--json`) |
-| `tokenix retrieve <key>` | Print the exact original output a compressed run stashed — the key comes from a `[tokenix: ...]` marker. Recovery without re-running the command |
-| `tokenix trust` / `untrust` | Approve (SHA-256 pinned) or revoke this repo's `.tokenix/filters` — repo-local filters are **skipped until trusted** so a cloned repo can't rewrite what the agent sees (`--status` shows state) |
-| `tokenix usage` | Absolute token spend + ≈USD cost from agent transcripts (`daily\|weekly\|monthly\|session\|model\|project\|blocks`, `--since/--until`, `--all-projects`, `--cost-mode`, `--statusline`, `--json`) |
+| `tokenix gain` | Tokens removed, split by source — Read interception vs command filters; semantic Grep counts as neutral usage (`--cost-estimate`, `--economics`) |
+| `tokenix discover` | Replay current filters over historical agent output — measured recoverable savings plus uncovered commands (`--agent`, `--top`, `--json`) |
+| `tokenix retrieve KEY` | Print the exact original output a compressed run stashed; the key comes from a `[tokenix: ...]` marker |
+| `tokenix trust` / `untrust` | Approve (SHA-256 pinned) or revoke this repo's `.tokenix/filters` (`--status`) |
+| `tokenix usage` | Absolute token spend + ≈USD from agent transcripts (`daily\|weekly\|monthly\|session\|model\|project\|blocks`, `--all-projects`, `--statusline`, `--json`) |
 | `tokenix stats` | Index statistics (files, chunks, tokens, age) |
-| `tokenix tokenmap` | Directory tree map with token counts, heaviest paths first, plus a top-10 files summary (`--format html` supported) |
-| `tokenix benchmark` | Reproducible token-savings and retrieval-quality benchmark — vanilla vs tokenix (`--json`) |
-| `tokenix filter list` | Show top Bash commands by tokens wasted (no filter yet) |
-| `tokenix filter active` | Show active user and bundled output filters |
-| `tokenix filter generate [CMD]` | AI-generate a TOML output filter for a command |
-| `tokenix filter record [CMD]` | Record real command output for richer filter generation |
-| `tokenix filter verify [NAME]` | Run the embedded `[[tests]]` golden cases of user/project filter files through the real pipeline from the installed binary (`--require-all` fails filters without tests) |
-| `tokenix prompt-audit` | Audit MCP/tool token weight across agents; warns on bloat (`--agent`, `--json`, `--recommend`, `--profile-impact`) |
-| `tokenix session-audit` | Token-economy health check: index, hook events, MCP/tool weight, cache hygiene |
-| `tokenix conversation-audit` | Scan local AI conversation histories for token-waste patterns (`--agent`, `--min-chars`, `--limit`, `--json`, `--generate`). `--generate` prints ready-to-run `tokenix filter generate` commands for unfiltered command-output waste, ranked by tokens |
-| `tokenix scan-secrets` | Scan AI agent conversation transcripts for exposed credentials, gitleaks-style; attributes each to its repo + git branch (`--agent`, `--filter`, `--group`, `--reveal`, `--json`) |
-| `tokenix egress-audit` | Scan AI agent conversation transcripts for external DNS/IP destinations and validate hosts against local safe/dangerous reputation lists (`--agent`, `--filter`, `--group`, `--safe`, `--json`) |
-| `tokenix artifacts list` | List context artifacts defined in `.tokenix/artifacts.json` |
-| `tokenix artifacts show NAME` | Show context artifact content |
-| `tokenix cycles` | Detect circular dependencies in the symbol graph using Tarjan's SCC algorithm |
+| `tokenix tokenmap` | Directory tree weighted by token count, heaviest paths first (`--format html`) |
+| `tokenix benchmark` | Reproducible token-reduction and retrieval-quality benchmark — vanilla vs tokenix (`--json`) |
+| `tokenix filter list\|active\|generate\|record\|verify` | Browse, generate, record, and golden-test output filters |
+| `tokenix prompt-audit` | Audit MCP/tool token weight across agents (`--agent`, `--recommend`, `--profile-impact`, `--json`) |
+| `tokenix session-audit` | Health check: index, hook events, MCP/tool weight, cache hygiene |
+| `tokenix conversation-audit` | Scan local conversation histories for token-waste patterns (`--generate` prints ready-to-run filter commands) |
+| `tokenix scan-secrets` | Scan agent transcripts for exposed credentials, gitleaks-style, attributed to repo + branch (`--group`, `--reveal`, `--json`) |
+| `tokenix egress-audit` | Scan agent transcripts for external DNS/IP destinations, validated against local reputation lists |
+| `tokenix artifacts list\|show` | Context artifacts from `.tokenix/artifacts.json` |
+| `tokenix cycles` | Detect circular dependencies (Tarjan's SCC) |
 | `tokenix rebuild-graph` | Rebuild graph tables from existing chunks without re-embedding |
 
-### ⚙ Internal (invoked by hooks/agents, not by hand)
+### ⚙ Internal (invoked by hooks, not by hand)
 
 | Command | Description |
 |---|---|
-| `tokenix hook` | `PreToolUse` handler — intercepts large reads, semantic grep, and noisy Bash/PowerShell commands (called by AI tools) |
-| `tokenix hook-post` | Legacy `PostToolUse` compatibility handler |
-| `tokenix run "CMD"` | Run a command and compress its output through tokenix filters (`--shell` re-executes under pwsh for the PowerShell path; `--path/-p` runs it in another directory) |
+| `tokenix hook` | `PreToolUse` handler — intercepts large reads, semantic grep, noisy commands |
+| `tokenix hook-post` | `PostToolUse` compatibility handler |
+| `tokenix run "CMD"` | Run a command and compress its output (`--shell`, `--path/-p`) |
 | `tokenix mcp` | MCP server exposing context, read/search, graph, and gain tools (`--profile slim\|full`) |
 
 <details>
 <summary>Selected flags</summary>
 
-**Global**
+**Global** — `--only-cpu` (force CPU embedding), `--no-tui` (plain text instead of
+the dashboard, same as `TOKENIX_NO_TUI=1`), `TOKENIX_BRANCH_AWARE=true` (suffix the
+SQLite DB per git branch), `TOKENIX_DISABLED=1` (bypass the hook for one command),
+`TOKENIX_MAX_OUTPUT_TOKENS` (global output ceiling, default 8000, `0` disables).
 
-| Flag | Description |
-|---|---|
-| `--only-cpu` | Force CPU embedding even on a GPU-enabled build (no-op on CPU-only builds) |
-| `--no-tui` | Print plain text instead of opening the dashboard (same as `TOKENIX_NO_TUI=1`) |
-| `TOKENIX_BRANCH_AWARE=true` | Env var: suffix SQLite DB per git branch (isolate indexes per branch) |
+**`tokenix index`** — `--force/-f`, `--cpu-profile <low|default|max>`, `--jobs N`,
+`--embed-batch N` (default 16 CPU / 64 GPU), `--if-stale`, `--path/-p`,
+`--model <id>`, `--no-low-priority` (indexing runs below-normal priority by
+default).
 
-**`tokenix index`** — `--force/-f`, `--cpu-profile <low\|default\|max>`, `--jobs N`, `--embed-batch N` (default 16 CPU / 64 GPU), `--if-stale`, `--path/-p`, `--model <id>`, `--no-low-priority` (indexing runs at below-normal OS priority by default; this flag or `TOKENIX_FOREGROUND=1` keeps normal priority)
+**Embedding model** — default `nomic-v1.5`. Select with `tokenix index --model <id>`
+or `TOKENIX_EMBED_MODEL=<id>`; `tokenix doctor` lists ids (`nomic-v1.5`,
+`bge-small`, `bge-base`, `minilm-l6`, `e5-small`, `jina-code`). The model is
+stamped into the index and read back at query time, so search always matches what
+was indexed. It is sticky across re-indexes; an explicit switch re-embeds.
+`nomic-v1.5` (768d) is the quality default, `bge-small` (384d) indexes faster,
+`e5-small` is multilingual, `jina-code` is code-specialized (custom ONNX
+downloaded on first use).
 
-**Embedding model** — default `nomic-v1.5`. Select another with `tokenix index --model <id>` or `TOKENIX_EMBED_MODEL=<id>`; run `tokenix doctor` to list available ids (`nomic-v1.5`, `bge-small`, `bge-base`, `minilm-l6`, `e5-small`, `jina-code`). The model is stamped into the index and read back at query time, so search always matches what was indexed; it is sticky across re-indexes and an explicit switch re-embeds. `nomic-v1.5` (768d) is the quality default; `bge-small` (384d) indexes faster; `e5-small` is multilingual; `jina-code` is code-specialized (a custom ONNX downloaded from Hugging Face on first use). Existing indexes keep working unchanged.
+**`tokenix query`** — `--budget/-b` (1200), `--k` (20), `--file/-f`, `--link`
+(cross-project, repeatable), `--json`, `--path/-p`
 
-**`tokenix query`** — `--budget/-b` (1200), `--k` (20), `--file/-f`, `--link` (cross-project, repeatable), `--json`, `--path/-p`
+**`tokenix context`** — `--mode <plan|debug|audit|security|review>`, `--budget/-b`
+(1200), `--max-files`, `--budget-breakdown`, `--json`, `--path/-p`
 
-**`tokenix symbols`** — `--limit/-l` (20), `--kind/-k <function\|struct\|class\|method\|...>`, `--json`, `--path/-p`
-
-**`tokenix deps`** — `--reverse` (files importing the target), `--transitive` (follow resolved imports), `--json`, `--path/-p`
+**`tokenix symbols`** — `--limit/-l` (20), `--kind/-k`, `--json`, `--path/-p`
 
 **`tokenix grep`** — `--limit/-l` (20), `--ignore-case/-i`, `--file/-f`, `--path/-p`
 
-**`tokenix context`** — `--mode <plan\|debug\|audit\|security\|review>`, `--budget/-b` (1200), `--max-files`, `--budget-breakdown`, `--json`, `--path/-p`
+**`tokenix deps`** — `--reverse`, `--transitive`, `--json`, `--path/-p`
 
-**`tokenix impact`** — `--depth/-d` (2), `--limit/-l` (50), `--format <text\|html\|mermaid\|json>`, `--output/-o` (write to a file; without it html/mermaid print to stdout), `--path/-p`
+**`tokenix impact`** — `--depth/-d` (2), `--limit/-l` (50),
+`--format <text|html|mermaid|json>`, `--output/-o`, `--path/-p`
 
-**`tokenix flow`** — `--depth/-d` (3), `--limit/-l` (50), `--format <text\|mermaid>`, `--path/-p`
+**`tokenix flow`** — `--depth/-d` (3), `--limit/-l` (50), `--format <text|mermaid>`
 
-**`tokenix install-hook` / `remove-hook`** — `--tool <claude-code\|copilot\|codex\|mcp\|opencode\|antigravity\|all>` (default `all`), `--local` (Claude Code, Copilot, and Antigravity)
+**`tokenix pack`** — `--mode/--profile <plan|debug|audit|security|review>`,
+`--budget N` (8000), `--format <markdown|xml|json>`, `--changed`, `--since REF`,
+`--token-map`, `--output/-o`
 
-**`tokenix pack`** — `--mode/--profile <plan\|debug\|audit\|security\|review>`, `--budget N` (8000), `--format <markdown\|xml\|json>`, `--changed`, `--since REF`, `--token-map`, `--output/-o`
+**`tokenix install-hook` / `remove-hook`** —
+`--tool <claude-code|copilot|codex|mcp|opencode|antigravity|all>` (default `all`),
+`--local`
+
+**`tokenix scan-secrets`** —
+`--agent <claude|gemini|copilot|antigravity|all>`, `--filter <substr>`,
+`--group <none|value|rule|agent|file|repo>`, `--reveal`, `--json`. Scans each
+agent's transcripts under `~`. Output is redacted by default; exit code is `1`
+when findings exist. Rules are TOML `[[rules]]` (`id`, `pattern`, optional
+`capture`/`min_entropy`): bundled defaults in `assets/secret-rules/`, extended by
+`<repo>/.tokenix/secret-rules/*.toml` then `~/.tokenix/secret-rules/*.toml` (later
+sources win on matching `id`).
+
+**`tokenix egress-audit`** — `--agent`, `--filter`, `--group <host|rule|agent|file>`,
+`--safe`, `--json`. Local reputation lists live in `~/.tokenix/safe-hosts.toml` and
+`~/.tokenix/dangerous-hosts.toml`.
+
+**`tokenix conversation-audit`** — `--agent`, `--min-chars N` (5000), `--limit N`
+(30), `--json`, `--generate`
+
+**`tokenix prompt-audit`** — `--agent`, `--json`, `--recommend`, `--profile-impact`
 
 **`tokenix benchmark`** — `--budget N` (1200), `--json`, `--refresh-index`, `--cases FILE`
-
-**`tokenix prompt-audit`** — `--agent <claude\|codex\|copilot\|opencode\|antigravity\|all>` (default `all`), `--json`, `--recommend`, `--profile-impact`
-
-**`tokenix session-audit`** — `--json`, `--cache-hygiene`, `--path/-p`
-
-**`tokenix conversation-audit`** — `--agent <claude\|codex\|copilot\|openai\|all>` (default `all`), `--min-chars N` (default `5000`), `--limit N` (default `30`), `--json`. Scans local conversation stores for token-waste patterns: full file reads, huge command/log outputs, bootstrap/system prompts, duplicated hook payloads, MCP/tool schemas, diff/test logs, task context blobs, image base64 payloads, connector JSON, build artifacts, provider signatures, documentation blobs, and oversized patches.
-
-**`tokenix scan-secrets`** — `--agent <claude\|gemini\|copilot\|antigravity\|all>` (default `all`), `--filter <substr>` (case-insensitive match over rule/agent/file/value/repo/branch), `--group <none\|value\|rule\|agent\|file\|repo>` (default `none`; `value` collapses each distinct secret into one block with its occurrence count, `repo` groups by the repository the secret was exposed in), `--reveal` (print raw values instead of redacting — warns on stderr), `--json`. Each finding is attributed to its **repository + git branch** when recoverable: Claude transcripts carry an exact `cwd`/`gitBranch` per message; otherwise the project directory is used as a best-effort `~slug:`/`~dir:` label. Scans each agent's conversation transcripts under `~` (Claude `~/.claude/projects`, Gemini `~/.gemini/tmp,history`, Copilot `~/.copilot/session-state,logs`, Antigravity `~/.gemini/antigravity`) for credential patterns; output is redacted by default and exit code is `1` when findings exist. Patterns are TOML `[[rules]]` (`id`, `pattern`, optional `capture`/`min_entropy`): bundled defaults in `assets/secret-rules/`, extended/overridden by `<repo>/.tokenix/secret-rules/*.toml` then `~/.tokenix/secret-rules/*.toml` (later sources win on matching `id`).
-
-**`tokenix mcp`** — `--profile <full\|slim>` (default `full`)
 
 </details>
 
 ---
 
-## 🧠 Supported Languages
+## 🔧 Output filters
 
-| Language | Extensions | Symbol types |
-|---|---|---|
-| Rust | `.rs` | `fn`, `struct`, `enum`, `impl`, `trait`, `mod` |
-| Python | `.py` | `def`, `async def`, `class` |
-| TypeScript | `.ts`, `.tsx` | `function`, `class`, `interface`, `type`, arrow functions |
-| JavaScript | `.js`, `.jsx`, `.mjs`, `.cjs` | `function`, `class`, arrow functions |
-| Go | `.go` | `func`, `type` |
-| C / C++ | `.c`, `.cpp`, `.h`, `.hpp`, `.cc`, `.cxx` | `function`, `class`, `struct`, `namespace` |
-| VB6 / VBA | `.bas`, `.cls`, `.ctl`, `.frm`, `.vbp` | `Sub`, `Function`, `Property` (line-scanning chunker, no grammar) |
-| SQL / Oracle | `.sql`, `.fnc`, `.trg`, `.pkg`, `.prc`, `.tab`, `.vw` | `CREATE [OR REPLACE] <object>` (line-scanning chunker; UTF-16 BOM handled) |
-| Config / Docs | `.toml`, `.md`, `.txt`, `.sh`, `.bash` | line blocks |
-| Data files (opt-in) | `.json`, `.yaml`, `.yml` | Indexed only when `data_files = true` in `.tokenix.toml` |
-| **Custom** | any extension | Mapped to an existing parser via `.tokenix.toml` |
-
-Languages without a symbol-aware chunker (Java, C#, Ruby, Swift, Kotlin, …) are not indexed by default — blind line-block chunking produces low-quality search results.
-
-### Custom language mapping
-
-Create a `.tokenix.toml` (or `tokenix.toml`) in the project root:
+528 bundled filters, 1,146 golden cases. A filter is a TOML file matching a
+command and shaping its output:
 
 ```toml
-[languages]
-pyi = "python"       # Python stub files
-mts = "typescript"   # TypeScript module files
-lua = "generic"      # use sliding-window chunks
+match_command = '^cargo test'
+strip_lines_matching = ['^\s*Compiling ', '^\s*Finished ']
+priority_lines = ['(?i)^error', '^test result:']
+tail_lines = 40
+on_empty = "cargo test: all tests passed"
+passthrough_when_emptied = true
+
+[[tests.all_pass]]
+input = """..."""
+expected = """cargo test: all tests passed"""
 ```
 
-Valid parser values: `rust`, `python`, `typescript`, `javascript`, `go`, `cpp`/`c`, `vb`/`vb6`/`vba`/`visualbasic`, `sql`/`plsql`/`tsql`, `generic`.
+Filters resolve in order: `<repo>/.tokenix/filters` (trust-gated) →
+`~/.tokenix/filters` → bundled. Every bundled filter ships **≥2 embedded golden
+cases**, enforced in CI along with never-mask-failure and no-inflation checks.
+`tokenix filter generate` drafts one from recorded output via a detected AI CLI;
+`tokenix filter verify` runs your own filters' golden cases through the real
+pipeline.
 
-### Hook tuning
-
-The same `.tokenix.toml` accepts a `[hook]` section to tune when the
-`PreToolUse` hook intercepts:
-
-```toml
-[hook]
-read_min_lines = 120   # outline files with >= this many lines (default 200)
-grep_min_words = 3     # treat Grep patterns with >= this many words as semantic (default 3; neutral in gain)
-```
-
-Lower `read_min_lines` to intercept more reads (saving more tokens); raise it
-when you prefer verbatim file content. The fail-open contract is unchanged —
-hook errors never break the session.
+Failed commands with clipped output tee the raw text to `~/.tokenix/tee/` with a
+`[full output: path]` hint (`TOKENIX_TEE=0` disables).
 
 ---
 
-## 🔧 Output Filters
+## 🧠 Supported languages
 
-tokenix reduces noisy shell output by rewriting matching `Bash` commands in `PreToolUse` so they run through `tokenix run` before the agent sees the result. Filtering happens in three layers (highest priority first):
+Rust, Python, JavaScript, TypeScript, Go, Java, C, C++, C#, Ruby, PHP, Kotlin,
+Swift, Scala, Bash, PowerShell, SQL, HTML, CSS, Markdown, JSON, YAML, TOML.
 
-1. **Local project filters** — `.toml` files in `.tokenix/filters/` inside the repo. Scoped to the project, committed to version control. **Trust-gated**: skipped until you approve them with `tokenix trust` (SHA-256 pinned; any edit revokes trust) — a cloned repository must not silently control what your agent sees.
-2. **User filters** — `.toml` files in `~/.tokenix/filters/`. Apply to all projects, override bundled filters.
-Filter resolution is lazy: the hook reads each file's `match_command` literal off the raw text and only parses the TOML of files whose literal can appear in the command at hand. User filters keep their prefilters in `~/.tokenix/filters/.prefilter-index.json`, rebuilt automatically whenever a filter file is added, edited, or removed. This is what keeps a `PreToolUse` rewrite decision at a few milliseconds even with hundreds of filters installed.
-
-3. **Bundled filters** — 528 TOML output filters shipped inside the binary (each homologated against 1146 embedded golden cases), covering `uv`, `cargo build`/`cargo run`/`cargo audit`, `git`, `gradle`, `terraform plan`, `make`, `npm`/`npm audit`, `pnpm`, `bun`, `deno`, `vite`, `node --test`, `poetry`, `docker`, `kubectl`/`kubectl top`, `helm`, `go`, `rust`, `python`, `dotnet`, `swift`, `apt`/`apt-get`, `journalctl`, `trivy`, `semgrep`, `bazel`, `ctest`, `tox`, `conda`/`mamba`, `pulumi up`/`preview`/`destroy`, `dnf`/`yum`, `pacman`, `apk`, `pip-audit`, `ng test` (Karma), `bru` (Bruno), `ps`, and more. Applied automatically — no setup needed.
-
-### Filter format
-
-```toml
-[filters.uv-sync]
-description = "Compact uv sync output"
-match_command = "^uv\\s+(sync|pip\\s+install)\\b"
-strip_ansi = true
-strip_lines_matching = ["^\\s*$", "^\\s+Downloading ", "^\\s+Using cached "]
-match_output = [
-  { pattern = "Audited \\d+ package", message = "ok (up to date)" },
-]
-max_lines = 20
-on_empty = "uv: ok"
-```
-
-| Field | Description |
-|---|---|
-| `match_command` | Rust regex matched against the command. Compound commands are split (quote-aware) on `&&`, `\|\|`, `;`, and `\|`, and each segment is matched independently, so anchoring on the base command (e.g. `^gitleaks\b`) still matches `cd repo && gitleaks`, `cd repo;gitleaks`, or `producer \| gitleaks` |
-| `strip_ansi` | Remove ANSI colour codes before filtering |
-| `strip_lines_matching` | Drop lines matching any of these regex patterns |
-| `keep_lines_matching` | Keep only lines matching these patterns |
-| `match_output` | Short-circuit: if output matches `pattern`, return `message` immediately; use `unless` for error/warning guards |
-| `uniform_success` | Whole-run summary for tools that report **per item** (`PASS - x`, `ok 1 - t`, `[200] url`). Collapses only when *every* significant line matches `pattern` and at least one did, so a single failed item leaves the real output in place. `{n}` in `message` becomes the item count — `conftest: 3 policies passed`, not a vague "all clear". `ignore_lines` skips banners/totals |
-| `max_lines` / `head_lines` / `tail_lines` | Truncate output. `head_lines` + `tail_lines` together keep a first+last window (header/context on top, verdict at the bottom) with an inline `[... N lines omitted ...]` marker in the middle |
-| `priority_lines` | Lines matching these regexes survive **every** sizing cut, even beyond the line budget — for verdict lines that must never be clipped (error summaries, totals) |
-| `category_caps` | `[{ pattern, max }]`: keep only the first `max` lines per category, collapsing the overflow into one count marker — bounds repetitive classes independently (e.g. 20 errors + 5 warnings) instead of a flat positional cut |
-| `on_failure` | Policy when the command exited nonzero: `"passthrough"` emits the raw output untouched, `"tail:N"` the last N raw lines. Even without it, success sentinels (`match_output`, `on_empty`) are suppressed on failure |
-| `truncate_lines_at` | Truncate individual lines at N characters |
-| `on_empty` | Message to return when filtering produces empty output. **Never emitted if the original output carries a generic failure signal** (`error`/`fatal`/`panic`/`FAILED`/`exit code N`…) — the engine falls back to a bounded view of the real output so a failed command is never masked as success, even when its error format isn't recognized by `keep_lines_matching` |
-| `passthrough_when_emptied` | When the filter reduces *non-empty* output to nothing (an unexpected output shape the keep/extract rules don't recognize), show a bounded view of the real output instead of `on_empty` — so format-specific filters never report a false "nothing here" (e.g. `git log --oneline` against the full-log filter) |
-| `filter_stderr` | Opt in to applying this command-specific filter to stderr. Without it, stderr uses generic safe compression so command errors are not turned into success sentinels |
-
-Engine invariants:
-- **Never worse** — a filter never makes output more expensive than the raw it replaces. If the filtered result (including any sentinel message or truncation notice) would cost more bytes than the raw output, the engine emits the raw output instead.
-- **Exit-code aware** — `tokenix run` passes the command's real exit status into filtering: on nonzero exit, success sentinels are suppressed (text heuristics alone miss quiet failures) and the filter's `on_failure` policy applies.
-- **Failure signal beats every sentinel** — `match_output` and `uniform_success` are also suppressed when the raw output carries a generic failure signal, even if the exit status is unknown (the PostToolUse/audit paths never see one). A filter's `unless` guard refines that; it is not the only thing preventing a failed run from reading as success. An `unless` regex that fails to compile fails *closed* — the sentinel is skipped rather than silently unguarded.
-- **Source precedence** — local filters beat user filters beat bundled ones. Within a source, the longest (most specific) `match_command` wins; a long bundled pattern can no longer outrank the user filter meant to override it.
-- **Failure tee** — when a failed command's compressed view dropped content, the full raw output is saved under `~/.tokenix/tee/` (20 files, 1 MB cap, disable with `TOKENIX_TEE=0`) and the output ends with `[full output: <path>]`, so recovery is a targeted Read instead of a full re-run.
-- **Fail loudly** — filter files reject unknown fields (a typo'd key prints a warning instead of silently disabling the filter). Validate your own filters anytime with `tokenix filter verify`.
-- **Escape hatch** — prefix any command with `TOKENIX_DISABLED=1` to skip the rewrite for that command only. Bypasses are logged and `tokenix gain` warns when ≥10% of commands dodge the filter.
-- **Hard output ceiling** — after every filter and heuristic, compressed output is clipped to `TOKENIX_MAX_OUTPUT_TOKENS` (default `8000`, `0` disables) keeping a head and tail window. This is the backstop for shapes the line-based caps cannot see: a single megabyte-long line, or a huge payload that `compact_json` shrank by only a few percent.
-- **Repeated blocks** — a multi-line stanza repeated 3+ times in a row (watch/poll loops, retry banners) is kept once and annotated `[block of N lines repeated Kx]`, alongside the existing identical-line collapsing.
-- **Identifiers survive truncation** — commit SHAs, UUIDs, URLs and error codes found in a range the output cap dropped are carried into the marker (`[ids kept from the omitted range: ...]`). Everything else that is dropped is re-derivable; those are not.
-- **Reversible** — every compressed run stashes its raw output under a content hash in `~/.tokenix/blobs/`. Markers carry the key, and `tokenix retrieve <key>` prints the exact original, so a compression that dropped the one line you needed costs a cheap lookup instead of a re-run.
-- **Cross-call dedup** — when a *successful* command produces output byte-identical to a recent call, it collapses to `[tokenix: output identical to \`<cmd>\` from 4m ago … run \`tokenix retrieve <key>\`]`. Failures are never deduped: a repeated error still needs its text in front of the model. Disable with `TOKENIX_DEDUP=0`, tune with `TOKENIX_DEDUP_MIN_TOKENS` (default 200).
-
-### AI-assisted filter generation
-
-```bash
-tokenix filter list                  # commands wasting the most tokens (no filter yet)
-tokenix filter active                # all active user + bundled filters
-tokenix filter record "cargo test"   # capture real output for richer generation
-tokenix filter generate "cargo test" # generate a TOML filter via a local AI CLI
-```
+Symbol-aware chunking and the reference graph use tree-sitter where a grammar is
+available; other files are chunked by structure. Add a custom extension →
+language mapping in `.tokenix.toml`.
 
 ---
 
 ## 🏗 Architecture
 
 ```
-src/
-├── main.rs        CLI entry (clap), command dispatch, install-hook helpers
-├── chunker.rs     Symbol-aware AST chunking (Tree-sitter) + dynamic language config (.tokenix.toml)
-├── embed.rs       fastembed ONNX: embed_documents(), embed_query() — optional GPU via ort features
-├── store.rs       SQLite schema, CRUD, FTS5, hybrid search, incremental branch fingerprint check
-├── indexer.rs     File walker + incremental index pipeline (parallel chunking + batch embedding)
-├── query.rs       Hybrid semantic + sparse FTS5 ranking, strict context modes, token-budget selection
-├── pack.rs        Budgeted repo pack generation for non-hook AI tools, changed packs, token maps
-├── graph.rs       Symbol relationship graph, cycle detection (Tarjan's SCC), HTML/Mermaid export
-├── artifacts.rs   Context artifacts — parse `.tokenix/artifacts.json`, read non-code content
-├── hook.rs        PreToolUse handler — Claude-, Copilot-, and grep_search/run_in_terminal-style JSON input
-├── daemon.rs      Background TCP server — holds model + in-memory embedding cache
-├── compress.rs    Output compression for `tokenix run` + legacy PostToolUse pipeline
-├── filters.rs     FilterDef, local/user/bundled loading, prefilter index, apply_filter()
-├── cmd_filter.rs  `tokenix filter` subcommands (list, active, generate, record, verify)
-├── recordings.rs  Capture/replay real command output for filter generation
-├── recall.rs      Content-addressed stash, cross-call dedup, re-read suppression
-├── discover.rs    Replays current filters over transcript history (missed savings)
-├── memory.rs      Global/project preference memory (editable Markdown)
-├── gain.rs        Analytics from the hook log — per-model cost table
-├── usage.rs       Absolute spend + ≈USD from agent transcripts
-├── transcripts.rs Shared enumeration of local agent transcript files
-├── benchmark.rs   Reproducible savings + retrieval-quality benchmark
-├── doctor.rs      Backend / GPU / model-cache / daemon diagnostics
-├── tui.rs         The interactive dashboard — the only human-facing interface
-├── ui.rs          Shared terminal vocabulary for plain CLI output (boxes, tables, bars)
-├── secrets_scan.rs Credential scan over agent conversation transcripts
-├── egress_scan.rs  External DNS/IP destinations found in those transcripts
-├── conversation_audit.rs  Token-waste classification of local AI histories
-├── mcp.rs         Model Context Protocol server (full and slim profiles)
-└── mcp_audit.rs   Multi-agent MCP config discovery + live tools/list introspection (prompt/session audit)
-
-assets/
-└── filters/       528 TOML output filters (+1146 golden cases), embedded in the binary via rust-embed
+┌─────────────┐   PreToolUse    ┌──────────────┐
+│  AI agent   │ ──────────────▶ │ tokenix hook │
+└─────────────┘                 └──────┬───────┘
+                                       │
+                    ┌──────────────────┼──────────────────┐
+                    ▼                  ▼                  ▼
+             ┌────────────┐     ┌────────────┐     ┌────────────┐
+             │ SQLite     │     │  Symbol    │     │  Output    │
+             │ index +    │     │  graph +   │     │  filters   │
+             │ embeddings │     │  PageRank  │     │  (TOML)    │
+             └────────────┘     └────────────┘     └────────────┘
 ```
 
-### GPU acceleration (opt-in)
-
-A default build runs embeddings on CPU. Compile with a GPU feature to use the GPU — it then becomes the **default at runtime, with automatic CPU fallback** if the provider is unavailable:
-
-```bash
-# Windows — DirectML (works with any D3D12-capable GPU, no CUDA toolkit required)
-cargo install --path . --features directml --locked
-
-# Linux / Windows — CUDA (needs CUDA 12.x + cuDNN 9.x installed and on PATH;
-# ort rc.9 does not support CUDA 13 yet)
-cargo install --path . --features cuda --locked
-```
-
-On a GPU build, force CPU per-invocation with the global `--only-cpu` flag:
-
-```bash
-tokenix index .              # uses the GPU
-tokenix --only-cpu index .   # forces CPU on a GPU build
-```
-
-`--embed-batch` drives peak memory (default 16 on CPU, 64 on GPU) — lower it if RAM/VRAM is tight. Run `tokenix doctor` to see the compiled backend, detected GPU, CUDA/cuDNN status, and tailored recommendations.
-
-### Daemon
-
-The background daemon (`tokenix serve`) keeps the ONNX model and project embeddings in RAM (int8-quantized — 4x less memory than f32). Hook calls route over TCP loopback instead of re-loading the model on each subprocess invocation, and it auto-starts on the first Grep hook call — you don't need to run it manually. Manage it with `tokenix daemon status` (pid, port, uptime, model, cache size), `tokenix daemon stop`, and `tokenix daemon restart`.
-
-### Embedding model
-
-| Property | Value |
-|---|---|
-| Model | `nomic-embed-text-v1.5` (quantized) |
-| Dimensions | 768 |
-| File size | ~130 MB |
-| Cache location | `<OS cache dir>/tokenix/models` — `%LOCALAPPDATA%\tokenix\models` (Windows), `~/.cache/tokenix/models` (Linux), `~/Library/Caches/tokenix/models` (macOS) |
-| Download | Automatic on first run |
-| Runtime | fastembed (ONNX Runtime, in-process) |
-
-Index storage lives at `~/.tokenix/<project-id>.db` (one DB per project). Embeddings are stored as **int8-quantized** blobs (4x smaller than f32, near-identical recall — the per-vector scale cancels out of the cosine) and similarity is computed in Rust — no external vector database needed. Indexes created before quantization migrate automatically (re-encode only, no re-embedding) on the next `tokenix index`; `tokenix doctor` reports migration coverage.
+- **Storage** — one SQLite DB per project under `~/.tokenix/`, int8-quantized
+  embeddings, FTS5 for lexical search.
+- **Embeddings** — in-process ONNX via `fastembed`. No daemon required; if
+  `tokenix serve` is running it keeps the model in RAM and answers over a local
+  socket, otherwise the hook embeds in-process.
+- **GPU (opt-in)** — DirectML on Windows, CUDA 12.x + cuDNN 9.x on Linux/Windows.
+  `tokenix doctor` reports what is detected.
 
 ---
 
 ## 🔒 Security
 
-tokenix's build and release pipeline is hardened against supply-chain attacks:
-SHA-pinned GitHub Actions, least-privilege workflow permissions, `cargo-deny`
-(advisories + license + crates.io-only sources), `zizmor` workflow analysis,
-OpenSSF Scorecard, and SLSA build-provenance attestations. The release workflow
-publishes to crates.io through OIDC Trusted Publishing when the crate has it
-configured, and falls back to a repository secret otherwise. See
-[SECURITY.md](SECURITY.md) for the disclosure policy and release-verification
-steps.
+- **Everything is local.** No code, prompt, or transcript leaves your machine. The
+  only network access is the one-time embedding-model download.
+- **Repo-local filters are untrusted by default** and skipped until `tokenix trust`
+  pins their SHA-256 — a cloned repository cannot silently rewrite what your agent
+  sees.
+- **Secrets are never indexed.** `.env`, `.pem`, and similar files are excluded,
+  and `tokenix scan-secrets` redacts by default.
+- **Supply chain** — releases publish `sha256sums.txt` and SLSA provenance;
+  workflows are SHA-pinned and covered by `cargo-deny`, `zizmor`, and OpenSSF
+  Scorecard. See [SECURITY.md](SECURITY.md).
 
 ---
 
 ## 🤝 Contributing
 
-Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for how to get started.
-
----
+See [CONTRIBUTING.md](CONTRIBUTING.md). New filters need ≥2 golden cases;
+`AGENTS.md` documents the engine invariants a filter must not break.
 
 ## 📄 License
 
-[MIT](LICENSE)
-
-<!-- GitHub Topics: rust cli llm token-optimization semantic-search embeddings fastembed onnx claude-code copilot ai-tools code-assistant developer-tools no-ollama -->
+MIT — see [LICENSE](LICENSE).

--- a/assets/secret-rules/default.toml
+++ b/assets/secret-rules/default.toml
@@ -286,19 +286,28 @@ pattern = '\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\b'
 # Credentials embedded in a URL or DB connection string — redact the password.
 # Scheme is restricted to credential-bearing protocols to avoid matching arbitrary
 # `foo://a:b@c` strings that appear in prose/logs.
-[[rules]]
-id = "basic-auth-url"
 # Password class allows `@` and `%` (both legal, and common in pasted
 # credentials); the greedy run plus the trailing `@[^\s/@]+` host makes the match
 # split on the LAST `@`, the way URL parsers do. Excluding them meant
 # `https://user:p@ss@host` matched nothing at all.
-pattern = '(?i)(?:https?|ftps?|smtps?|ldaps?)://[^\s/:@]{1,64}:([^\s/:${}<>]{5,63})@[^\s/@]+'
+#
+# Entropy floors here are bounded by string length: Shannon entropy over the
+# observed distribution maxes out at log2(n) for an n-char string, so a
+# threshold above log2(min_match_len) can NEVER be reached and silently kills
+# the rule for short passwords. The old pair (`{5,63}` @ 3.5) needed 12+ chars
+# and (`{4,}` @ 2.8) needed 7+, so 5-11 and 4-6 char passwords were unreportable
+# by arithmetic rather than by choice. Both now sit at 2.8 with a matching 7-char
+# floor: reachable at the shortest match, and still below `password`/`changeme`
+# (both ~2.75), which stay rejected.
+[[rules]]
+id = "basic-auth-url"
+pattern = '(?i)(?:https?|ftps?|smtps?|ldaps?)://[^\s/:@]{1,64}:([^\s/:${}<>]{7,63})@[^\s/@]+'
 capture = 1
-min_entropy = 3.5
+min_entropy = 2.8
 
 [[rules]]
 id = "db-connection-uri"
-pattern = '(?i)(?:postgres(?:ql)?|mysql|mongodb(?:\+srv)?|redis|amqp)://[^\s:@/]+:([^\s:/${}<>]{4,})@[^\s/@]+'
+pattern = '(?i)(?:postgres(?:ql)?|mysql|mongodb(?:\+srv)?|redis|amqp)://[^\s:@/]+:([^\s:/${}<>]{7,})@[^\s/@]+'
 capture = 1
 min_entropy = 2.8
 

--- a/docs/research/2026-08-token-economy.md
+++ b/docs/research/2026-08-token-economy.md
@@ -1,0 +1,692 @@
+# Token Economy Research — August 2026
+
+Market and literature review positioning `tokenix` (baseline: v0.62.0) against the
+GitHub ecosystem and the 2026 research on token economy for coding agents.
+
+**Thesis:** the whole market crowded into *retrieval*. The literature says the
+biggest share of an agent's tokens is *observation* — command output, logs, stack
+traces. That is where tokenix already lives and where almost nobody else is.
+
+> Status: pass 1 (single-researcher sweep). A five-lane deep sweep is appended in
+> [Deep sweep](#deep-sweep-pass-2) below.
+
+---
+
+## 1. Landscape
+
+Consolidated from third-party comparisons and project pages. Star counts and
+claimed savings were **not** reproduced locally — treat as order of magnitude.
+
+| Project | Stars | Approach | Layer | Claimed saving |
+|---|---:|---|---|---|
+| CodeGraph | 47.4k | AST graph in SQLite | Retrieval | 58–70% fewer tool calls |
+| GitNexus | 42.0k | Graph (LadybugDB) | Retrieval | 74% tokens, 88% fewer calls |
+| Repomix | 26.2k | Packing + tree-sitter | Retrieval | ~70% via compression |
+| Serena | 25.2k | LSP / symbol navigation | Retrieval | not measured |
+| Context Hub | 13.6k | Documentation packing | Retrieval | not measured |
+| claude-context | 11.8k | Embedding + BM25 | Retrieval | not measured |
+| code2prompt | 7.4k | Packing (Rust) | Retrieval | not measured · stalled since 2025-12 |
+| CodeGraphContext | 3.7k | Pluggable graphs | Retrieval | not measured |
+| grepai | 1.7k | Embedding + call graph (Go) | Retrieval | 97% input · **27.5% cost** |
+| Octocode MCP | 0.9k | Multi-repo LSP | Retrieval | not measured |
+| mcp-compressor (Atlassian) | — | Two-phase disclosure | MCP surface | not quantified |
+| token-optimizer-mcp | — | Cache + compression | Mixed | 95%+ (unverified) |
+| token-saver | — | Per-filetype compression | Observation | not quantified |
+| **tokenix** | — | Index + 528 filters + hooks | Retrieval **and** observation | 67.4% over 7,807 real hook calls |
+
+Of the 14, only grepai publishes the gap between tokens cut and money saved —
+and that gap is **3.5×**.
+
+---
+
+## 2. Findings
+
+### F1 · Positioning — the observation layer is the largest and it is empty
+
+CoACT ([arXiv 2607.02911](https://arxiv.org/html/2607.02911)) measured where an
+agent's tokens actually go: observations are **45.7%** of total consumption on
+SWE-bench Verified and **67.8%** on Terminal-Bench. None of the ten most-starred
+tools in the landscape table operate on that layer.
+
+The whole market optimizes what the agent *reads from the repo*. Almost nobody
+optimizes what the agent *gets back from running a command*. tokenix has 528
+deterministic filters with 1,146 golden cases operating exactly there.
+
+**→** Stop positioning tokenix as "local semantic search". Position it as the
+observation compressor for coding agents, index included.
+
+### F2 · Risk — the 67.4% figure is cache-blind and overstates dollar savings
+
+- grepai measured **97%** reduction in fresh `input_tokens` and only **27.5%**
+  cost saving, because `cache_read_input_tokens` dominated both arms.
+- The two-tier cost model
+  ([arXiv 2607.15516](https://arxiv.org/html/2607.15516v1)) formalizes it: with
+  cache hit rate ρ, compression at ratio r only pays if
+  `ρ < ρ_cross(r) = (α − 1/r)/(α − β)` where `α = c_write/p_in`, `β = c_read/p_in`.
+  On Anthropic May-2026 pricing: r=2 → 0.652, r=3 → 0.797, r=6 → 0.942, r≥10 →
+  always worth it. On τ-bench retail, query-aware compression cost **+40.1% more**
+  than the vanilla baseline.
+
+`tokenix gain` counts removed tokens and prices them at the full input rate. In a
+real session a large share would have been billed at `cache_read` — an order of
+magnitude cheaper. The report is correct in tokens and optimistic in dollars.
+
+Structural good news: tokenix compresses at **write time** — the observation is
+reduced before entering history — and never rewrites an already-cached prefix.
+That is the pattern the paper flags as safe. The problem is accounting, not
+architecture, and the safety property is worth stating publicly.
+
+**→** Cache-aware gain: report "tokens removed" and "≈USD" separately, using the
+effective blended rate. `usage.rs` already parses `cache_read`/`cache_write`.
+
+### F3 · Gap — byte-exact golden tests prove determinism, not usefulness
+
+CoACT defines **next-action preservation (NAP)** as the acceptance criterion: a
+compression is valid if the agent picks the same next action from the compressed
+observation as from the raw one. With that gate: 36% token saving and pass@1
+*rising* 57.0 → 60.5. Without it, LLMLingua-2 saves tokens but drops pass@1 to
+50% and increases step count by **111%** — the agent spends the savings
+recovering.
+
+The 1,146 golden cases guarantee a filter always produces the same output, and
+the `never_mask_failure` rules guarantee an error never becomes a success. Nothing
+measures whether the agent still *acts the same*. That is the difference between
+"the filter is stable" and "the filter is safe".
+
+Infrastructure already exists: `recordings` stores real output and
+`filter generate` already invokes a detected AI CLI.
+
+**→** Per-filter action-preservation homologation. Publish "% saved / % action
+preserving" — a claim no competitor makes.
+
+### F4 · Gap — no trajectory layer
+
+In long-horizon tool tasks ([arXiv 2606.10209](https://arxiv.org/abs/2606.10209)):
+full history = 71.0% completion at 1.48M tokens; prune to last 5 interactions =
+79.0% at 535k; prune **and** summarize = **91.6% at 553k** — 37% of the tokens and
+60% less wall time. Trajectory compression stacked on observation compression took
+a run from $45.65 to $25.88.
+
+The tokenix hook sees one call at a time. What accumulates over a session is
+partially covered by re-read suppression and `stash`/`retrieve`.
+
+The safe extension is **delta reads**: if a file or command was already delivered
+this session and changed, return only the diff plus a pointer. Action-preserving
+by construction (changed content appears in full) and avoids fuzzy dedup, which
+was already correctly refused — hiding altered output is the failure mode the
+literature punishes hardest. Note `ROADMAP.md` already defers a "diff-aware Read
+intercept" — this is the same item with evidence behind it.
+
+**→** Per-session observation ledger + delta mode. Exact hashes only, never
+approximate similarity.
+
+### F5 · Opportunity — the MCP surface is the cheapest saving available
+
+- Anthropic: on-demand tool search took an MCP library from **77,000 → 8,700**
+  tokens (85%); the code-execution pattern took a benchmark from **150,000 →
+  2,000** (98.7%).
+- TSCG ([arXiv 2605.04107](https://arxiv.org/pdf/2605.04107)): deterministic,
+  lossless schema compilation cuts **40–60%** on its own.
+- GitHub reported up to 62% reduction from pruning unused MCP alone.
+
+tokenix has `mcp --profile slim`, `prompt-audit`, and an `mcp-proxy` that
+compresses `tools/call` results. The missing middle is compressing the *schemas*
+of the third-party servers the proxy fronts, with two-phase disclosure (minimal
+surface → full schema on demand → invoke).
+
+This is the only lane with a direct named competitor — Atlassian Labs'
+`mcp-compressor`. But it only compresses schemas. A local Rust proxy that
+compresses schema *and* result does not exist.
+
+**→** Deterministic schema compilation + two-phase disclosure in `mcp-proxy`.
+
+> Caveat pending verification: system prompt and tool schemas normally sit in the
+> cached prefix, so a 60% schema cut may be worth far less in dollars than in
+> tokens. Same correction as F2. Being checked in pass 2.
+
+### F6 · Opportunity — nobody in this market publishes a public benchmark number
+
+All 14 tools' claimed savings come from their own harness. Mature public targets
+exist: CORE-Bench ([arXiv 2606.11864](https://arxiv.org/abs/2606.11864) — 180k
+queries, 106k broader-context relevance labels, three levels), Terminal-Bench 2.1,
+SWE-bench Verified.
+
+`tokenix benchmark` measures against a vanilla baseline and deliberately refuses
+competitor arms — an honest stance that avoids unfair comparison, but leaves the
+project without external proof. Terminal-Bench is the natural target: it is where
+observations are 67.8% of spend, i.e. tokenix's best case, scored by a third party.
+
+**→** One public run reporting tokens **and** resolve rate. One auditable number
+beats ten self-measured ones.
+
+### F7 · Constraint — do not trade deterministic rules for a learned compressor
+
+- LLMLingua-2 on agent observations: pass@1 57.0 → 50.0, steps +111%.
+- Learned implicit compression (ICAE,
+  [arXiv 2605.11051](https://arxiv.org/html/2605.11051)) on SWE-bench Verified:
+  **19 → 7** issues resolved (p=0.013), with hallucinated paths and URLs during
+  reconstruction — errors that compound every step. Works on single-shot tasks,
+  breaks in agentic flow.
+
+It is tempting to reuse the ONNX runtime already in `embed.rs` to run a token
+classifier. The evidence says that without an action-preservation gate it destroys
+more value than it saves. tokenix's deterministic rules are not a technical
+limitation to overcome — they are why it does not have this failure mode.
+
+**→** Any learned component goes only in the uncovered long tail (which
+`discover` already ranks) and only behind the F3 gate.
+
+---
+
+## 3. Roadmap
+
+Tiers are sequential — each depends on the previous one measuring correctly.
+
+### Tier 1 — fix what is already claimed (weeks, low risk)
+
+1. **Cache-aware gain accounting** (F2) — separate "tokens removed" from
+   "≈USD saved", priced with the real full-input / `cache_read` / `cache_write`
+   mix read from transcripts.
+2. **Action-preservation homologation** (F3) — per filter, compare the next action
+   proposed from raw vs filtered recorded output. A filter that changes the
+   agent's action fails even at 95% savings.
+3. **Schema compression in `mcp-proxy`** (F5) — deterministic lossless compilation
+   of fronted servers' schemas plus two-phase disclosure. Process `tools/list`,
+   not only `tools/call`.
+
+### Tier 2 — open the trajectory layer and prove it externally (months, medium risk)
+
+4. **Session ledger + delta reads** (F4) — exact hash only; changed content always
+   shown in full.
+5. **Public benchmark run** (F6) — Terminal-Bench 2.1 primary, published
+   methodology, tokens and resolve rate side by side. Cheaper alternative:
+   CORE-Bench for the retrieval arm only.
+6. **Long-tail coverage loop** (F3, F7) — `discover` ranks uncovered waste, Studio
+   records and generates, the Tier-1 gate accepts or rejects.
+
+### Tier 3 — bets
+
+7. **Compaction bridge** (F4) — expose what tokenix knows about the session to the
+   agent's own compaction mechanism instead of letting it summarize blind.
+8. **Signed filter registry** (F1) — the SHA-256 trust gate already exists locally;
+   a shared registry turns 528 filters into a network effect, which a commodity
+   code graph cannot have.
+
+---
+
+## 4. What the research advises against
+
+- **Building a code graph to compete with CodeGraph / GitNexus.** Two projects
+  above 40k stars, both local, both permissively licensed. Commodity, and
+  `graph.rs` with PageRank already covers the internal use that matters.
+- **Adopting TOON as a headline.** ~40% fewer tokens than JSON on tabular data,
+  but the 2026 benchmark shows JSON with the best accuracy plus an instruction
+  "prompt tax" that eats the gain in short contexts. At most useful for internal
+  tabular output.
+- **Similarity-based dedup.** Already refused, and the literature confirms: hiding
+  altered output is the most expensive failure mode, because the agent acts on a
+  reality that no longer exists.
+- **Publishing a savings percentage without the cache math.** After F2, every
+  savings number should carry its compression ratio and assumed cache hit rate.
+
+---
+
+## 5. Sources
+
+- [CoACT: Action-Preserving Observation Compression for Coding Agents](https://arxiv.org/html/2607.02911) — arXiv 2607.02911
+- [On Problems of Implicit Context Compression for Software Engineering Agents](https://arxiv.org/html/2605.11051) — arXiv 2605.11051
+- [Cache-Aware Prompt Compression: A Two-Tier Cost Model for LLM API Caching](https://arxiv.org/html/2607.15516v1) — arXiv 2607.15516
+- [Less Context, Better Agents: Efficient Context Engineering for Long-Horizon Tool-Using LLM Agents](https://arxiv.org/abs/2606.10209) — arXiv 2606.10209
+- [CORE-Bench: A Comprehensive Benchmark for Code Retrieval in the Era of Agentic Coding](https://arxiv.org/abs/2606.11864) — arXiv 2606.11864
+- [TSCG: Deterministic Tool-Schema Compilation for Agentic LLM Deployments](https://arxiv.org/pdf/2605.04107) — arXiv 2605.04107
+- [Token-Oriented Object Notation vs JSON](https://arxiv.org/abs/2603.03306) — arXiv 2603.03306
+- [Prompt Compression for Large Language Models: A Survey](https://arxiv.org/html/2410.12388v2) — arXiv 2410.12388
+- [Code Isn't Memory: A Structural Codebase Index Inside a Coding Agent](https://arxiv.org/abs/2606.22417) — arXiv 2606.22417
+- [Code Intelligence Tools for AI Agents Compared](https://rywalker.com/research/code-intelligence-tools) — Ry Walker Research
+- [Codebase Memory: The 6 Best Tools for AI Coding Agents (2026)](https://www.sentra.app/articles/best-codebase-context-memory-tools) — Sentra
+- [Benchmark: grepai vs grep on Claude Code](https://yoanbernabeu.github.io/grepai/blog/benchmark-grepai-vs-grep-claude-code/)
+- [mcp-compressor](https://github.com/atlassian-labs/mcp-compressor/) — Atlassian Labs
+- [Production Results: MCP Server for GitHub Validates Anthropic's Code-First Pattern](https://github.com/orgs/modelcontextprotocol/discussions/629)
+- [GitHub Slashes Agent Workflow Token Spend up to 62%](https://www.infoq.com/news/2026/05/github-agentic-token-savings/) — InfoQ
+
+---
+
+## Deep sweep (pass 2)
+
+Six parallel research lanes: client-side caching and the proxy question,
+observation/trajectory compression, retrieval benchmarks, MCP/tool-surface
+compression, exhaustive GitHub sweep, and the wider frontier. **Pass 2 overturns
+most of pass 1.** Corrections come first.
+
+### Corrections to pass 1
+
+| Pass-1 claim | Verdict | Why |
+|---|---|---|
+| **F1** — the observation layer is empty | **FALSE** | rtk 75.2k★, headroom 65.4k★, lean-ctx 3.5k★, snip 397★ (same architecture, same `gain`/`discover` command names). tokenix is at 13★. The layer is one of the most crowded in agent tooling. |
+| **F2** — `gain` overstates dollars | **TRUE, and worse than stated** | Not an accounting nuance. Token reduction has **r = 0.15** correlation with billed cost change (n=2,848 paired runs). See below. |
+| **F5** — compress MCP schemas in the proxy | **DEAD** | Not implementable at the proxy layer, Claude Code already defers by default (120 tokens), and a facade would destroy per-tool permissions. |
+| **F6** — Terminal-Bench as the benchmark target | **WRONG TARGET** | Expensive, high variance at n=89, signal diluted. CORE-Bench L2 is IR-only, $0 API. |
+| **F3, F4, F7** | **Confirmed and strengthened** | The literature named F3's metric (NAP) in July 2026 with a concrete protocol. |
+
+**Also invalidated: a stored project memory.** `project-claude-no-posttooluse-by-design`
+claimed Claude Code PostToolUse cannot replace tool results. It can:
+`hookSpecificOutput.updatedToolOutput` **replaces the tool's result**, for all
+tools ([docs](https://code.claude.com/docs/en/hooks)). Verified directly. Memory
+corrected 2026-08-08.
+
+### The decisive finding
+
+**Token Reduction Is Not Cost Reduction** ([arXiv 2607.12161](https://arxiv.org/html/2607.12161))
+— 2,908 provider-billed Claude Code runs, 103 tasks, 7 repos, 3 models,
+pre-registered paired design. It evaluates **hook-based compressors on Claude
+Code**, i.e. tokenix's exact deployment shape, and names RTK, RTK-ML, Headroom,
+ml_lexical and Caveman.
+
+- An arm removing **38.4%** of raw tool-output tokens cost **+6.8% more**
+  (95% CI [+2.8, +11.3]).
+- Per-task correlation, reduction vs cost change: **Pearson r = 0.154**
+  (CI crosses zero), **Spearman ρ = 0.013**.
+- Bill composition: cache creation **44.3%**, cache reads **35.4%**, output
+  **10.4%**, uncached input **1.3%**. ~80% of the bill is cache traffic; the
+  share addressable by visible-token compression is **~5% of input cost**.
+- Four break mechanisms: cache pricing multipliers, **closed-loop recovery**
+  (the agent re-searches and re-transmits the prefix), **trajectory
+  elongation**, and **downstream consumer corruption**.
+- Proposed metric: **success-adjusted billed cost** (L7 on an L1–L8 evidence
+  ladder). tokenix currently reports L1 — the rung with r = 0.15.
+
+**Independently corroborated.** JetBrains ran rtk on SkillsBench: 425 billed
+trials, 86 tasks, Claude Code 2.1.201 headless, Sonnet 5, Harbor sandboxes,
+Wilcoxon signed-rank, pre-registered endpoints
+([blog](https://blog.jetbrains.com/ai/2026/07/rtk-claude-code-token-savings/)).
+Low effort: **+7.6% cost** (p=0.004), **+13.8% turns** (p=0.03), **+14.3% cache
+reads** (p=0.008). High effort: +0.1% (p=0.99). Quality indistinguishable. Their
+sentence: *"a tool's self-reported savings are a claim about its counterfactual,
+not about your bill"* — rtk's own analytics showed **96 million tokens saved**
+while cost rose.
+
+tokenix's 67.4% is the same class of claim.
+
+### Confirmed bug: `count_tokens` counts bytes
+
+`src/chunker.rs:92` — comment says "~4 chars per token", code is
+`text.len().div_ceil(4)`, and `len()` is **bytes**. Non-ASCII content (accented
+logs, box-drawing, emoji, CJK) inflates by up to 3–4×. Three stacked errors:
+bytes vs chars; 4 vs Anthropic's own ~3.5 guidance; and blind to the Opus 4.7+
+tokenizer, which emits **1.32× more tokens than the old Claude tokenizer and
+1.73× more than GPT-5.x on TypeScript** at unchanged prices.
+
+Fix: [`bpe`](https://crates.io/crates/bpe) (github/rust-gems, MIT) — ~3.5× faster
+than tiktoken, **linear** where tiktoken is quadratic (tokenix's inputs *are* the
+adversarial cases), `AppendableEncoder` for streaming counts,
+`IntervalEncoding` for exact-budget truncation.
+
+### Two live hazards in the current design
+
+1. **Edit-anchor corruption.** 73% token reduction dropped successful patch
+   application **27/40 → 15/40** on SWE-bench-derived Go tasks, by rewriting the
+   verbatim text an edit tool must match exactly (2607.12161). Corroborated:
+   dedent alone costs **−8pp** absolute ([2606.01326](https://arxiv.org/abs/2606.01326)).
+2. **Shell-pipeline corruption.** Filtered output entering a pipeline that
+   expects raw text produces silently wrong answers. `tokenix run` has this
+   exposure and no stdout-consumer guard.
+
+### F3 upgraded: the metric now has a published protocol
+
+CoACT ([arXiv 2607.02911](https://arxiv.org/abs/2607.02911)) formalizes
+**Next-Action Preservation** and — critically — **uses no LLM judge**:
+
+```
+refs  = [sample(policy, prefix + raw_obs,      T=0.6) for _ in range(8)]
+cand  =  sample(policy, prefix + filtered_obs, T=0.0)
+score = mean(top_3([action_sim(cand, r) for r in refs]))
+PASS if score >= 0.60
+```
+
+`action_sim` parses the action into `(op_type, fields)`, returns 0.0 on op_type
+mismatch, else normalized field agreement — **deterministic, writable in Rust**.
+Validated at **80.0% agreement** with human same/different labels on 100 pairs.
+Reference actions cache per `(prefix, raw_obs)`, so a filter change costs one
+greedy call per affected test: the suite is incremental, not 10k calls per PR.
+
+Five formulations exist (CoACT NAP, AGORA counterfactual action-change, LCoW
+action-matching, ACON contrastive trajectories, Self-GC no-impact rate). **None
+uses an LLM as the equivalence judge** — LLM-judge step attribution measures
+~14% accuracy. Use a model to *produce* the action; use code to *compare* them.
+
+Report two axes with Wilson CIs — **(% tokens removed, % action preserved)**.
+Self-GC's table is the proof: baselines pruned 1.5× more at 20pp lower no-impact.
+
+### Determinism is the correct architecture, and it is now defensible
+
+| Claim | Evidence |
+|---|---|
+| Deterministic masking matches LLM summarization at half the cost | Complexity Trap ([2508.21433](https://arxiv.org/abs/2508.21433), JetBrains): mask obs >10 turns → Qwen3-Coder-480B **54.8% / $0.61** vs summary 53.8% / $0.64 vs raw 53.4% / $1.29 |
+| Deterministic beats generative in the aggressive regime | Control Under Compression ([2608.01056](https://arxiv.org/html/2608.01056), 15,525 runs): at 35% retained, section-based **47.0%** vs LLM rewriting **19.9%** |
+| The deterministic floor contributes more than the learned scorer | AGORA ([2605.26596](https://arxiv.org/abs/2605.26596)): removing the floor costs −0.088 reward; removing the 125M scorer costs −0.031 |
+| Rules have zero variance; summarizers do not | Parallel Context Compaction ([2605.23296](https://arxiv.org/abs/2605.23296)): compaction output **CV 19.8–84.5%**, and prompt instructions are *ignored* |
+| Extractive output cannot poison context | ICAE-for-SWE ([2605.11051](https://arxiv.org/html/2605.11051)): hallucinated URLs/paths compounding across steps; **19 → 7** issues resolved (p=0.013) |
+
+Perplexity-ranked token pruning is unusable on tool output — five independent
+measurements (CoACT, AGORA, Control Under Compression, Cross-Lingual Arbitrage,
+AgentDiet). LLMLingua-2 on agent observations: pass@1 57.0 → 50.0, tokens
+**+172%**, steps **+111%**.
+
+What determinism **cannot** do, per the same literature: task-conditioned
+relevance in heterogeneous output (BM25 hits 0.22 recall where a 2B model hits
+0.86); telling which of N similar items matters; generalizing across
+environments without adaptation — TACO ([2604.19572](https://arxiv.org/abs/2604.19572))
+found **200 hand-curated rules plateaued** while self-evolving rules kept
+improving. That is a direct warning about a hand-maintained 528-filter set.
+
+### The always-on context nobody measures
+
+Measured on this machine:
+
+| Source | Cost | State |
+|---|---|---|
+| `AGENTS.md` (tokenix repo) | ≈ **13,500 tok** | always loaded |
+| 101 installed skills (frontmatter) | ≈ **13,000 tok** | always listed |
+| `~/.claude/CLAUDE.md` | ≈ 790 tok | always loaded |
+| MCP tools (deferred by default) | **120 tok** | — |
+
+Anthropic's own reference for a project CLAUDE.md is **1,800 tokens**, with
+explicit guidance of "under 200 lines". tokenix's `AGENTS.md` is **7.5× that**
+and **112× the MCP line** that F5 wanted to optimize. `prompt-audit`'s
+`context_weight()` already measures this.
+
+### Where tokenix is genuinely unique (survived the sweep)
+
+1. **528 TOML filters with 1,146 golden cases** — the largest per-command output
+   filter corpus in existence (snip 132, rtk ~100 compiled, token-saver 36,
+   squeez 19). Only token-saver has comparable test discipline, at 1/15 the size.
+   No other project publishes filter-level correctness testing at all.
+2. **In-process ONNX embeddings**, no daemon, no API, no Ollama. claude-context,
+   octocode and codeseek all default to remote APIs.
+3. **Retrospective transcript forensics** (secrets + egress). The entire egress
+   field is inline proxies you had to install beforehand; nobody analyzes
+   recorded sessions after the fact.
+
+Not unique despite framing: `gain` and `discover` (rtk coined both, snip copied
+the names), multi-agent interception (5 vs field median ~14), Rust, "60–90%",
+stash/retrieve, cross-call dedup.
+
+### Emphasis inversion
+
+SWE-Pruner ([2601.16746](https://arxiv.org/abs/2601.16746)) measures **reads =
+76.1% of coding-agent context tokens**. Filters on `cargo test` address the
+minority. tokenix's semantic index — not the headline today — is the more
+valuable asset. Corroboration: graph beats embeddings for localization by large
+margins (LocAgent 75.91 Acc@1 vs best embedding 52.55 vs BM25 38.69), and 2026
+consensus is **lexical as anchor, graph second, embeddings optional**
+([LARGER 2605.16352](https://arxiv.org/abs/2605.16352): +13.9 pp Acc@5).
+
+Also: `nomic-embed-text-v1.5` is a *general text* model. On CORE-Bench L2 even
+Qwen3-Embedding-8B collapses to **20.3 NDCG@10**; CodeRankEmbed (137M, fits
+local-first) leads small models at 52.55 Acc@1 on LocBench. `embed.rs` already
+supports custom ONNX models — this is a registry change, not architecture.
+
+### On caching: no proxy
+
+- Claude Code and Codex CLI already place `cache_control` correctly; Claude Code
+  closed breakpoint configuration as *not planned*
+  ([#58103](https://github.com/anthropics/claude-code/issues/58103)). The broken
+  harnesses are Cline, Roo, Continue, Aider.
+- A proxy silently breaks subscription auth
+  ([#33330](https://github.com/anthropics/claude-code/issues/33330),
+  [#23022](https://github.com/anthropics/claude-code/issues/23022)), gateways are
+  documented stripping `cache_control`
+  ([Portkey #1579](https://github.com/Portkey-AI/gateway/issues/1579)), beta
+  headers drift weekly, and LiteLLM shipped credential-stealing malware on PyPI.
+  It would put every credential the agent touches inside tokenix.
+- `prompt-cache-skills`, the one project built to fix agent caching,
+  deliberately avoids a proxy and patches harnesses instead.
+- **The non-proxy route**: Claude Code emits `claude_code.token.usage` over
+  OpenTelemetry with `type = input | output | cache_read | cache_creation`, per
+  model and session. A local OTLP receiver gives live cache hit rate and billed
+  cost with zero interception.
+
+Architectural point worth stating publicly: tokenix compresses at **write time**,
+before the observation enters history, and never rewrites a cached prefix. That
+is the safe side of the line that inverted AgentDiet's cost (−40.3% tokens,
++10.6% cost from rewriting history). But it must be **measured**, not asserted —
+2607.12161 measured hook-based compressors and still found +6.8%.
+
+---
+
+## Decision — what to implement
+
+Ordered. Each tier is a precondition for the next.
+
+### Tier 0 — make the numbers true (nothing else is meaningful first)
+
+1. **Real tokenizer.** Fix bytes→chars, then move to the `bpe` crate with a
+   per-model calibration table (old-Claude / new-Claude / GPT). Every budget
+   decision, gauge and `gain` figure depends on it.
+2. **Billed-cost accounting in `gain`.** Demote "tokens removed" from headline to
+   diagnostic. Report success-adjusted billed cost from `cache_read` /
+   `cache_write` / `output` / uncached input, which `usage.rs` already parses.
+   Report **Δturns alongside Δtokens** — +13.8% turns is the documented
+   mechanism by which savings invert.
+3. **Holdout mode.** `TOKENIX_HOLDOUT=0.1` to leave a random slice uncompressed
+   as a control group, with paired CIs. headroom ships this; it is now the bar,
+   and without it no causal claim is possible.
+4. **OTLP receiver in the daemon** — live cache hit rate and cost split, no
+   proxy. Enables (2) with provider-billed ground truth and doubles as a
+   cache-breaking-action warning (instruction-file edit mid-session, MCP add or
+   remove, model switch).
+
+### Tier 1 — close the two hazards, then ship the claim nobody else can
+
+5. **Edit-anchor guard.** Never filter content destined for exact-match editing.
+6. **Shell-consumer guard** for `tokenix run` — detect pipeline consumption,
+   pass through raw.
+7. **NAP harness** (`filter test --action-preservation`). Two tiers: free
+   deterministic CI checks (entity retention — paths, identifiers, hashes, line
+   numbers, exit codes; verbatim-anchor preservation; negative-evidence tokens),
+   then the CoACT protocol nightly against a local 3–8B model. Plus a ~50-case
+   red-team set where a single token is load-bearing. Publish
+   **(% saved, % action-preserving)** with Wilson CIs.
+
+### Tier 2 — newly unlocked surface, and the reframe
+
+8. **PostToolUse `updatedToolOutput`** for Claude Code — size-adaptive
+   compression (the same `git status` varies 5 → 5,491 tokens, **1,098×**) and
+   secret redaction *before* the model sees the output, not after in the
+   transcript.
+9. **`prompt-audit --recommend`** on instruction files and skills. The largest
+   always-on cost measured, nobody else measures it, and tokenix's own
+   `AGENTS.md` is the worst offender on this machine.
+10. **Swap the embedding model** to a code-specialized one and measure. Cheap,
+    and the current default is the weakest link in the retrieval pipeline.
+
+### Tier 3 — external proof
+
+11. **CORE-Bench L2** — IR-only, ~$0 API, 32 GB disk, published weak baselines,
+    harness exists. Report NDCG@10 and Recall@100 plus **tokens-to-recall@10**
+    and query latency, which nobody reports. Keep the retrieval claim and the
+    economics claim in separate rooms.
+
+### Dropped
+
+- **MCP schema compression** — not implementable at the proxy layer; the
+  `AGENTS.md` contract line stays as written.
+- **Learned/perplexity compressor** — five independent measurements say it is
+  harmful on tool output.
+- **Code knowledge graph as a product** — commodity, two projects above 40k
+  stars.
+- **TOON as a headline** — accuracy loss plus prompt tax; at most for internal
+  uniform tabular results.
+- **Similarity-based dedup** — hiding altered output is the most expensive
+  failure mode.
+- **Any LLM proxy** — catastrophic tail risk for a benefit the evidence says is
+  small on the harnesses tokenix targets.
+
+### The positioning change
+
+Stop leading with "60–90% token savings". That claim is now owned and publicly
+discredited by a competitor 5,800× larger. Lead instead with the two things that
+survived the sweep: **measurement nobody else does honestly** (billed cost,
+holdout control, action preservation) and **forensics nobody else does at all**
+(retrospective transcript secrets and egress). Being the first tool in this
+category to survive a neutral harness is available, and currently unclaimed.
+
+---
+
+## Deep sweep (pass 3) — log induction, edit anchors, secrets, NAP corpus
+
+### The benchmark decision is settled: LogDx-CI
+
+[arXiv 2605.28876](https://arxiv.org/abs/2605.28876) — 35 real GitHub Actions
+failures, logs 27 to 200,000+ lines, 8 failure categories, 7 ecosystems. Code
+Apache-2.0, data CC-BY-4.0, API `logdx_ci.evaluate(reducer=...)`, and the default
+`static-signal-recall` scorer is **deterministic and free — no API key, no LLM**.
+
+| Method | Score | Tokens/case |
+|---|---:|---:|
+| hybrid-grep + **rtk** + tail | 0.670 | 19,844 |
+| grep | 0.639 | 88,355 |
+| **tail-200** | **0.614** | **6,108** |
+| **raw (no reduction)** | **0.353** | 275,248 |
+| **rtk-log** (aggressive filter) | **0.249** | 810 |
+
+`rtk-log` scores **below doing nothing**. A dumb `tail -200` beats raw by 74% at
+2.2% of the tokens. This is "never mask a failure" measured by a third party, on
+the 75k-star competitor.
+
+**Structural invariant implied:** a filter must never emit less context than an
+unconditional tail window. `never_worse` guards bytes; this guards evidence. Do
+not change 528 filters before LogDx-CI is wired up as the baseline.
+
+Second corpus: **LogChunks** ([Zenodo 3632351](https://zenodo.org/record/3632351))
+— 797 Travis CI logs, 80 repos, 29 languages, with the failure-explaining chunk
+manually annotated plus developer search keywords (free seed material for
+`priority_lines`). Third axis, unclaimed by anyone:
+**CiDiff** ([2504.18182](https://arxiv.org/abs/2504.18182)) — diff the failing run
+against the last green run: **~60% median reduction** in lines to inspect,
+preferred **70% vs 5%**, over 17,906 CI regressions.
+
+Calibration: the honest ceiling is **LogSieve's 40–42%** at cosine fidelity 0.93,
+and TACO's self-evolving rules deliver **1–4% accuracy**, not big compression.
+
+Other confirmed invariants: **exit code is the only high-precision failure
+oracle** (F1 0.99, SWE-Factory) vs text heuristics at 99.2% precision but **76.2%
+of faults missed** (Chromium CI) — text may never override a non-zero exit; force
+`LC_ALL=C` on children. **ANSI stripping is not a token win** (tools auto-disable
+when piped); the volume is progress bars (500–2,000 tok/run) and `\r` rewriting,
+best fixed upstream (`--no-progress` alone = ~45% on PHPUnit).
+
+### CORVUS validates delta reads
+
+[arXiv 2607.22711](https://arxiv.org/abs/2607.22711) — decouples file-read actions
+from observations via a synchronized registry. **9–50% fewer input tokens, 15–32%
+shorter prompts, up to 37% FEWER reasoning cycles** at comparable pass rates.
+
+That third number is the point: every content compressor pays a
+trajectory-elongation tax (LLMLingua-2 +111% steps, ICAE +40%, rtk +13.8% turns).
+Removing *duplicates* does not, because it removes no information. Caveats: CORVUS
+reports input tokens, not billed cost; and its mechanism mutates history, which a
+hook cannot do — the implementable form is write-side.
+
+### Two anchor bugs confirmed in the tree
+
+1. **CRLF laundering.** `join("\n")` appears 36× in `compress.rs` and 19× in
+   `filters.rs`, and `\r` appears in **neither file**. The pipeline splits with
+   `.lines()` (which consumes `\r\n`) and rejoins with `"\n"`. On Windows — this
+   repo's primary platform — any CRLF file passed through a filter comes back
+   LF-only, so every line ending differs by one byte from disk. No repair ladder
+   surveyed handles CRLF. This is exactly the 27/40 → 15/40 mechanism.
+2. **Outline signature lines.** `generate_outline` emits signatures via
+   `extract_full_signature` — re-derived, not sliced verbatim. A near-exact code
+   line in a code context is the most quotable-looking, least quotable thing
+   tokenix can emit.
+
+**Guard principle:** tokenix may delete content, and may replace content with a
+pointer to its exact bytes. It may never hand back a *modified copy* of content
+the agent might quote. Anchor-bearing-ness is decidable deterministically at hook
+time from tool identity + path + repo state.
+
+Supporting evidence: Sweep measured **77% of `str_replace` failures were "the code
+isn't in the file"**; aider **removed** similarity fuzz in 2023 because silent
+wrong edits beat loud apply failures; Anthropic's `str_replace` spec has **zero**
+fuzz tolerance.
+
+### Secrets: a confirmed arithmetic bug, now fixed
+
+Shannon entropy over the observed distribution is bounded by `log2(n)`, so a
+`min_entropy` above `log2(min_match_len)` can never be satisfied. Two bundled
+rules were dead for short passwords: `basic-auth-url` (`{5,63}` @ 3.5 needed 12
+chars) and `db-connection-uri` (`{4,}` @ 2.8 needed 7). Both now sit at 2.8 with a
+matching 7-char floor. Regression test added. Residual limit: at 8 chars the 2.8
+floor still needs ~7 distinct characters, so `s3cr3t99` stays missed — closing
+that needs length-normalized entropy, not a lower constant.
+
+Context: gitleaks-class scanners measure **46% precision / 88% recall**
+([ESEM 2023](https://arxiv.org/abs/2307.00714)), FP root causes named verbatim as
+*"generic regular expressions and ineffective entropy calculation"*.
+
+Next, in order: **structural/checksum validation** (AWS AKIA, Stripe, `gh*_`, JWT
+`exp`) — zero network, large FP reduction; **placeholder as an explicit third
+class** (−33% high-severity alerts at 93% recall,
+[2605.31520](https://arxiv.org/abs/2605.31520)); **format-preserving redaction** —
+SlotGuard ([2607.17147](https://arxiv.org/abs/2607.17147)) measured generic
+`[REDACTED]` dropping downstream task success to **2.5%** while same-shape
+synthetic substitution held near baseline at 14.4 µs/turn. tokenix writes
+`[REDACTED]` today.
+
+Premise validated: **73.5% of agent credential leaks come from debug logging**,
+because *"agent frameworks feed stdout into the LLM context window"*
+([2604.03070](https://arxiv.org/abs/2604.03070)). And tokenix can compute a feature
+no code scanner can — was the value in a *tool result* (near-certainly real) vs an
+*assistant message* (possibly hallucinated)?
+
+Unmeasured and publishable: **how often do agent CLI session files contain
+plaintext secrets?** For egress, the highest-value detector is **sensitive-file
+read → outbound call within N turns** — the only thing that catches exfiltration
+to a vendor's own API. Do **not** build beaconing detection (event density is
+orders of magnitude too low) and do **not** verify credentials over the network.
+
+### NAP: the goldens are the wrong corpus
+
+Measured in-repo: the 1,146 golden blocks have a **median `input` of 150 chars
+(~40 tokens)**, mean 192, max 1,301 — far too small for compression to be a
+meaningful decision. The goldens stay the right *byte-exactness* regression suite;
+they are the wrong *behavioral* corpus.
+
+**Cheapest path is Phase 0: mine local transcripts.** 990 Claude/Codex session
+files / 873 MB on this machine already contain prefix + call + verbatim output +
+*the actual next action a frontier model took* — a stronger label than any
+small-model rollout, at zero inference cost. Gate on observations ≥2,000 chars
+where the filter actually changes the output. Backfill uncovered filters from
+AlienKevin/SWE-ZERO-12M (Apache-2.0, bash-only, same scaffold as CoACT),
+nebius/SWE-agent-trajectories (CC-BY-4.0, prefer *failed* trajectories),
+SWE-bench/SWE-smith-trajectories (MIT).
+
+CoACT's protocol verified exactly: K=8 references at T=1.0, greedy under
+compressed, mean of top M=3 structural similarity, θ=0.6, **80.0% agreement with
+human labels**. Add AGORA's **soft labels** (fraction of K=8 paired rollouts whose
+canonicalized next action differs) — same generations, absorbs decoder noise a
+binary label conflates with real loss. Always run a **raw-vs-raw replicate arm**:
+raw self-agreement is not 1.0, and without that floor the number is
+uninterpretable.
+
+**The statistics decide the reporting format.** Exact one-sided Clopper-Pearson
+with zero failures is `LCB = α^(1/n)`: n=20 → **0.861**, n=30 → 0.905, n=59 →
+**0.9505**. So a filter with a perfect 20/20 record supports "≥0.861", not
+"≥0.95". McNemar needs ≥5 discordant pairs for one-sided p<0.05; at n=20 you
+expect ~1.6, so an n=20 filter cannot produce a significant result at *any* effect
+size. FWER across 528 tests pushes the requirement to **n=181** (Bonferroni) or
+**n=219** (Benjamini-Yekutieli) — 96k–116k labeled examples. That settles the
+frame: **estimation with hierarchical partial pooling, not 528 hypothesis tests.**
+
+Report three states, never binary: **PASS / FAIL / INSUFFICIENT**.
+"412 INSUFFICIENT, 109 PASS, 7 FAIL" is defensible; "521/528 pass at 95%" from
+n=20 is not.
+
+### Corrections to earlier passes
+
+- The "Squeez, 11,477 examples / 618 curated test set" figure cited in pass 2 has
+  **no found provenance** on arXiv or GitHub. Do not cite it.
+- TACO's headline is **1–4% accuracy gain**, not a large compression number, and
+  the "200 hand-curated rules plateaued" figure could not be extracted from the
+  paper — treat as unverified positioning.

--- a/src/compress.rs
+++ b/src/compress.rs
@@ -1311,7 +1311,44 @@ fn redact_base64_blobs(s: &str) -> String {
     strip_wrapped_base64(&strip_base64_blobs(s))
 }
 
+/// The line terminator that dominates `s`.
+///
+/// Every `\r\n` also contains a `\n`, so CRLF dominates when it accounts for
+/// more than half of all newlines.
+pub(crate) fn dominant_eol(s: &str) -> &'static str {
+    let crlf = s.matches("\r\n").count();
+    let lf = s.matches('\n').count();
+    if crlf > 0 && crlf * 2 > lf {
+        "\r\n"
+    } else {
+        "\n"
+    }
+}
+
+/// Restore `eol` over output that the line pipeline has normalized to LF.
+///
+/// Every transform in this crate splits with `.lines()` — which consumes `\r\n`
+/// and `\n` alike — and rejoins with `"\n"`. On a CRLF input that silently hands
+/// the agent a copy where *every* line ending differs from the bytes on disk. If
+/// the agent then quotes those lines into an exact-match edit (SEARCH/REPLACE,
+/// `str_replace`), the anchor cannot match: measured elsewhere as successful
+/// patch application dropping from 27/40 to 15/40 when compression rewrote the
+/// bytes an edit tool has to reproduce. Windows is this project's primary
+/// platform, so this is the common case, not the corner case.
+pub(crate) fn restore_eol(out: String, eol: &str) -> String {
+    if eol != "\r\n" || out.is_empty() {
+        return out;
+    }
+    // Normalize first so a partially-CRLF result cannot become `\r\r\n`.
+    out.replace("\r\n", "\n").replace('\n', "\r\n")
+}
+
 pub fn compress_output(s: &str) -> String {
+    let eol = dominant_eol(s);
+    restore_eol(compress_output_inner(s), eol)
+}
+
+fn compress_output_inner(s: &str) -> String {
     // Redact embedded base64 blobs first: a data URI inside a JSON string would
     // otherwise survive JSON compaction at full weight.
     let stripped = redact_base64_blobs(s);
@@ -1331,6 +1368,49 @@ pub fn compress_output(s: &str) -> String {
 
     // Additional generic aggressive compression
     enforce_token_budget(&generic_aggressive_compress(&s))
+}
+
+#[cfg(test)]
+mod eol_tests {
+    use super::*;
+
+    #[test]
+    fn crlf_survives_the_compression_pipeline() {
+        // Regression: `.lines()` + `join("\n")` laundered CRLF into LF, so every
+        // line the agent got back differed from disk by one byte.
+        let src = "fn main() {\r\n    println!(\"hi\");\r\n}\r\n";
+        let out = compress_output(src);
+        assert!(
+            out.contains("\r\n"),
+            "CRLF input must come back CRLF, got {out:?}"
+        );
+        assert!(
+            !out.replace("\r\n", "").contains('\n'),
+            "no bare LF may survive in a CRLF payload: {out:?}"
+        );
+    }
+
+    #[test]
+    fn lf_input_stays_lf() {
+        let src = "fn main() {\n    println!(\"hi\");\n}\n";
+        assert!(!compress_output(src).contains('\r'));
+    }
+
+    #[test]
+    fn dominant_eol_picks_the_majority() {
+        assert_eq!(dominant_eol("a\r\nb\r\nc\r\n"), "\r\n");
+        assert_eq!(dominant_eol("a\nb\nc\n"), "\n");
+        assert_eq!(dominant_eol(""), "\n");
+        // Mixed endings: a lone CRLF in a mostly-LF payload must not flip it.
+        assert_eq!(dominant_eol("a\nb\nc\r\nd\n"), "\n");
+    }
+
+    #[test]
+    fn restore_eol_is_idempotent() {
+        let once = restore_eol("a\nb\n".to_string(), "\r\n");
+        assert_eq!(once, "a\r\nb\r\n");
+        assert_eq!(restore_eol(once.clone(), "\r\n"), once);
+    }
 }
 
 /// Absolute ceiling on how many tokens any single compressed output may cost.

--- a/src/docshot.rs
+++ b/src/docshot.rs
@@ -1,0 +1,291 @@
+//! Headless renderer for documentation screenshots.
+//!
+//! The TUI is drawn into a ratatui `TestBackend` buffer and emitted as SVG, so
+//! README images are a build artifact instead of a manual screen capture. Two
+//! properties matter and neither is achievable with a real screenshot:
+//!
+//! * **No private data can leak.** The render never touches the machine's
+//!   transcripts, spend, or secrets — tabs that would show them are seeded with
+//!   synthetic fixtures. A screenshot of a real session cannot make that
+//!   guarantee, which is why the Secrets and Egress tabs have never had one.
+//! * **Images cannot go stale silently.** Regenerating is a test run, so a tab
+//!   that changes shape shows up as a diff instead of drifting away from the
+//!   docs for months.
+//!
+//! SVG rather than PNG: sharp at any zoom, roughly an order of magnitude smaller
+//! than the equivalent PNG, and diffable in review.
+
+use ratatui::buffer::Buffer;
+use ratatui::style::{Color, Modifier};
+
+/// Terminal cell metrics, in SVG user units. Tuned so the glyph advance matches
+/// a typical monospace face at this size; box-drawing characters butt together
+/// with no seam.
+const CELL_W: f32 = 8.4;
+const CELL_H: f32 = 18.0;
+const FONT_SIZE: f32 = 14.0;
+/// Baseline offset inside the cell box.
+const BASELINE: f32 = 13.6;
+
+/// Palette used for the 16 ANSI colors. Chosen to stay legible on the dark
+/// canvas below and to keep tokenix's orange accent recognizable.
+fn ansi_hex(c: Color) -> Option<&'static str> {
+    Some(match c {
+        Color::Black => "#1c1f24",
+        Color::Red => "#e5534b",
+        Color::Green => "#3fb950",
+        Color::Yellow => "#d29922",
+        Color::Blue => "#4a9eff",
+        Color::Magenta => "#bc8cff",
+        Color::Cyan => "#39c5cf",
+        Color::Gray => "#8b949e",
+        Color::DarkGray => "#484f58",
+        Color::LightRed => "#ff7b72",
+        Color::LightGreen => "#56d364",
+        Color::LightYellow => "#e3b341",
+        Color::LightBlue => "#79c0ff",
+        Color::LightMagenta => "#d2a8ff",
+        Color::LightCyan => "#56d4dd",
+        Color::White => "#e6edf3",
+        _ => return None,
+    })
+}
+
+const CANVAS_BG: &str = "#0d1117";
+const DEFAULT_FG: &str = "#e6edf3";
+
+fn fg_hex(c: Color) -> String {
+    match c {
+        Color::Reset => DEFAULT_FG.to_string(),
+        Color::Rgb(r, g, b) => format!("#{r:02x}{g:02x}{b:02x}"),
+        Color::Indexed(i) => indexed_hex(i),
+        other => ansi_hex(other).unwrap_or(DEFAULT_FG).to_string(),
+    }
+}
+
+fn bg_hex(c: Color) -> Option<String> {
+    match c {
+        Color::Reset => None,
+        Color::Rgb(r, g, b) => Some(format!("#{r:02x}{g:02x}{b:02x}")),
+        Color::Indexed(i) => Some(indexed_hex(i)),
+        other => ansi_hex(other).map(str::to_string),
+    }
+}
+
+/// xterm-256 cube + grayscale ramp. The first 16 fall back to the ANSI palette.
+fn indexed_hex(i: u8) -> String {
+    match i {
+        0..=15 => {
+            const BASE: [Color; 16] = [
+                Color::Black,
+                Color::Red,
+                Color::Green,
+                Color::Yellow,
+                Color::Blue,
+                Color::Magenta,
+                Color::Cyan,
+                Color::Gray,
+                Color::DarkGray,
+                Color::LightRed,
+                Color::LightGreen,
+                Color::LightYellow,
+                Color::LightBlue,
+                Color::LightMagenta,
+                Color::LightCyan,
+                Color::White,
+            ];
+            ansi_hex(BASE[i as usize]).unwrap_or(DEFAULT_FG).to_string()
+        }
+        16..=231 => {
+            let n = i - 16;
+            let steps = [0u8, 95, 135, 175, 215, 255];
+            let r = steps[(n / 36) as usize];
+            let g = steps[((n % 36) / 6) as usize];
+            let b = steps[(n % 6) as usize];
+            format!("#{r:02x}{g:02x}{b:02x}")
+        }
+        _ => {
+            let v = 8 + (i - 232) * 10;
+            format!("#{v:02x}{v:02x}{v:02x}")
+        }
+    }
+}
+
+fn escape(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for ch in s.chars() {
+        match ch {
+            '&' => out.push_str("&amp;"),
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            '"' => out.push_str("&quot;"),
+            _ => out.push(ch),
+        }
+    }
+    out
+}
+
+/// A run of adjacent cells sharing one style — emitted as a single `<text>`
+/// element so a full-screen render stays a few hundred nodes rather than
+/// width × height of them.
+struct Run {
+    x: u16,
+    text: String,
+    fg: String,
+    bg: Option<String>,
+    bold: bool,
+    italic: bool,
+}
+
+/// Render a ratatui buffer to a standalone SVG document.
+pub fn buffer_to_svg(buf: &Buffer) -> String {
+    let area = buf.area;
+    let (w, h) = (area.width, area.height);
+    let px_w = w as f32 * CELL_W;
+    let px_h = h as f32 * CELL_H;
+
+    let mut svg = String::with_capacity(64 * 1024);
+    svg.push_str(&format!(
+        r#"<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {px_w:.0} {px_h:.0}" width="{px_w:.0}" height="{px_h:.0}" font-family="ui-monospace,'SF Mono','Cascadia Mono',Consolas,'DejaVu Sans Mono',monospace" font-size="{FONT_SIZE}">
+<rect width="100%" height="100%" rx="6" fill="{CANVAS_BG}"/>
+"#
+    ));
+
+    for y in 0..h {
+        let mut runs: Vec<Run> = Vec::new();
+        for x in 0..w {
+            let idx = (y as usize) * (w as usize) + (x as usize);
+            let Some(cell) = buf.content.get(idx) else {
+                continue;
+            };
+            let sym = cell.symbol();
+            if sym.is_empty() {
+                continue;
+            }
+            let fg = fg_hex(cell.fg);
+            let bg = bg_hex(cell.bg);
+            let bold = cell.modifier.contains(Modifier::BOLD);
+            let italic = cell.modifier.contains(Modifier::ITALIC);
+
+            match runs.last_mut() {
+                Some(r)
+                    if r.fg == fg
+                        && r.bg == bg
+                        && r.bold == bold
+                        && r.italic == italic
+                        && r.x as usize + r.text.chars().count() == x as usize =>
+                {
+                    r.text.push_str(sym);
+                }
+                _ => runs.push(Run {
+                    x,
+                    text: sym.to_string(),
+                    fg,
+                    bg,
+                    bold,
+                    italic,
+                }),
+            }
+        }
+
+        // Backgrounds first so glyphs are never painted over.
+        for r in &runs {
+            if let Some(bg) = &r.bg {
+                let cols = r.text.chars().count() as f32;
+                svg.push_str(&format!(
+                    r#"<rect x="{:.2}" y="{:.2}" width="{:.2}" height="{:.2}" fill="{}"/>
+"#,
+                    r.x as f32 * CELL_W,
+                    y as f32 * CELL_H,
+                    cols * CELL_W,
+                    CELL_H,
+                    bg
+                ));
+            }
+        }
+        for r in &runs {
+            if r.text.trim().is_empty() {
+                continue;
+            }
+            let mut attrs = String::new();
+            if r.bold {
+                attrs.push_str(r#" font-weight="bold""#);
+            }
+            if r.italic {
+                attrs.push_str(r#" font-style="italic""#);
+            }
+            // `xml:space` keeps runs of interior spaces (table padding, tree
+            // indentation) from collapsing.
+            svg.push_str(&format!(
+                r#"<text xml:space="preserve" x="{:.2}" y="{:.2}" fill="{}"{}>{}</text>
+"#,
+                r.x as f32 * CELL_W,
+                y as f32 * CELL_H + BASELINE,
+                r.fg,
+                attrs,
+                escape(&r.text)
+            ));
+        }
+    }
+
+    svg.push_str("</svg>\n");
+    svg
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui::buffer::Buffer;
+    use ratatui::layout::Rect;
+    use ratatui::style::Style;
+
+    fn probe() -> Buffer {
+        let mut buf = Buffer::empty(Rect::new(0, 0, 12, 2));
+        buf.set_string(0, 0, "tokenix", Style::default().light_blue().bold());
+        buf.set_string(0, 1, "a<b&c", Style::default());
+        buf
+    }
+
+    #[test]
+    fn emits_a_well_formed_document() {
+        let svg = buffer_to_svg(&probe());
+        assert!(svg.starts_with("<svg xmlns="));
+        assert!(svg.trim_end().ends_with("</svg>"));
+        assert_eq!(svg.matches("<svg").count(), 1);
+    }
+
+    #[test]
+    fn escapes_xml_metacharacters() {
+        let svg = buffer_to_svg(&probe());
+        assert!(svg.contains("a&lt;b&amp;c"), "must escape < and &: {svg}");
+        assert!(!svg.contains("a<b&c"));
+    }
+
+    #[test]
+    fn merges_adjacent_cells_of_one_style_into_one_run() {
+        let svg = buffer_to_svg(&probe());
+        // "tokenix" is a single styled run, not seven <text> elements.
+        assert!(svg.contains(">tokenix<"), "run not merged: {svg}");
+        assert!(svg.contains(r#"font-weight="bold""#));
+    }
+
+    #[test]
+    fn preserves_interior_whitespace() {
+        let mut buf = Buffer::empty(Rect::new(0, 0, 10, 1));
+        buf.set_string(0, 0, "a    b", Style::default());
+        let svg = buffer_to_svg(&buf);
+        assert!(svg.contains(r#"xml:space="preserve""#));
+        // The row is one default-styled run, so it carries the buffer's trailing
+        // padding too — what matters is that the interior gap survived.
+        assert!(svg.contains(">a    b"), "spacing collapsed: {svg}");
+    }
+
+    #[test]
+    fn indexed_colors_cover_cube_and_ramp() {
+        assert_eq!(indexed_hex(16), "#000000");
+        assert_eq!(indexed_hex(231), "#ffffff");
+        assert_eq!(indexed_hex(232), "#080808");
+        // Low indices fall back to the ANSI palette rather than the cube.
+        assert_eq!(indexed_hex(1), "#e5534b");
+    }
+}

--- a/src/filters.rs
+++ b/src/filters.rs
@@ -1964,6 +1964,15 @@ pub fn apply_filter(output: &str, f: &FilterDef) -> String {
 /// (`match_output` messages, `on_empty`) are suppressed — text heuristics
 /// alone miss failing commands with quiet or unusual output.
 pub fn apply_filter_with_exit(output: &str, f: &FilterDef, exit_ok: Option<bool>) -> String {
+    // Every path below splits with `.lines()` and rejoins with "\n", which
+    // launders CRLF into LF. On Windows that hands the agent a copy whose line
+    // endings differ from disk on every line — fatal if it later quotes them
+    // into an exact-match edit. Detect once here, restore once on the way out.
+    let eol = crate::compress::dominant_eol(output);
+    crate::compress::restore_eol(apply_filter_with_exit_inner(output, f, exit_ok), eol)
+}
+
+fn apply_filter_with_exit_inner(output: &str, f: &FilterDef, exit_ok: Option<bool>) -> String {
     let failed = exit_ok == Some(false);
     if failed {
         if let Some(policy) = &f.on_failure {

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -573,7 +573,11 @@ pub fn repo_hotspots(edges: &[store::GraphEdgeRow], top: usize) -> Vec<Hotspot> 
     by_degree.sort_by(|a, b| {
         let da = indeg.get(a).unwrap_or(&0) + outdeg.get(a).unwrap_or(&0);
         let db = indeg.get(b).unwrap_or(&0) + outdeg.get(b).unwrap_or(&0);
-        db.cmp(&da)
+        // Break ties on (name, path). The candidates come out of a HashMap, so
+        // without this the order among equal-degree symbols is whatever the
+        // hash seed produced — and since `candidate_cap` then truncates the
+        // list, two runs over an unchanged index reported different hotspots.
+        db.cmp(&da).then_with(|| label[a].cmp(&label[b]))
     });
 
     let candidate_cap = (top * 3).max(top);

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,10 @@ mod compress;
 mod conversation_audit;
 mod daemon;
 mod discover;
+/// Documentation screenshots are a test-time artifact, so this never ships in
+/// the binary. See `tui::tests::render_docs_svg`.
+#[cfg(test)]
+mod docshot;
 mod doctor;
 mod egress_scan;
 mod embed;

--- a/src/secrets_scan.rs
+++ b/src/secrets_scan.rs
@@ -1171,6 +1171,64 @@ mod tests {
     }
 
     #[test]
+    fn entropy_floors_are_reachable_at_the_shortest_match() {
+        // Shannon entropy over the observed distribution maxes out at log2(n)
+        // for an n-char string, so a `min_entropy` above log2(min_match_len) can
+        // never be satisfied and silently disables the rule. Regression: the URI
+        // rules paired a 5-char (resp. 4-char) floor with a 3.5 (resp. 2.8)
+        // threshold, needing 12 (resp. 7) chars — so short passwords were
+        // unreportable by arithmetic, not by choice.
+        for (label, s) in [("4 chars", "abcd"), ("7 chars", "abcdefg")] {
+            let max = (s.chars().count() as f64).log2();
+            assert!(
+                shannon_entropy(s) <= max + f64::EPSILON,
+                "{label}: entropy must be bounded by log2(len)"
+            );
+        }
+
+        // An 8-char random password in a credential-bearing URI is a real leak
+        // and must be reported by both URI rules. Residual limit worth knowing:
+        // at 8 chars the 2.8 floor still needs ~7 distinct characters, so a
+        // leet-ish password like `s3cr3t99` (6 distinct, entropy 2.5) stays
+        // missed. Closing that needs length-normalized entropy or structural
+        // scoring, not a lower constant.
+        let hits = scan_content(
+            "https://svc:Xk9mQ2vp@example.com/api\n", // gitleaks:allow synthetic test fixture
+            &bundled_rules(),
+        );
+        assert!(
+            hits.iter().any(|h| h.rule == "basic-auth-url"),
+            "8-char basic-auth password should be reported: {:?}",
+            hits.iter().map(|h| h.rule.as_str()).collect::<Vec<_>>()
+        );
+
+        let hits = scan_content(
+            "postgres://admin:Xk9mQ2vp@db.internal:5432/app\n", // gitleaks:allow synthetic test fixture
+            &bundled_rules(),
+        );
+        assert!(
+            hits.iter().any(|h| h.rule == "db-connection-uri"),
+            "8-char db password should be reported: {:?}",
+            hits.iter().map(|h| h.rule.as_str()).collect::<Vec<_>>()
+        );
+
+        // The floor still has to reject the common placeholders it was there
+        // for: `password` and `changeme` both sit at ~2.75 bits/char.
+        for placeholder in ["password", "changeme"] {
+            assert!(
+                shannon_entropy(placeholder) < 2.8,
+                "{placeholder} must stay below the 2.8 floor"
+            );
+            let uri = format!("postgres://admin:{placeholder}@localhost:5432/app\n");
+            let hits = scan_content(&uri, &bundled_rules());
+            assert!(
+                !hits.iter().any(|h| h.rule == "db-connection-uri"),
+                "{placeholder} placeholder should not be reported"
+            );
+        }
+    }
+
+    #[test]
     fn clean_conversation_yields_no_findings() {
         let hits = scan_content(
             "how do I configure the API client?\nuse the SDK.\n",

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -408,56 +408,66 @@ fn new_shell(entry: Entry) -> Shell {
 }
 
 impl Shell {
+    /// Spawn whatever the current tab needs and collect whatever finished.
+    ///
+    /// Returns `true` while background work is still in flight, which is what
+    /// drives both the spinner poll below and the headless doc renderer — the
+    /// renderer pumps until this goes quiet so it captures content instead of a
+    /// loading frame.
+    fn pump(&mut self) -> bool {
+        self.ensure_report();
+        self.ensure_gain();
+        self.ensure_secrets();
+        self.ensure_egress();
+
+        // Collect a finished background secret scan, if any.
+        let done = self.secrets_rx.as_ref().and_then(|rx| rx.try_recv().ok());
+        if let Some((findings, counts)) = done {
+            self.secrets_all = Some(findings);
+            self.secrets_counts = counts;
+            self.secrets_rx = None;
+            self.apply_sec_scope();
+        }
+
+        // Collect a finished background egress scan, if any.
+        let done = self.egress_rx.as_ref().and_then(|rx| rx.try_recv().ok());
+        if let Some((findings, counts)) = done {
+            self.egress_all = Some(findings);
+            self.egress_counts = counts;
+            self.egress_rx = None;
+            self.apply_egr_scope();
+        }
+
+        // Collect a finished background report capture, if any.
+        let done = self
+            .report_rx
+            .as_ref()
+            .and_then(|(i, rx)| rx.try_recv().ok().map(|body| (*i, body)));
+        if let Some((idx, body)) = done {
+            self.reports.insert(idx, body);
+            self.report_rx = None;
+        }
+
+        // Collect a finished background gain computation, if any.
+        let done = self.gain_rx.as_ref().and_then(|rx| rx.try_recv().ok());
+        if let Some(view) = done {
+            self.gain_cache = Some(view);
+            self.gain_rx = None;
+        }
+
+        self.secrets_rx.is_some()
+            || self.egress_rx.is_some()
+            || self.report_rx.is_some()
+            || self.gain_rx.is_some()
+    }
+
     fn event_loop(&mut self, terminal: &mut DefaultTerminal) -> Result<()> {
         loop {
-            self.ensure_report();
-            self.ensure_gain();
-            self.ensure_secrets();
-            self.ensure_egress();
-
-            // Collect a finished background secret scan, if any.
-            let done = self.secrets_rx.as_ref().and_then(|rx| rx.try_recv().ok());
-            if let Some((findings, counts)) = done {
-                self.secrets_all = Some(findings);
-                self.secrets_counts = counts;
-                self.secrets_rx = None;
-                self.apply_sec_scope();
-            }
-
-            // Collect a finished background egress scan, if any.
-            let done = self.egress_rx.as_ref().and_then(|rx| rx.try_recv().ok());
-            if let Some((findings, counts)) = done {
-                self.egress_all = Some(findings);
-                self.egress_counts = counts;
-                self.egress_rx = None;
-                self.apply_egr_scope();
-            }
-
-            // Collect a finished background report capture, if any.
-            let done = self
-                .report_rx
-                .as_ref()
-                .and_then(|(i, rx)| rx.try_recv().ok().map(|body| (*i, body)));
-            if let Some((idx, body)) = done {
-                self.reports.insert(idx, body);
-                self.report_rx = None;
-            }
-
-            // Collect a finished background gain computation, if any.
-            let done = self.gain_rx.as_ref().and_then(|rx| rx.try_recv().ok());
-            if let Some(view) = done {
-                self.gain_cache = Some(view);
-                self.gain_rx = None;
-            }
-
-            terminal.draw(|f| self.draw(f))?;
-
             // While any background work runs, poll so the shared spinner animates;
             // otherwise block until the next key.
-            let loading = self.secrets_rx.is_some()
-                || self.egress_rx.is_some()
-                || self.report_rx.is_some()
-                || self.gain_rx.is_some();
+            let loading = self.pump();
+
+            terminal.draw(|f| self.draw(f))?;
             let timeout = if loading {
                 Duration::from_millis(120)
             } else {
@@ -3163,9 +3173,15 @@ fn short_path(p: &str) -> String {
 /// Run the tokenix binary again with `args` and return its stdout (stderr if
 /// stdout is empty). Output is plain text — colors auto-disable off a TTY.
 fn capture(args: &[&str]) -> String {
-    let exe = match std::env::current_exe() {
-        Ok(p) => p,
-        Err(e) => return format!("cannot locate tokenix binary: {e}"),
+    // `TOKENIX_SELF_EXE` overrides the self-exec target. Needed by the headless
+    // doc renderer: under `cargo test` the current exe is the test harness, so
+    // re-execing it yields nothing and report tabs render empty.
+    let exe = match std::env::var_os("TOKENIX_SELF_EXE") {
+        Some(p) => std::path::PathBuf::from(p),
+        None => match std::env::current_exe() {
+            Ok(p) => p,
+            Err(e) => return format!("cannot locate tokenix binary: {e}"),
+        },
     };
     match std::process::Command::new(exe)
         .args(args)
@@ -3394,6 +3410,81 @@ mod tests {
         assert!(!s.sec_confirm, "redaction stayed armed across tabs");
         assert!(!s.studio_confirm_delete, "delete stayed armed across tabs");
         assert!(!s.stats_confirm, "install stayed armed across tabs");
+    }
+
+    /// Regenerate the README screenshots:
+    /// `cargo test --bin tokenix render_docs_svg -- --ignored --nocapture`
+    ///
+    /// Only tabs whose content is public by construction are rendered here —
+    /// bundled filters, this repo's own symbols and files, and build info. Tabs
+    /// backed by transcripts (Secrets, Egress, Usage, Gain) are deliberately
+    /// excluded until they are seeded with synthetic fixtures: rendering them
+    /// from a real machine is exactly the leak this whole approach exists to
+    /// avoid.
+    // The doc comment has to precede the attributes: between `#[test]` and
+    // `#[ignore]` it makes rustc re-apply `#[test]` in the expansion
+    // (`duplicate_macro_attributes`), which fails the `-D warnings` gate.
+    #[test]
+    #[ignore = "writes .github/prints/*.svg; run explicitly"]
+    fn render_docs_svg() {
+        use ratatui::backend::TestBackend;
+        use ratatui::Terminal;
+
+        const SAFE_TABS: &[(Cmd, &str)] = &[
+            (Cmd::Filters, "filters"),
+            (Cmd::Stats, "stats"),
+            (Cmd::Doctor, "doctor"),
+            (Cmd::Tokenmap, "tokenmap"),
+            (Cmd::Graph, "graph"),
+        ];
+
+        // Report tabs self-exec. Under `cargo test` the current exe is the test
+        // harness, so point them at the real binary sitting two levels up from
+        // `target/<profile>/deps/`.
+        let harness = std::env::current_exe().expect("current exe");
+        let bin = harness
+            .parent()
+            .and_then(|p| p.parent())
+            .expect("target dir")
+            .join(format!("tokenix{}", std::env::consts::EXE_SUFFIX));
+        assert!(
+            bin.is_file(),
+            "build the binary first (`cargo build`): {} not found",
+            bin.display()
+        );
+        std::env::set_var("TOKENIX_SELF_EXE", &bin);
+
+        let out = std::path::Path::new(".github/prints");
+        std::fs::create_dir_all(out).expect("prints dir");
+
+        for (tab, name) in SAFE_TABS {
+            let mut shell = new_shell(Entry {
+                tab: *tab,
+                usage_group: 0,
+                global: false,
+                gain_cost: false,
+            });
+
+            // Doctor, Graph and Tokenmap load on a background thread, so a frame
+            // drawn immediately captures the spinner. Pump until the loaders go
+            // quiet — bounded, because a hung child must fail the render rather
+            // than block the suite forever.
+            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(60);
+            while shell.pump() {
+                assert!(
+                    std::time::Instant::now() < deadline,
+                    "{name}: background load did not settle in 60s"
+                );
+                std::thread::sleep(std::time::Duration::from_millis(50));
+            }
+
+            let mut term = Terminal::new(TestBackend::new(120, 34)).expect("test terminal");
+            term.draw(|f| shell.draw(f)).expect("draw");
+            let svg = crate::docshot::buffer_to_svg(term.backend().buffer());
+            let path = out.join(format!("{name}.svg"));
+            std::fs::write(&path, svg).expect("write svg");
+            println!("wrote {}", path.display());
+        }
     }
 
     #[test]


### PR DESCRIPTION
> Draft — the renderer and the fixes below are done and green; the remaining work is seeding the four excluded tabs with synthetic fixtures.

## What

`docshot` draws the TUI into a ratatui `TestBackend` buffer and emits SVG, so README images become a build artifact instead of a manual screen capture. `render_docs_svg` regenerates them:

```
cargo test --bin tokenix render_docs_svg -- --ignored --nocapture
```

The module is `#[cfg(test)]` — none of it ships in the binary.

Two properties a real screenshot cannot give:

- **No private data can leak.** Only tabs that are public by construction are rendered — bundled filters, this repo's own symbols and files, build info. Secrets, Egress, Usage and Gain are deliberately excluded until they are seeded with synthetic fixtures; rendering those from a real machine is exactly the leak this approach exists to avoid.
- **Images cannot go stale silently.** Regenerating is a test run, so a tab that changes shape shows up as a diff instead of drifting from the docs for months.

SVG over PNG: sharp at any zoom, roughly an order of magnitude smaller, and diffable in review.

## Two bugs this surfaced

**`tokenix graph` was not reproducible.** `graph.svg` differed between two regeneration runs over an unchanged index. `repo_hotspots` collects candidates from a `HashMap` and sorted on degree alone, so equal-degree symbols came out in hash-seed order — and since `candidate_cap` truncates, *which* tied symbols survived changed per run. Ties now break on `(name, path)`.

Verified: two consecutive regenerations now produce byte-identical output for all five images (was 4/5).

**Two secret rules had unreachable entropy floors.** Shannon entropy over an n-character string caps at `log2(n)`, so a 3.5 floor on a `{5,63}` match cannot be met below 12 characters, and 2.8 on `{4,}` cannot be met below 7. Passwords of 5–11 and 4–6 characters were unreportable by arithmetic rather than by choice. Both now sit at 2.8 with a matching 7-character minimum — reachable at the shortest match, still below `password`/`changeme` (~2.75), which stay rejected.

That 3.5 floor came in with #61 (mine); the fix is the right call.

## Docs

README and AGENTS rewritten around what is actually measured, with the token-reduction vs provider-billed-cost distinction stated explicitly rather than implied, and the evidence review added under `docs/research/`.

⚠️ One thing to confirm before this leaves draft: the rewrite dropped the engine-invariant section #61 added to AGENTS.md — failure-signal suppression of `match_output`/`uniform_success`, `unless` failing closed, and source precedence (local > user > bundled). That behavior is live in `main`, so the docs currently understate it. Happy to fold it back into the new structure if you want it kept.

## Checks

`fmt` clean · `clippy --all-targets --all-features -D warnings` clean · **405 tests**, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
