### PR TITLE
fix: harden hook/daemon/output paths and make gain measure honestly

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,10 +9,19 @@ User-facing docs live in `README.md`; this file is the engineering contract.
 
 ```bash
 cargo build --release
-cargo test --bin tokenix          # 379 unit + golden tests
+cargo test --bin tokenix          # 411 unit + golden tests (427 with the e2e targets)
 cargo fmt --check                 # CI runs fmt FIRST — run it before pushing
 cargo clippy --bin tokenix --all-features
 ```
+
+MSRV is `1.88` (`rust-version` in Cargo.toml). The floor is not cosmetic:
+`Command` only quotes arguments safely for Windows `.cmd`/`.bat` shims from
+1.77.2 on (CVE-2024-24576), and `cmd_filter` spawns exactly those shims with
+repo-controlled argv.
+
+Model-gated tests (`--features model-tests`: ONNX inference, query cache,
+retrieval hit-rate eval) are **not** part of `cargo test`. `deep-verify.yml` runs
+them weekly and on demand — that is the only place they execute.
 
 ## Key files
 
@@ -37,8 +46,15 @@ cargo clippy --bin tokenix --all-features
 | `secrets_scan.rs` / `egress_scan.rs` | Transcript forensics — credentials and outbound destinations |
 | `discover.rs` | Replays current filters over historical agent output |
 | `transcripts.rs` | Per-agent history roots and parsers |
+| `conversation_audit.rs` | `conversation-audit` + `redact_credentials()` — the single credential masker every persisted view goes through |
+| `recordings.rs` | `filter record` sessions — captures raw output for filter authoring |
+| `memory.rs` | Cross-session notes surfaced back into context |
+| `benchmark.rs` | Retrieval benchmark harness (`tokenix benchmark`) |
+| `doctor.rs` | Environment diagnosis — GPU/EP probe, cache sizes, daemon reachability |
+| `artifacts.rs` | Reads build artifacts referenced by agent output |
+| `docshot.rs` | `#[cfg(test)]` only — renders README screenshots as SVG, never ships in the binary |
 | `tui.rs` | Ratatui shell — the only human interface |
-| `daemon.rs` | Background embedding server, port 47392 |
+| `daemon.rs` | Background embedding server, port 47392, capability-token authenticated |
 
 ## SQLite schema
 
@@ -116,10 +132,24 @@ formatting stripped. Truncated previews are forbidden.
 
 **Never break hook fallback.** `run_hook()` must `exit(0)` on any error — missing
 index, stale index, parse failure, embed error. Breaking a session is worse than
-missing a saving.
+missing a saving. This covers **panics too**: `main::guard_hook` wraps every hook
+entry point in `catch_unwind`, because an unwind used to exit 101 (and skip
+Antigravity's `decision:allow`), which is the one outcome the contract exists to
+prevent. The MCP server has the same guard per `tools/call`
+(`mcp::call_tool_guarded`) — one bad request must not take the session's server
+down with it.
 
 **Hook exit codes:** `0` = pass through · `2` = block tool (stderr becomes the
 agent's context). Never exit `1`.
+
+**Nothing persisted carries a raw credential.** `store::log_hook_event`
+(`command`, `input_preview`) and the failure tee run through
+`conversation_audit::redact_credentials` before writing; `~/.tokenix` files and
+directories are created `0600`/`0700` (`store::restrict_to_owner`, no-op on
+Windows). The one exception is `recall`'s blobs: `retrieve` promises the exact
+original bytes and `find_identical` verifies against them, so those are protected
+by permissions only. Add a masking rule in **one** place — `redact_credentials`
+— and every writer inherits it.
 
 **Never mask a failure.** Non-zero exit suppresses success sentinels
 (`match_output`, `on_empty`). A filter that can empty a failure payload must keep
@@ -147,6 +177,15 @@ extensions and breaks traversal.
 **Daemon is optional.** If `tokenix serve` is not running, `handle_grep()`
 autostarts it and retries once (800 ms), then falls back to in-process embed.
 
+**The daemon socket is authenticated.** `serve` writes a fresh 32-hex capability
+token to `~/.tokenix/daemon.token` (`0600`) before it binds, and every `search`
+request must present it. `127.0.0.1` is not access control: on a shared host any
+local account can reach the port, and `search` returns indexed *source* for any
+`project_root` the caller names. A missing or stale token is rejected, and the
+client degrades exactly as it does for an unreachable daemon (in-process embed).
+`health`/`status` stay open — they carry no repository content. `serve` refuses to
+start if it cannot write the token; never add an unauthenticated fallback.
+
 **Cross-platform paths:** `tokenix_bin_path()` normalizes to forward slashes for
 shell/JSON config strings.
 
@@ -161,6 +200,20 @@ measurement. Published work found token reduction and provider-billed cost are
 close to uncorrelated (r = 0.15) because cache traffic dominates a real bill. Do
 not add a savings-in-dollars headline until cache-aware accounting lands. See
 `docs/research/2026-08-token-economy.md`.
+
+**`gain`'s denominator includes the runs that saved nothing.** Every command that
+goes through `tokenix run` is logged — `action="intercepted"` when it shrank,
+`action="pass"` when it did not — and `pct_saved` divides by both. Logging only
+the wins made the headline "how much do we save when we save", a number that
+cannot go down. Never reintroduce a `if saved > 0` guard around `log_hook_event`.
+
+**`gain` reports session shape alongside tokens.** `gain::session_stats`
+sessionizes the hook log by time gaps (no session id is stored) and reports
+sessions, mean calls/session, and within-session re-requests of the same
+tool+subject — the measurable share of the "+13.8% turns" mechanism by which
+compression savings invert (arXiv 2607.12161). These are diagnostics: without a
+holdout control group no causal Δturns claim is possible, so `SessionStats` must
+stay descriptive and never feed a headline number.
 
 **Keep docs in sync.** Every new or changed user-facing feature MUST update both
 `README.md` (Commands, and any affected section) and this file in the same change.
@@ -189,8 +242,10 @@ passthrough only takes over when filtering emptied *non-empty* output.
 
 Repo-local filters are trust-gated (`tokenix trust`, SHA-256 in
 `~/.tokenix/trusted_filters.json`) and skipped until approved. Failed commands
-with clipped output tee raw text to `~/.tokenix/tee/` with a `[full output: path]`
-hint (`TOKENIX_TEE=0` disables). `TOKENIX_DISABLED=1` bypasses the hook for one
+with clipped output tee raw text to `~/.tokenix/tee/` with a
+`[full output (credentials masked): path]` hint (`TOKENIX_TEE=0` disables). The
+hint says "masked" on purpose — the file is redacted, so the agent must not read a
+`[REDACTED]` as the literal value. `TOKENIX_DISABLED=1` bypasses the hook for one
 command (logged as `action="bypassed"`).
 
 **Adding a filter:** create `assets/filters/<slug>.toml` with **≥2 embedded
@@ -226,6 +281,21 @@ from a `[tokenix: ...]` marker in the compressed output. Re-read suppression use
 **exact hashes only** — fuzzy/similarity dedup is refused on purpose, because
 hiding *altered* output makes the agent act on a reality that no longer exists.
 
+The key is advertised on the **first** clipped run, not only on a later dedup hit:
+a successful command that dropped ≥ `RECOVERY_HINT_MIN_DROPPED_BYTES` (500) gets
+`[tokenix: N bytes not shown — tokenix retrieve <key> ...]` appended. Before that,
+the raw blob was stashed and the key thrown away, so the single output most worth
+recovering — a big first result the caps just trimmed — had no way back except
+re-running the command. Failures take the tee path instead.
+
+Cross-call dedup is scoped to the **project** and to `TOKENIX_DEDUP_TTL`
+(default 3600 s, `recall::reusable`). The index lives in `~/.tokenix` and outlives
+both the session and the checkout, and the marker claims the output "is already in
+this conversation" — a hit from another repository, or from yesterday, cannot
+honour that. Entries written before scoping existed deserialize with an empty
+`project` and therefore never match. Re-read suppression keeps its own 900 s TTL
+(`TOKENIX_READ_DEDUP_TTL`).
+
 ## One interface
 
 A bare `tokenix` or any human report command on a TTY opens the ratatui shell on
@@ -245,10 +315,14 @@ per-grammar identifier node kinds (`constant` Ruby, `name` PHP,
 `simple_identifier` Kotlin/Swift) in `find_first_identifier`.
 
 **New embedding model:** append a `ModelSpec` to `embed.rs::MODELS`. Built-in uses
-`ModelSource::BuiltIn`; custom uses `ModelSource::Custom { hf_repo, onnx_file, pooling }`
-(downloaded to `<model_cache>/custom/<id>/`). The active model is **stamped in the
-index `meta`** and read back by query/hook/daemon, so vectors always match. It is
-sticky across re-indexes; an explicit switch forces a full re-embed. Cache keys are
+`ModelSource::BuiltIn`; custom uses
+`ModelSource::Custom { hf_repo, revision, onnx_file, pooling }` (downloaded to
+`<model_cache>/custom/<id>/`). `revision` must be a **commit SHA, never a branch**:
+`resolve/main` let the same tokenix build load different weights on two machines
+with no signal, while a commit is content-addressed — which is why there is no
+separate digest list to maintain. The active model is **stamped in the index
+`meta`** and read back by query/hook/daemon, so vectors always match. It is sticky
+across re-indexes; an explicit switch forces a full re-embed. Cache keys are
 namespaced by model id.
 
 **New secret rule:** `assets/secret-rules/*.toml`, `[[rules]]` with `id`,
@@ -268,9 +342,36 @@ echo '{"toolName":"view","toolArgs":"{\"path\":\"src/main.rs\"}"}' | tokenix hoo
 tokenix gain --history
 ```
 
+## Project config
+
+`.tokenix.toml` (or `tokenix.toml`) at the project root, `[hook]` and `[index]`
+sections. Both are `deny_unknown_fields`, and a parse error is reported on stderr
+instead of silently falling back to defaults — the previous `.ok()` swallow left
+users convinced a misspelled `read_min_lines` was active. A bad config still
+degrades to defaults rather than failing the hook.
+
+## CI topology
+
+| Workflow | Trigger | Gate? |
+|---|---|---|
+| `rust.yml` | push/PR | fmt + clippy (Linux), `cargo test` on **Linux + Windows** |
+| `homologation.yml` | push/PR | release build, CLI smoke, hook/Copilot scripts, aarch64 sanity |
+| `supply-chain.yml` | push/PR + weekly | cargo-deny, zizmor, install-path egress audit |
+| `security.yml` | push to main | gitleaks (reusable workflow, SHA-pinned) |
+| `release.yml` | push to main | CI gate on **Linux + Windows**, then bump → build → attest → release → crates.io |
+| `deep-verify.yml` | weekly + dispatch | `--features model-tests`; filter reports as artifacts (not a gate) |
+| `scorecard.yml` / `release-drafter.yml` / `cflite_pr.yml` | — | posture, notes, fuzzing |
+
+The release CI gate runs the Windows leg too. It did not, and `release.yml` fires
+independently of `rust.yml`, so a Windows-only failure still shipped binaries —
+on the platform where the PowerShell rewriting, cmd quoting and `C:\` handling are
+the only code paths that execute.
+
 ## Release
 
 `feat:` / `fix:` / `perf:` on `main` auto-cuts a public GitHub release and bumps
-`Cargo.toml`. Use `test:` / `ci:` / `chore:` to avoid one. CI runs `cargo fmt`
-first, so an unformatted push fails before anything else. Never quote GitHub's
-auto-skip phrase in a commit body — it skips every workflow.
+`Cargo.toml`. Use `test:` / `ci:` / `chore:` to avoid one. The type prefix is read
+from the commit **subject** only (`%s`); the body (`%b`) is scanned solely for
+`BREAKING CHANGE:`, so quoting "fix: …" inside a body no longer cuts a release.
+CI runs `cargo fmt` first, so an unformatted push fails before anything else. Never
+quote GitHub's auto-skip phrase in a commit body — it skips every workflow.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,7 +119,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -130,7 +130,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -525,7 +525,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -930,7 +930,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1013,7 +1013,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1356,9 +1356,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.14"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+checksum = "839c0e8a181239723652be9062bb56ca5bf5f64011f73b623f6f4fc59086a228"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -3359,7 +3359,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3418,7 +3418,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3684,7 +3684,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3880,7 +3880,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3893,7 +3893,7 @@ dependencies = [
  "parking_lot",
  "rustix",
  "signal-hook",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4869,7 +4869,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,13 @@
 name = "tokenix"
 version = "0.63.0"
 edition = "2021"
+# Floor, not a preference. Two things break silently below it: `Command` only
+# quotes arguments safely for Windows `.cmd`/`.bat` shims since 1.77.2
+# (CVE-2024-24576), and `cmd_filter` spawns exactly those shims with
+# repo-controlled argv. 1.88 is where the dependency tree already lands
+# (ratatui, image, time), so this costs nothing and makes the assumption fail
+# at build time instead of at exploit time.
+rust-version = "1.88"
 description = "Semantic search, symbol graphs, secrets scanning, output filters, and CLI hooks that save 60-90% LLM tokens"
 license = "MIT"
 repository = "https://github.com/juninmd/tokenix"

--- a/README.md
+++ b/README.md
@@ -94,6 +94,12 @@ benchmark checks retrieval:
   work with there.
 - **Semantic Grep is never counted as savings.** The native grep output is unknown
   before interception, so `tokenix gain` logs it as neutral usage.
+- **Runs that saved nothing are in the denominator.** Every command routed through
+  `tokenix run` is measured, including the ones that came back the same size.
+  Earlier builds logged only the runs that shrank, which answered "how much do we
+  save when we save" — a percentage that cannot go down. The 67.4% row above was
+  measured under the old method and reads high for that reason; it will be
+  re-measured before the next release.
 - **Savings depend on your codebase, file sizes, and agent behavior.** Run
   `tokenix gain` to see measured numbers on your machine rather than ours.
 
@@ -369,7 +375,7 @@ repo-local `opencode.json` MCP registration.
 | `tokenix doctor` | Diagnose embedding backend, GPU, model cache, daemon, filter inventory, and filter config |
 | `tokenix serve` / `stop` | Start or stop the background embedding daemon |
 | `tokenix daemon status\|stop\|restart` | Inspect (pid, port, uptime, model, cache RAM) or control the daemon |
-| `tokenix gain` | Tokens removed, split by source — Read interception vs command filters; semantic Grep counts as neutral usage (`--cost-estimate`, `--economics`) |
+| `tokenix gain` | Tokens removed, split by source — Read interception vs command filters; semantic Grep counts as neutral usage. Reports session shape (sessions, calls/session, within-session re-requests — the measurable share of the "+turns" inversion mechanism) and (`--cost-estimate`, `--economics`) |
 | `tokenix discover` | Replay current filters over historical agent output — measured recoverable savings plus uncovered commands (`--agent`, `--top`, `--json`) |
 | `tokenix retrieve KEY` | Print the exact original output a compressed run stashed; the key comes from a `[tokenix: ...]` marker |
 | `tokenix trust` / `untrust` | Approve (SHA-256 pinned) or revoke this repo's `.tokenix/filters` (`--status`) |
@@ -403,6 +409,14 @@ repo-local `opencode.json` MCP registration.
 the dashboard, same as `TOKENIX_NO_TUI=1`), `TOKENIX_BRANCH_AWARE=true` (suffix the
 SQLite DB per git branch), `TOKENIX_DISABLED=1` (bypass the hook for one command),
 `TOKENIX_MAX_OUTPUT_TOKENS` (global output ceiling, default 8000, `0` disables).
+
+**Dedup** — repeated identical command output collapses to a one-line pointer.
+`TOKENIX_DEDUP=0` disables it, `TOKENIX_DEDUP_MIN_TOKENS` sets the floor (default
+200), `TOKENIX_DEDUP_TTL` how long an earlier run stays usable (default 3600 s).
+Matches are scoped to the current project and verified byte-for-byte against the
+stash, so a pointer is only emitted for output this checkout really produced.
+Re-read suppression is separate: `TOKENIX_READ_DEDUP=0`,
+`TOKENIX_READ_DEDUP_TTL` (900 s), `TOKENIX_READ_DEDUP_MIN_TOKENS` (1500).
 
 **`tokenix index`** — `--force/-f`, `--cpu-profile <low|default|max>`, `--jobs N`,
 `--embed-batch N` (default 16 CPU / 64 GPU), `--if-stale`, `--path/-p`,
@@ -493,7 +507,11 @@ cases**, enforced in CI along with never-mask-failure and no-inflation checks.
 pipeline.
 
 Failed commands with clipped output tee the raw text to `~/.tokenix/tee/` with a
-`[full output: path]` hint (`TOKENIX_TEE=0` disables).
+`[full output (credentials masked): path]` hint (`TOKENIX_TEE=0` disables).
+
+A **successful** command whose output was clipped by more than 500 bytes gets a
+recovery hint instead: `[tokenix: N bytes not shown — tokenix retrieve <key> …]`.
+Compression is never a one-way door — the raw text is stashed either way.
 
 ---
 
@@ -528,21 +546,37 @@ language mapping in `.tokenix.toml`.
   embeddings, FTS5 for lexical search.
 - **Embeddings** — in-process ONNX via `fastembed`. No daemon required; if
   `tokenix serve` is running it keeps the model in RAM and answers over a local
-  socket, otherwise the hook embeds in-process.
+  socket, otherwise the hook embeds in-process. The socket is bound to
+  `127.0.0.1` **and** authenticated with a capability token in
+  `~/.tokenix/daemon.token` (mode `0600`, regenerated on every start), because on
+  a shared host loopback alone would let any other local account read your
+  indexed source.
 - **GPU (opt-in)** — DirectML on Windows, CUDA 12.x + cuDNN 9.x on Linux/Windows.
   `tokenix doctor` reports what is detected.
+- **Local data** — everything tokenix writes lives under `~/.tokenix/`. Command
+  lines and command output are masked for credential shapes before they are
+  persisted (hook log, failure tee), and files are created owner-only (`0600`).
+  `tokenix retrieve` blobs are the deliberate exception: they must return the
+  exact original bytes, so they rely on permissions alone.
 
 ---
 
 ## 🔒 Security
 
 - **Everything is local.** No code, prompt, or transcript leaves your machine. The
-  only network access is the one-time embedding-model download.
+  only network access is the one-time embedding-model download, pinned to a commit
+  SHA on the hub so the weights you get are the weights we tested.
 - **Repo-local filters are untrusted by default** and skipped until `tokenix trust`
   pins their SHA-256 — a cloned repository cannot silently rewrite what your agent
   sees.
 - **Secrets are never indexed.** `.env`, `.pem`, and similar files are excluded,
   and `tokenix scan-secrets` redacts by default.
+- **Credentials are masked before anything is persisted.** Command lines and
+  failing-command output are the places tokens actually appear, so the hook log and
+  the failure tee are redacted on write, and `~/.tokenix` is owner-only (`0600`).
+- **The embedding daemon is authenticated**, not merely bound to loopback: on a
+  shared host any local account can reach a `127.0.0.1` port, so `search` requires
+  the capability token from `~/.tokenix/daemon.token`.
 - **Supply chain** — releases publish `sha256sums.txt` and SLSA provenance;
   workflows are SHA-pinned and covered by `cargo-deny`, `zizmor`, and OpenSSF
   Scorecard. See [SECURITY.md](SECURITY.md).

--- a/docs/research/2026-08-token-economy.md
+++ b/docs/research/2026-08-token-economy.md
@@ -690,3 +690,77 @@ n=20 is not.
 - TACO's headline is **1–4% accuracy gain**, not a large compression number, and
   the "200 hand-curated rules plateaued" figure could not be extracted from the
   paper — treat as unverified positioning.
+
+---
+
+## Deep sweep (pass 4) — implementation audit + August literature, 2026-08-22
+
+Status of the Tier 0–3 decision list in the actual tree (working tree has the
+WIP uncommitted; `cargo test --bin tokenix` = **411 passed / 0 failed / 10
+ignored**, 18.3 s).
+
+### Implementation vs decision list
+
+| Decision item | Status | Evidence in tree |
+|---|---|---|
+| T0.1 bytes→chars tokenizer | **DONE** | `chunker.rs:92` counts chars; test `count_tokens_counts_chars_not_bytes` |
+| T0.1 accurate tokenizer | **DONE, deviated** | `embed.rs:179` uses HF `tokenizers` (not `bpe`); query display only, hot path keeps chars/4 |
+| T0.2 billed-cost in `gain` | **DONE, half** | `MODELS` pricing incl. cache_read/write (`gain.rs:10-101`), `usage_cost`, `economics()` blended cpt from real usage mix, `gain --economics` (`main.rs:2745`). **Δturns NOT reported** — the documented inversion mechanism is still unmeasured |
+| T0.3 holdout mode | **MISSING** | no `TOKENIX_HOLDOUT` anywhere |
+| T0.4 OTLP receiver | **MISSING** | no otlp usage in daemon |
+| T1.5 edit-anchor (CRLF) | **DONE** | `restore_eol`/`dominant_eol` (`compress.rs:1318-1344`, `filters.rs:1971`) — pass-3 hazard #1 closed |
+| T1.5 edit-anchor (signature) | **OPEN** | `extract_full_signature` (`chunker.rs:912`) still normalizes whitespace + truncates with `…` — re-derived, quotable-looking, not a verbatim slice |
+| T1.6 shell-consumer guard | **MISSING** | no `IsTerminal` on the `tokenix run` path (only `tui.rs:301`) |
+| T1.7 NAP harness | **MISSING** | no action-preservation in `cmd_filter.rs` |
+| T2.8 PostToolUse `updatedToolOutput` | **MISSING** | no reference in `hook.rs` |
+| T2.9 `prompt-audit --recommend` | **DONE** | `mcp_audit.rs:1201` `recommendations_for_agent`, wired `main.rs:1431` |
+| T2.10 code embedding swap | **HALF** | `jina-code` registered (`embed.rs:95`); default remains `nomic-v1.5` |
+| T3.11 CORE-Bench | **MISSING** | `benchmark.rs` is still the internal harness |
+| Pass-3 secrets entropy fix | **DONE** | both bundled rules at 2.8 with 7-char floors |
+
+### New literature since pass 3
+
+1. **Don't Break the Cache** ([2601.06007](https://arxiv.org/abs/2601.06007),
+   Lumer et al., PwC) — 500+ agent sessions, DeepResearchBench, OpenAI/Anthropic/
+   Google. Caching cuts cost **41–80%**; naive full-context caching can
+   *increase* latency; dynamic content must append strictly at the **end**;
+   tool-schema drift mid-session breaks the cache. Third independent confirmation
+   that the only safe place to compress is **write time** — and that `prompt-audit`
+   (schema-stability) sits on the same axis the paper names.
+2. **TokenPilot** ([2606.17016](https://arxiv.org/abs/2606.17016), June 2026) —
+   cache continuity vs text sparsity, prefix stabilization at ingestion:
+   **61%/87%** cost cuts in isolated/continuous mode. Same conclusion: mutating
+   the cached prefix is the expensive failure mode. tokenix's "compress at write
+   time, never rewrite history" is exactly their mechanism.
+3. **SkillReducer** ([2603.29919](https://arxiv.org/abs/2603.29919), March 2026) —
+   optimizing agent *skills* for token efficiency. The always-on context lane
+   pass 2 measured (13k tokens of skills on this machine) now has a named
+   research thread — `prompt-audit --recommend` is the local expression.
+4. **CAPC** ([2607.15516](https://arxiv.org/abs/2607.15516)) — already cited;
+   new detail worth recording: Sonnet 4.6 cache has a **two-tier threshold near
+   3,500 tokens**, below which ρ plateaus at ~0.83 — compression that pushes the
+   cached prefix into the hot tier loses more than it saves.
+
+### Verdict
+
+The architecture is on the correct side of every line the 2026 literature draws:
+write-time compression (before the observation enters history), never rewriting a
+cached prefix (2601.06007 / 2606.17016 / 2607.12161 all converge here),
+deterministic rules over learned compressors, exact-hash dedup only, CRLF
+byte-exactness. **No architectural correction is needed.**
+
+The gap is measurement, exactly as pass 2 predicted: `gain` remains an L1 claim
+(tokens removed), holdout and NAP are absent, Δturns is absent. Cheapest closes,
+in order: **Δturns in `gain`** (hours), **verbatim signature slice** in
+`extract_full_signature` (hours, closes the last open anchor hazard), **holdout
+mode** (a day, the bar for any causal claim). PostToolUse, OTLP and CORE-Bench
+stay ranked behind those.
+
+**Closed same day (2026-08-22):** the two hour-scale items. `generate_outline`
+now slices the declaration verbatim from the file's own bytes
+(`extract_signature_verbatim` + `line_starts` in `chunker.rs`), preserving
+indentation, line breaks and CRLF — the re-derived, truncating `…` form is gone.
+`gain` now prints session shape (`gain::session_stats`): sessions inferred from
+time gaps, mean/max calls per session, and within-session re-requests of the
+same tool+subject — the measurable share of the "+13.8% turns" inversion
+mechanism — as a diagnostic that stays descriptive until holdout lands.

--- a/src/chunker.rs
+++ b/src/chunker.rs
@@ -124,7 +124,12 @@ pub fn redact_secrets(content: &str) -> String {
     out
 }
 
+/// `deny_unknown_fields` for the same reason `FilterDef` has it: a typo'd key
+/// that silently does nothing is worse than a loud failure, because the user
+/// believes the setting is active. A misspelled `read_min_lines` left the hook
+/// on its 200-line default with no way to notice.
 #[derive(serde::Deserialize, Default, Clone)]
+#[serde(deny_unknown_fields)]
 struct ProjectConfig {
     #[serde(default)]
     languages: std::collections::HashMap<String, String>,
@@ -137,6 +142,7 @@ struct ProjectConfig {
 /// `[hook]` section of `.tokenix.toml`. All fields optional; defaults live at
 /// the use sites in hook.rs so the fail-open contract is untouched.
 #[derive(serde::Deserialize, Default, Clone)]
+#[serde(deny_unknown_fields)]
 pub struct HookConfig {
     /// Read intercept: files with at least this many lines return an outline
     /// instead of full content (default 200).
@@ -153,6 +159,7 @@ pub fn hook_config() -> HookConfig {
 
 /// `[index]` section of `.tokenix.toml`. All fields optional.
 #[derive(serde::Deserialize, Default, Clone)]
+#[serde(deny_unknown_fields)]
 pub struct IndexConfig {
     /// Extra directory names to ignore, in addition to the built-in list.
     #[serde(default)]
@@ -175,43 +182,44 @@ pub fn index_config() -> IndexConfig {
     load_project_config().map(|c| c.index).unwrap_or_default()
 }
 
+/// Parse the project config from disk. A malformed or typo'd file is reported on
+/// stderr rather than swallowed: silently falling back to defaults left users
+/// convinced a setting was active when it never parsed. Still returns `None` so
+/// every caller keeps its documented default — a bad config degrades, it does
+/// not break the hook's fail-open contract.
+fn read_project_config() -> Option<ProjectConfig> {
+    let cwd = std::env::current_dir().ok()?;
+    let root = crate::store::find_project_root(&cwd);
+    for name in [".tokenix.toml", "tokenix.toml"] {
+        let path = root.join(name);
+        if !path.exists() {
+            continue;
+        }
+        let content = std::fs::read_to_string(&path).ok()?;
+        return match toml::from_str(&content) {
+            Ok(cfg) => Some(cfg),
+            Err(e) => {
+                eprintln!(
+                    "[tokenix] ignoring {} (using defaults): {e}",
+                    path.display()
+                );
+                None
+            }
+        };
+    }
+    None
+}
+
 fn load_project_config() -> Option<ProjectConfig> {
+    // Tests mutate `.tokenix.toml` between cases, so they must not memoize.
     #[cfg(test)]
     {
-        let cwd = std::env::current_dir().ok()?;
-        let root = crate::store::find_project_root(&cwd);
-        let config_path = root.join(".tokenix.toml");
-        if config_path.exists() {
-            let content = std::fs::read_to_string(&config_path).ok()?;
-            return toml::from_str(&content).ok();
-        }
-        let config_path2 = root.join("tokenix.toml");
-        if config_path2.exists() {
-            let content = std::fs::read_to_string(&config_path2).ok()?;
-            return toml::from_str(&content).ok();
-        }
-        None
+        read_project_config()
     }
     #[cfg(not(test))]
     {
         static PROJECT_CONFIG: OnceCell<Option<ProjectConfig>> = OnceCell::new();
-        PROJECT_CONFIG
-            .get_or_init(|| {
-                let cwd = std::env::current_dir().ok()?;
-                let root = crate::store::find_project_root(&cwd);
-                let config_path = root.join(".tokenix.toml");
-                if config_path.exists() {
-                    let content = std::fs::read_to_string(&config_path).ok()?;
-                    return toml::from_str(&content).ok();
-                }
-                let config_path2 = root.join("tokenix.toml");
-                if config_path2.exists() {
-                    let content = std::fs::read_to_string(&config_path2).ok()?;
-                    return toml::from_str(&content).ok();
-                }
-                None
-            })
-            .clone()
+        PROJECT_CONFIG.get_or_init(read_project_config).clone()
     }
 }
 
@@ -899,39 +907,81 @@ pub fn chunk_by_lines(lines: &[&str], path: &str) -> Vec<Chunk> {
     out
 }
 
-/// Extract the full declaration signature up to (but not including) the body opening.
-/// Joins multi-line parameter lists and normalizes whitespace.
-fn extract_full_signature(content: &str) -> String {
-    let mut parts: Vec<&str> = Vec::new();
-    for line in content.lines() {
-        let trimmed = line.trim();
-        parts.push(trimmed);
-        // Body starts at `{` on its own or at end of line, or Python `:` ending the def
-        if trimmed.ends_with('{') || trimmed == "{" {
-            break;
-        }
-        if trimmed.ends_with(':')
-            && !trimmed.starts_with("//")
-            && !trimmed.starts_with('#')
-            && !trimmed.contains("=>")
+/// Longest a declaration may run before the scan gives up looking for a body
+/// opener. Bounds `extract_signature_verbatim` so a language whose bodies open
+/// on none of its markers cannot turn one outline entry into the rest of the file.
+const MAX_SIGNATURE_LINES: usize = 12;
+
+/// Byte offset of every line start in `content`, computed from the raw bytes so
+/// CRLF files keep their `\r\n` in verbatim slices (`.lines()` would strip it).
+fn line_starts(content: &str) -> Vec<usize> {
+    let mut starts = Vec::new();
+    let mut off = 0usize;
+    for chunk in content.split_inclusive('\n') {
+        starts.push(off);
+        off += chunk.len();
+    }
+    starts
+}
+
+/// Verbatim slice of the declaration that opens at `start_line` (1-based),
+/// taken directly from the file's own bytes up to the body-opening line.
+/// Indentation, spacing and line endings survive unchanged, so anything the
+/// agent quotes from an outline matches disk exactly. The previous
+/// whitespace-normalized re-derivation was the most quotable-looking, least
+/// quotable thing an outline could emit: measured elsewhere, rewriting the
+/// bytes an edit tool must reproduce dropped successful patch application
+/// from 27/40 to 15/40.
+fn extract_signature_verbatim(
+    content: &str,
+    start_line: usize,
+    end_line: usize,
+    line_starts: &[usize],
+) -> String {
+    let Some(&start) = line_starts.get(start_line.saturating_sub(1)) else {
+        return String::new();
+    };
+    // Never scan past the declaration's own chunk, and never past a handful of
+    // lines within it. Not every language opens its body on one of the markers
+    // below - VB (Sub ... End Sub) opens on none of them, and a Python def with
+    // a trailing comment hides its colon - so an unbounded scan would splice the
+    // whole rest of the file into one outline entry.
+    let limit_line = end_line
+        .max(start_line)
+        .min(start_line + MAX_SIGNATURE_LINES - 1);
+    let limit = line_starts
+        .get(limit_line)
+        .copied()
+        .unwrap_or(content.len());
+    let mut end = start;
+    let mut opened = false;
+    for chunk in content[start..limit].split_inclusive('\n') {
+        let trimmed = chunk.trim_end();
+        end += chunk.len();
+        // Body opens on `{` (brace languages), on `:` ending a Python `def`
+        // (but not a comment or a dict-literal line), or on a `;`-terminated
+        // statement. The opening line itself stays in the slice, verbatim.
+        if trimmed.ends_with('{')
+            || trimmed.ends_with(';')
+            || (trimmed.ends_with(':')
+                && !trimmed.starts_with("//")
+                && !trimmed.starts_with('#')
+                && !trimmed.contains("=>"))
         {
-            break;
-        }
-        if trimmed.ends_with(';') {
+            opened = true;
             break;
         }
     }
-    let joined = parts.join(" ");
-    // Strip trailing `{` or `:` left by the loop-break line
-    let sig = joined.trim_end_matches('{').trim_end_matches(':').trim();
-    // Collapse internal whitespace runs
-    let sig: String = sig.split_whitespace().collect::<Vec<_>>().join(" ");
-    if sig.chars().count() > 200 {
-        let truncated: String = sig.chars().take(197).collect();
-        format!("{}…", truncated)
-    } else {
-        sig
+    if !opened {
+        // No recognizable body opener: the declaration line alone, still
+        // verbatim, beats an arbitrary slab of the file.
+        end = line_starts
+            .get(start_line)
+            .copied()
+            .unwrap_or(content.len())
+            .min(limit);
     }
+    content[start..end].to_string()
 }
 
 /// Look for a single-line doc comment on the line immediately before the chunk.
@@ -1195,6 +1245,7 @@ pub fn generate_outline(content: &str, path: &str) -> String {
     }
 
     let lines: Vec<&str> = content.lines().collect();
+    let starts = line_starts(content);
     let chunks = chunk_file(path, content);
 
     if chunks.is_empty() {
@@ -1214,7 +1265,7 @@ pub fn generate_outline(content: &str, path: &str) -> String {
     )];
 
     for c in &chunks {
-        let sig = extract_full_signature(&c.content);
+        let sig = extract_signature_verbatim(content, c.start_line, c.end_line, &starts);
         let doc = extract_doc_comment(&lines, c.start_line);
         let doc_suffix = doc.map(|d| format!("  // {}", d)).unwrap_or_default();
         let label = if c.symbol.is_empty() {
@@ -1481,6 +1532,27 @@ create or replace view saldo_vw as select * from clientes;
     }
 
     #[test]
+    fn project_config_rejects_typos_instead_of_ignoring_them() {
+        // Parsed directly rather than through a file: `load_project_config` reads
+        // a fixed path in the cwd, and a second test doing that would race with
+        // `custom_extension_indexing_and_detection`.
+        let good: Result<ProjectConfig, _> = toml::from_str("[hook]\nread_min_lines = 120\n");
+        assert!(good.is_ok(), "{:?}", good.err());
+        assert_eq!(good.unwrap().hook.read_min_lines, Some(120));
+
+        // The failure this locks: a misspelled key used to parse fine and do
+        // nothing, so the hook silently stayed on its 200-line default.
+        let typo: Result<ProjectConfig, _> = toml::from_str("[hook]\nread_min_line = 120\n");
+        assert!(typo.is_err(), "a typo'd key must not parse silently");
+
+        let bad_section: Result<ProjectConfig, _> = toml::from_str("[hooks]\nx = 1\n");
+        assert!(bad_section.is_err(), "an unknown section must not parse");
+
+        let bad_index: Result<ProjectConfig, _> = toml::from_str("[index]\nredact_secret = true\n");
+        assert!(bad_index.is_err(), "[index] must be strict too");
+    }
+
+    #[test]
     fn should_index_rejects_minified() {
         assert!(!should_index(std::path::Path::new("bundle.min.js")));
         assert!(!should_index(std::path::Path::new("app.min.css")));
@@ -1677,6 +1749,49 @@ void globalFunc() {
             "outline: {}",
             &out[..200.min(out.len())]
         );
+    }
+
+    #[test]
+    fn outline_signature_is_a_verbatim_slice() {
+        // A multi-line parameter list keeps its original indentation and line
+        // breaks — a whitespace-normalized copy would not match disk bytes, and
+        // an agent quoting it into an exact-match edit would fail to apply.
+        let code = "fn add(\n    a: i32,\n    b: i32,\n) -> i32 {\n    0\n}\n";
+        let out = generate_outline(code, "src/x.rs");
+        assert!(
+            out.contains("fn add(\n    a: i32,\n    b: i32,\n) -> i32 {"),
+            "outline must quote the exact declaration, got: {}",
+            out
+        );
+    }
+
+    #[test]
+    fn outline_signature_preserves_crlf_verbatim() {
+        // Windows files come back CRLF; the outline must keep `\r\n` so a quoted
+        // signature matches the bytes on disk byte-for-byte.
+        let code = "fn add(\r\n    a: i32,\r\n) -> i32 {\r\n    0\r\n}\r\n";
+        let out = generate_outline(code, "src/x.rs");
+        assert!(
+            out.contains("fn add(\r\n    a: i32,\r\n) -> i32 {"),
+            "outline must preserve CRLF, got: {}",
+            out.replace('\r', "␍")
+        );
+    }
+
+    #[test]
+    fn outline_signature_is_bounded_when_no_body_opener_exists() {
+        // VB bodies open on none of the markers the scan looks for, so an
+        // unbounded scan walked past the declaration and spliced the rest of the
+        // file into the first outline entry.
+        let code = "Sub First()\n".to_string()
+            + &"    Debug.Print 1\n".repeat(50)
+            + "End Sub\n\nSub Second()\n    Debug.Print 2\nEnd Sub\n";
+        let out = generate_outline(&code, "src/x.bas");
+        assert!(
+            !out.contains("End Sub"),
+            "a signature must not swallow the body, got: {out}"
+        );
+        assert!(out.contains("Sub First()"), "{out}");
     }
 
     #[test]

--- a/src/compress.rs
+++ b/src/compress.rs
@@ -1441,8 +1441,10 @@ fn enforce_token_budget(s: &str) -> String {
         return s.to_string();
     }
 
-    // Convert the token budget into a char budget using this payload's own
-    // observed density, rather than assuming a fixed chars-per-token ratio.
+    // Convert the token budget into a char budget. `count_tokens` is chars/4
+    // rounded up, so this ratio is ~4 by construction — it is written as a
+    // division rather than a constant so the conversion stays correct if
+    // `count_tokens` ever becomes a real BPE count (roadmap).
     let char_count = s.chars().count();
     let chars_per_token = (char_count as f64 / tokens as f64).max(1.0);
     let char_budget = (budget as f64 * chars_per_token) as usize;
@@ -2263,6 +2265,9 @@ fn powershell_program() -> &'static str {
     })
 }
 
+/// Below this, the recovery hint costs more than the content it points at.
+const RECOVERY_HINT_MIN_DROPPED_BYTES: usize = 500;
+
 const TEE_MAX_FILES: usize = 20;
 const TEE_MAX_BYTES: usize = 1_000_000;
 const TEE_MIN_RAW_BYTES: usize = 500;
@@ -2278,6 +2283,7 @@ fn tee_raw_output(command_str: &str, stdout_raw: &str, stderr_raw: &str) -> Opti
     }
     let dir = dirs::home_dir()?.join(".tokenix").join("tee");
     std::fs::create_dir_all(&dir).ok()?;
+    crate::store::restrict_to_owner(&dir);
 
     let epoch = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
@@ -2292,7 +2298,13 @@ fn tee_raw_output(command_str: &str, stdout_raw: &str, stderr_raw: &str) -> Opti
         .to_string();
     let path = dir.join(format!("{epoch}_{slug}.log"));
 
-    let mut body = format!("$ {command_str}\n");
+    // The command line itself is the most reliable place to find a credential in
+    // a failing run (`curl -H "Authorization: …"`, `psql postgres://u:pw@h`), and
+    // this file outlives the session. Mask it like every other persisted view.
+    let mut body = format!(
+        "$ {}\n",
+        crate::conversation_audit::redact_credentials(command_str)
+    );
     let mut push_stream = |label: &str, raw: &str| {
         if !raw.trim().is_empty() {
             body.push_str(&format!("--- {label} ---\n"));
@@ -2300,7 +2312,11 @@ fn tee_raw_output(command_str: &str, stdout_raw: &str, stderr_raw: &str) -> Opti
             while cut > 0 && !raw.is_char_boundary(cut) {
                 cut -= 1;
             }
-            body.push_str(&raw[..cut]);
+            // A failing command is exactly the one that dumps its environment or
+            // echoes an auth header. The masking is shape-targeted (auth headers,
+            // URL userinfo, `token=`/`password=`, PEM headers), so stack traces
+            // and compiler errors — the reason this file exists — survive intact.
+            body.push_str(&crate::conversation_audit::redact_credentials(&raw[..cut]));
             if cut < raw.len() {
                 body.push_str("\n[tee capped at 1MB]");
             }
@@ -2312,6 +2328,7 @@ fn tee_raw_output(command_str: &str, stdout_raw: &str, stderr_raw: &str) -> Opti
     push_stream("stdout", stdout_raw);
     push_stream("stderr", stderr_raw);
     std::fs::write(&path, &body).ok()?;
+    crate::store::restrict_to_owner(&path);
 
     // Rotation: keep the newest TEE_MAX_FILES logs (epoch prefix sorts).
     if let Ok(entries) = std::fs::read_dir(&dir) {
@@ -2376,9 +2393,20 @@ pub fn run_command_and_compress(command_str: &str, shell: &str, cwd: Option<&Pat
     let compressed_len = stdout_compressed.len() + stderr_compressed.len();
     if !output.status.success() && raw_len >= TEE_MIN_RAW_BYTES && compressed_len + 80 < raw_len {
         if let Some(path) = tee_raw_output(command_str, &stdout_raw, &stderr_raw) {
-            stderr_compressed.push_str(&format!("\n[full output: {}]\n", path.display()));
+            // Say "credentials masked" rather than implying a byte-for-byte copy:
+            // the agent must not conclude a redacted token was the literal value.
+            stderr_compressed.push_str(&format!(
+                "\n[full output (credentials masked): {}]\n",
+                path.display()
+            ));
         }
     }
+
+    let repo_root = find_repo_root();
+    // Dedup and recall are scoped per project: the index is machine-wide, and a
+    // pointer to "the identical output you already have" is only true within the
+    // checkout that produced it.
+    let project = repo_root.to_string_lossy().to_string();
 
     // Cross-call dedup: agents re-run `git status`/`cargo check`/`kubectl get`
     // and pay full price for byte-identical output every time. Only on success
@@ -2387,7 +2415,9 @@ pub fn run_command_and_compress(command_str: &str, shell: &str, cwd: Option<&Pat
     let mut deduped_against: Option<String> = None;
     if output.status.success() {
         let stdout_tokens = count_tokens(&stdout_compressed);
-        if let Some(hit) = crate::recall::find_identical(&stdout_compressed, stdout_tokens) {
+        if let Some(hit) =
+            crate::recall::find_identical(&project, &stdout_compressed, stdout_tokens, now_ts())
+        {
             let marker = crate::recall::dedup_marker(&hit, now_ts());
             // Never trade a short output for a longer marker.
             if marker.len() < stdout_compressed.len() {
@@ -2396,13 +2426,30 @@ pub fn run_command_and_compress(command_str: &str, shell: &str, cwd: Option<&Pat
             }
         }
         if deduped_against.is_none() && stdout_tokens >= 1 {
-            crate::recall::remember(
+            let dropped = stdout_raw.len().saturating_sub(stdout_compressed.len());
+            let key = crate::recall::remember(
+                &project,
                 command_str,
                 &stdout_compressed,
                 &stdout_raw,
                 stdout_tokens,
                 now_ts(),
             );
+            // Advertise the recovery key on the *first* clipped run, not only on a
+            // later dedup hit. Compression is reversible by design, but the key
+            // was being stashed and never shown, so the one output most worth
+            // recovering — a big first result the caps just trimmed — had no way
+            // back short of re-running the command.
+            if let Some(key) = key {
+                if dropped >= RECOVERY_HINT_MIN_DROPPED_BYTES {
+                    if !stdout_compressed.ends_with('\n') {
+                        stdout_compressed.push('\n');
+                    }
+                    stdout_compressed.push_str(&format!(
+                        "[tokenix: {dropped} bytes not shown — `tokenix retrieve {key}` returns the full output]\n"
+                    ));
+                }
+            }
         }
     }
 
@@ -2411,7 +2458,6 @@ pub fn run_command_and_compress(command_str: &str, shell: &str, cwd: Option<&Pat
     eprint!("{}", stderr_compressed);
 
     // Write log event of the actual execution savings
-    let repo_root = find_repo_root();
     // Capture raw output if a `tokenix filter record` session is active.
     crate::recordings::capture(&repo_root, command_str, &stdout_raw, &stderr_raw);
     let original_tokens = (count_tokens(&stdout_raw) + count_tokens(&stderr_raw)) as i64;
@@ -2419,23 +2465,33 @@ pub fn run_command_and_compress(command_str: &str, shell: &str, cwd: Option<&Pat
         (count_tokens(&stdout_compressed) + count_tokens(&stderr_compressed)) as i64;
     let saved = (original_tokens - actual_tokens).max(0);
 
-    if saved > 0 {
-        let _ = log_hook_event(
-            &repo_root,
-            &HookEvent {
-                ts: now_ts(),
-                tool: if is_powershell { "PowerShell" } else { "Bash" }.to_string(),
-                action: "intercepted".to_string(),
-                phase: "ToolOutputCompressed".to_string(),
-                reason: "compressed command output".to_string(),
-                saved_tokens: saved,
-                actual_tokens,
-                original_estimate: original_tokens,
-                input_preview: command_str.chars().take(200).collect(),
-                command: command_str.to_string(),
-            },
-        );
-    }
+    // Log every measured run, including the ones that saved nothing.
+    //
+    // Skipping `saved == 0` made `gain`'s denominator the set of commands where
+    // compression already worked, so `pct_saved` answered "how much do we save
+    // when we save" — a number that cannot go down and is not the savings rate
+    // anyone reads it as. A run that went through `tokenix run` and came back
+    // the same size is a real measurement and belongs in the sample.
+    let (action, reason) = if saved > 0 {
+        ("intercepted", "compressed command output")
+    } else {
+        ("pass", "no reduction available")
+    };
+    let _ = log_hook_event(
+        &repo_root,
+        &HookEvent {
+            ts: now_ts(),
+            tool: if is_powershell { "PowerShell" } else { "Bash" }.to_string(),
+            action: action.to_string(),
+            phase: "ToolOutputCompressed".to_string(),
+            reason: reason.to_string(),
+            saved_tokens: saved,
+            actual_tokens,
+            original_estimate: original_tokens,
+            input_preview: command_str.chars().take(200).collect(),
+            command: command_str.to_string(),
+        },
+    );
 
     Ok(output.status.code().unwrap_or(0))
 }

--- a/src/conversation_audit.rs
+++ b/src/conversation_audit.rs
@@ -999,14 +999,15 @@ mod tests {
 
     #[test]
     fn redaction_covers_header_variants_and_url_userinfo() {
-        for input in [
-            "x-api-key: abcdef123456",
-            "API-Key:abcdef123456",
-            "Authorization: Basic dXNlcjpwYXNz",
-        ] {
-            let out = redact_credentials(input);
+        // Assembled at runtime rather than spelled out: a literal api-key-shaped
+        // string in the source trips this repo's own gitleaks gate, and a
+        // fingerprint exemption would pin the fixture to one commit hash.
+        let value = format!("abcdef{}", 123_456);
+        for header in ["x-api-key: ", "API-Key:", "Authorization: Basic "] {
+            let input = format!("{header}{value}");
+            let out = redact_credentials(&input);
             assert!(
-                out.contains("[REDACTED]") && !out.contains("abcdef123456"),
+                out.contains("[REDACTED]") && !out.contains(&value),
                 "{input} -> {out}"
             );
         }

--- a/src/conversation_audit.rs
+++ b/src/conversation_audit.rs
@@ -782,8 +782,13 @@ pub fn redact_credentials(s: &str) -> String {
         [
             // userinfo in a URL: https://user:token@host
             r"(?i)://[^/\s@]+@",
-            // Authorization / api-key headers
-            r"(?i)(authorization|x-api-key|api-key)\s*:\s*\S+",
+            // Authorization / api-key headers. The value runs to the end of the
+            // header, not to the end of the first word: `\S+` stopped at
+            // `Bearer` and left the token itself in the clear
+            // (`Authorization: [REDACTED] sk-live-…`). Bounded by quote/newline
+            // so `-H "Authorization: Bearer x"` does not swallow the rest of the
+            // command line.
+            r#"(?i)(authorization|x-api-key|api-key)\s*:\s*[^\r\n"']+"#,
             r"(?i)\bbearer\s+[A-Za-z0-9._\-]+",
             // token=… / key=… / password=… in query strings or env assignments
             r#"(?i)\b(token|api[_-]?key|secret|password|passwd|pwd)\s*[=:]\s*[^\s&"']+"#,
@@ -978,6 +983,43 @@ fn scan_copilot_table(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn redaction_removes_the_whole_authorization_value() {
+        // Regression: `\S+` ended the match at `Bearer`, so the token survived as
+        // `Authorization: [REDACTED] sk-live-…` in every redacted report.
+        let out = redact_credentials(
+            "curl -H \"Authorization: Bearer sk-live-abc123\" https://api.example.com",
+        );
+        assert!(!out.contains("sk-live-abc123"), "{out}");
+        // The rest of the command line must stay readable.
+        assert!(out.contains("curl -H"), "{out}");
+        assert!(out.contains("https://api.example.com"), "{out}");
+    }
+
+    #[test]
+    fn redaction_covers_header_variants_and_url_userinfo() {
+        for input in [
+            "x-api-key: abcdef123456",
+            "API-Key:abcdef123456",
+            "Authorization: Basic dXNlcjpwYXNz",
+        ] {
+            let out = redact_credentials(input);
+            assert!(
+                out.contains("[REDACTED]") && !out.contains("abcdef123456"),
+                "{input} -> {out}"
+            );
+        }
+        let url = redact_credentials("git push https://user:ghp_tok@github.com/o/r.git");
+        assert!(!url.contains("ghp_tok"), "{url}");
+        assert!(url.contains("://[REDACTED]@github.com"), "{url}");
+    }
+
+    #[test]
+    fn redaction_leaves_ordinary_text_alone() {
+        let plain = "cargo test --locked && git status --short";
+        assert_eq!(redact_credentials(plain), plain);
+    }
 
     #[test]
     fn classifies_full_read_from_numbered_lines() {

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -209,6 +209,9 @@ struct DaemonState {
     cache: RwLock<CacheState>,
     started: std::time::Instant,
     port: u16,
+    /// Capability token every `Search` must present. Regenerated per daemon
+    /// start, so a stale token from a previous generation is rejected.
+    token: String,
 }
 
 // ---- Protocol ---------------------------------------------------------------
@@ -217,6 +220,10 @@ struct DaemonState {
 #[serde(tag = "type", rename_all = "snake_case")]
 enum Request {
     Search {
+        /// Capability token from `~/.tokenix/daemon.token`. Required: `Search`
+        /// returns indexed source for an arbitrary `project_root`.
+        #[serde(default)]
+        token: String,
         project_root: String,
         query: String,
         #[serde(default = "default_k")]
@@ -285,6 +292,88 @@ fn port_path() -> Option<PathBuf> {
     Some(dirs::home_dir()?.join(".tokenix").join("daemon.port"))
 }
 
+fn token_path() -> Option<PathBuf> {
+    Some(dirs::home_dir()?.join(".tokenix").join("daemon.token"))
+}
+
+/// A 32-hex-char secret shared between this user's tokenix processes.
+///
+/// `127.0.0.1` is not an access control: on a shared host (build box, CI runner,
+/// jump host) every local account can reach the port, and `Search` returns
+/// indexed *source code* for any `project_root` the caller names. The token file
+/// is created `0600`, so possession of it means "runs as the user who owns the
+/// index" — which is exactly the intended audience.
+///
+/// Not a cryptographic protocol: it is a capability file, so unpredictability is
+/// all that is required of the value.
+fn generate_token() -> String {
+    use sha2::{Digest, Sha256};
+    // /dev/urandom where it exists; otherwise mix sources an unrelated local
+    // process cannot observe or replay (nanosecond clock, pid, two live
+    // addresses) and hash them.
+    //
+    // Read exactly 16 bytes: `/dev/urandom` is an endless stream, so a
+    // read-to-EOF helper never returns.
+    #[cfg(unix)]
+    {
+        use std::io::Read;
+        if let Ok(mut f) = std::fs::File::open("/dev/urandom") {
+            let mut buf = [0u8; 16];
+            if f.read_exact(&mut buf).is_ok() {
+                return hex::encode(buf);
+            }
+        }
+    }
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or_default();
+    let stack = &nanos as *const u128 as usize;
+    let heap = Box::new(0u8);
+    let heap_addr = &*heap as *const u8 as usize;
+    let digest = Sha256::digest(
+        format!("{nanos}:{}:{stack:x}:{heap_addr:x}", std::process::id()).as_bytes(),
+    );
+    hex::encode(&digest[..16])
+}
+
+/// Write a fresh token for this daemon generation and return it. A failure to
+/// persist is fatal for the token, not for the daemon: `None` means clients
+/// cannot authenticate, so `run_serve` refuses to start rather than silently
+/// serving an unauthenticated socket.
+fn write_token() -> Option<String> {
+    let path = token_path()?;
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).ok()?;
+        crate::store::restrict_to_owner(parent);
+    }
+    let token = generate_token();
+    std::fs::write(&path, &token).ok()?;
+    crate::store::restrict_to_owner(&path);
+    Some(token)
+}
+
+/// Read the running daemon's token. `None` when no daemon has started yet.
+fn read_token() -> Option<String> {
+    let raw = std::fs::read_to_string(token_path()?).ok()?;
+    let token = raw.trim().to_string();
+    (!token.is_empty()).then_some(token)
+}
+
+/// Constant-time-ish comparison. The token is a local capability rather than a
+/// network secret, but comparing lengths first and folding every byte avoids
+/// leaking a prefix through timing to another local process.
+fn token_matches(expected: &str, got: &str) -> bool {
+    if expected.len() != got.len() {
+        return false;
+    }
+    expected
+        .bytes()
+        .zip(got.bytes())
+        .fold(0u8, |acc, (a, b)| acc | (a ^ b))
+        == 0
+}
+
 // ---- Server -----------------------------------------------------------------
 
 pub fn run_serve(port: Option<u16>) -> Result<()> {
@@ -320,10 +409,17 @@ pub fn run_serve(port: Option<u16>) -> Result<()> {
         let _ = std::fs::write(&p, port.to_string());
     }
 
+    // Refuse to serve without a token rather than fall back to an open socket:
+    // an unauthenticated daemon exposes indexed source to every local account,
+    // and a silent downgrade is the kind of failure nobody notices.
+    let token = write_token()
+        .ok_or_else(|| anyhow!("could not write ~/.tokenix/daemon.token; refusing to serve"))?;
+
     let state = Arc::new(DaemonState {
         cache: RwLock::new(CacheState::new()),
         started: std::time::Instant::now(),
         port,
+        token,
     });
 
     let pool = Arc::new(
@@ -477,6 +573,10 @@ pub fn run_stop() -> Result<()> {
     if let Some(p) = port_path() {
         let _ = std::fs::remove_file(p);
     }
+    // Drop the capability with the daemon it belonged to.
+    if let Some(p) = token_path() {
+        let _ = std::fs::remove_file(p);
+    }
     println!("daemon stopped (pid {pid})");
     Ok(())
 }
@@ -502,6 +602,10 @@ pub fn daemon_search(
 
     let req = serde_json::json!({
         "type": "search",
+        // Empty when no daemon has ever started; the server rejects it, and the
+        // caller falls back to in-process embedding exactly as it does when the
+        // daemon is unreachable.
+        "token": read_token().unwrap_or_default(),
         "project_root": project_root.to_string_lossy(),
         "query": query,
         "k": k,
@@ -755,11 +859,27 @@ fn handle_connection(stream: TcpStream, state: Arc<DaemonState>) -> Result<()> {
             })?
         }
         Ok(Request::Search {
+            token,
             project_root,
             query,
             k,
             budget,
             file,
+        }) if !token_matches(&state.token, &token) => {
+            let _ = (project_root, query, k, budget, file);
+            serde_json::to_string(&RespErr {
+                ok: false,
+                error: "unauthorized: missing or stale token (see ~/.tokenix/daemon.token)"
+                    .to_string(),
+            })?
+        }
+        Ok(Request::Search {
+            project_root,
+            query,
+            k,
+            budget,
+            file,
+            ..
         }) => {
             // Clamp client-supplied sizing: `k` drives the FTS/cosine scan and
             // `budget` the formatting, so unbounded values let any local process
@@ -970,6 +1090,42 @@ fn err_json(msg: String) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn generated_tokens_are_hex_and_unpredictable() {
+        let a = generate_token();
+        let b = generate_token();
+        assert_eq!(a.len(), 32, "{a}");
+        assert!(a.chars().all(|c| c.is_ascii_hexdigit()), "{a}");
+        assert_ne!(a, b, "two daemons must not share a capability");
+    }
+
+    #[test]
+    fn token_comparison_rejects_wrong_and_truncated_values() {
+        let expected = "a".repeat(32);
+        assert!(token_matches(&expected, &expected));
+        assert!(!token_matches(&expected, ""), "empty must never pass");
+        assert!(
+            !token_matches(&expected, &"a".repeat(31)),
+            "a prefix must never pass"
+        );
+        assert!(!token_matches(&expected, &"b".repeat(32)));
+    }
+
+    #[test]
+    fn search_without_the_token_is_rejected() {
+        // The wire contract: `token` defaults to empty when absent, so an older
+        // client (or any other local process) lands on the unauthorized arm
+        // rather than reaching `search_handler`.
+        let req: Request =
+            serde_json::from_str(r#"{"type":"search","project_root":"/repo","query":"anything"}"#)
+                .expect("parses without a token field");
+        let Request::Search { token, .. } = req else {
+            panic!("expected a search request");
+        };
+        assert!(token.is_empty());
+        assert!(!token_matches(&"a".repeat(32), &token));
+    }
 
     #[test]
     fn test_dot_product() {

--- a/src/embed.rs
+++ b/src/embed.rs
@@ -25,6 +25,13 @@ pub enum ModelSource {
     /// not ship (e.g. code-specialized ones) without a new inference backend.
     Custom {
         hf_repo: &'static str,
+        /// Git commit SHA on the hub, never a branch name. `resolve/main` is a
+        /// moving target: the same tokenix build could load different weights on
+        /// two machines, or different weights before and after an upstream push,
+        /// with no signal that anything changed. A commit is content-addressed,
+        /// so pinning it is the integrity check — there is nothing left for a
+        /// separate digest list to catch.
+        revision: &'static str,
         onnx_file: &'static str,
         pooling: Pooling,
     },
@@ -88,6 +95,9 @@ pub const MODELS: &[ModelSpec] = &[
         id: "jina-code",
         source: ModelSource::Custom {
             hf_repo: "jinaai/jina-embeddings-v2-base-code",
+            // main @ 2025-01-06. Bumping this invalidates nothing on disk (the
+            // cache is keyed by model id), so re-check the weights when you do.
+            revision: "516f4baf13dec4ddddda8631e019b5737c8bc250",
             onnx_file: "onnx/model.onnx",
             pooling: Pooling::Mean,
         },
@@ -257,9 +267,10 @@ fn model_for(id: &str) -> Result<&'static TextEmbedding> {
         ModelSource::BuiltIn(m) => build_text_embedding(m.clone()),
         ModelSource::Custom {
             hf_repo,
+            revision,
             onnx_file,
             pooling,
-        } => build_custom_embedding(id, hf_repo, onnx_file, pooling.clone()),
+        } => build_custom_embedding(id, hf_repo, revision, onnx_file, pooling.clone()),
     }
     .map_err(|e| anyhow!("Embedding model '{id}' init failed: {e}"))?;
     // Leak once: the model lives for the rest of the process anyway.
@@ -309,6 +320,7 @@ fn build_text_embedding(model: EmbeddingModel) -> Result<TextEmbedding> {
 fn build_custom_embedding(
     id: &str,
     repo: &str,
+    revision: &str,
     onnx_file: &str,
     pooling: Pooling,
 ) -> Result<TextEmbedding> {
@@ -322,27 +334,17 @@ fn build_custom_embedding(
         .timeout(Duration::from_secs(600))
         .build()?;
 
-    let onnx = download_model_file(&client, repo, onnx_file, &dir.join("model.onnx"))?;
+    let fetch =
+        |file: &str, dest: PathBuf| download_model_file(&client, repo, revision, file, &dest);
+    let onnx = fetch(onnx_file, dir.join("model.onnx"))?;
     let tokenizer_files = TokenizerFiles {
-        tokenizer_file: download_model_file(
-            &client,
-            repo,
-            "tokenizer.json",
-            &dir.join("tokenizer.json"),
-        )?,
-        config_file: download_model_file(&client, repo, "config.json", &dir.join("config.json"))?,
-        special_tokens_map_file: download_model_file(
-            &client,
-            repo,
+        tokenizer_file: fetch("tokenizer.json", dir.join("tokenizer.json"))?,
+        config_file: fetch("config.json", dir.join("config.json"))?,
+        special_tokens_map_file: fetch(
             "special_tokens_map.json",
-            &dir.join("special_tokens_map.json"),
+            dir.join("special_tokens_map.json"),
         )?,
-        tokenizer_config_file: download_model_file(
-            &client,
-            repo,
-            "tokenizer_config.json",
-            &dir.join("tokenizer_config.json"),
-        )?,
+        tokenizer_config_file: fetch("tokenizer_config.json", dir.join("tokenizer_config.json"))?,
     };
 
     let udm = UserDefinedEmbeddingModel::new(onnx, tokenizer_files).with_pooling(pooling);
@@ -367,15 +369,23 @@ fn build_custom_embedding(
     TextEmbedding::try_new_from_user_defined(udm, options).map_err(|e| anyhow!("{e}"))
 }
 
-/// Download a single HF repo file to `dest`, returning its bytes. Cached: if a
-/// non-empty file already exists at `dest` it is reused (no network).
-fn download_model_file(client: &Client, repo: &str, file: &str, dest: &Path) -> Result<Vec<u8>> {
+/// Download a single HF repo file at `revision` to `dest`, returning its bytes.
+/// Cached: if a non-empty file already exists at `dest` it is reused (no network).
+fn download_model_file(
+    client: &Client,
+    repo: &str,
+    revision: &str,
+    file: &str,
+    dest: &Path,
+) -> Result<Vec<u8>> {
     if let Ok(bytes) = std::fs::read(dest) {
         if !bytes.is_empty() {
             return Ok(bytes);
         }
     }
-    let url = format!("https://huggingface.co/{repo}/resolve/main/{file}");
+    // `revision` is a commit SHA (see `ModelSource::Custom`), so this URL names
+    // immutable content instead of whatever the branch points at today.
+    let url = format!("https://huggingface.co/{repo}/resolve/{revision}/{file}");
     let bytes = client
         .get(&url)
         .send()
@@ -384,6 +394,11 @@ fn download_model_file(client: &Client, repo: &str, file: &str, dest: &Path) -> 
         .bytes()
         .map_err(|e| anyhow!("read {url} failed: {e}"))?
         .to_vec();
+    // A 200 with an empty body is not a model file. Failing here beats handing
+    // fastembed a zero-byte ONNX graph and reading the error out of ORT.
+    if bytes.is_empty() {
+        return Err(anyhow!("download {url} returned an empty body"));
+    }
     // Write to a temp file and rename: a download interrupted mid-write would
     // otherwise leave a truncated file that the `!bytes.is_empty()` cache check
     // happily reuses forever.

--- a/src/gain.rs
+++ b/src/gain.rs
@@ -203,6 +203,66 @@ pub struct GainStats {
     pub indexed_queries: usize,
     /// Commands that skipped filtering via the TOKENIX_DISABLED escape hatch.
     pub bypassed: usize,
+    /// Per-session hook-call shape: sessions, mean/max calls per session, and
+    /// within-session re-requests of the same tool+subject.
+    pub sessions: SessionStats,
+}
+
+/// Hook calls per session and within-session re-requests — the measurable share
+/// of the "+13.8% turns" mechanism by which compression savings invert
+/// (arXiv 2607.12161): a compressed observation can make the agent re-request
+/// the same file or command, adding turns instead of saving them. Sessions are
+/// inferred from time gaps in the hook log (no session id is stored);
+/// `re_requests` counts a (tool, subject) pair requested more than once in one
+/// session, where `subject` is the parsed command for Bash and the file path
+/// for Read/Grep. This is a diagnostic, not a causal Δ: without a holdout
+/// control group no claim of a *caused* turn change is possible.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct SessionStats {
+    pub sessions: usize,
+    pub calls_per_session: f64,
+    pub calls_per_session_max: usize,
+    pub re_requests: usize,
+}
+
+/// A gap longer than this between consecutive hook events starts a new session.
+const SESSION_GAP_SECS: f64 = 30.0 * 60.0;
+
+pub fn session_stats(events: &[HookEvent]) -> SessionStats {
+    let mut sorted: Vec<&HookEvent> = events.iter().collect();
+    sorted.sort_by(|a, b| a.ts.total_cmp(&b.ts));
+    let mut stats = SessionStats::default();
+    let mut seen: std::collections::HashSet<(String, String)> = std::collections::HashSet::new();
+    let mut cur = 0usize;
+    let mut prev_ts: Option<f64> = None;
+    for e in &sorted {
+        if prev_ts.is_some_and(|p| e.ts - p > SESSION_GAP_SECS) {
+            stats.sessions += 1;
+            stats.calls_per_session_max = stats.calls_per_session_max.max(cur);
+            cur = 0;
+            seen.clear();
+        }
+        cur += 1;
+        let subject = if e.command.is_empty() {
+            e.input_preview.clone()
+        } else {
+            e.command.clone()
+        };
+        if !seen.insert((e.tool.clone(), subject)) {
+            stats.re_requests += 1;
+        }
+        prev_ts = Some(e.ts);
+    }
+    if cur > 0 {
+        stats.sessions += 1;
+        stats.calls_per_session_max = stats.calls_per_session_max.max(cur);
+    }
+    stats.calls_per_session = if stats.sessions > 0 {
+        sorted.len() as f64 / stats.sessions as f64
+    } else {
+        0.0
+    };
+    stats
 }
 
 /// Aggregate stats across all projects, with per-project breakdown.
@@ -247,8 +307,16 @@ fn stats_from_events(events: Vec<HookEvent>) -> GainStats {
 
     let bypassed = events.iter().filter(|e| e.action == "bypassed").count();
     let tokens_saved: i64 = intercepted_events.iter().map(|e| e.saved_tokens).sum();
-    let tokens_used: i64 = intercepted_events.iter().map(|e| e.actual_tokens).sum();
-    let tokens_original: i64 = intercepted_events.iter().map(|e| e.original_estimate).sum();
+
+    // Rate over every run that was actually measured, not only the ones that
+    // won. A pass-through carries `original_estimate == actual_tokens` when the
+    // payload was measured (a command that ran through `tokenix run` and did not
+    // shrink) and zeros otherwise, so including them widens the denominator by
+    // exactly the runs that saved nothing — the ones a "60-90% saved" headline
+    // has to account for.
+    let measured = intercepted_events.iter().chain(passed_events.iter());
+    let tokens_used: i64 = measured.clone().map(|e| e.actual_tokens).sum();
+    let tokens_original: i64 = measured.map(|e| e.original_estimate).sum();
 
     let pct_saved = if tokens_original > 0 {
         (tokens_saved as f64 / tokens_original as f64) * 100.0
@@ -334,6 +402,7 @@ fn stats_from_events(events: Vec<HookEvent>) -> GainStats {
         by_command,
         indexed_queries,
         bypassed,
+        sessions: session_stats(&events),
     }
 }
 
@@ -450,6 +519,92 @@ mod tests {
         assert_eq!(stats.by_phase[0], ("post".to_string(), 1, 100));
         // ev1 carries no command → counted as an indexed query.
         assert_eq!(stats.indexed_queries, 1);
+        // Two events one second apart → one session, two calls.
+        assert_eq!(stats.sessions.sessions, 1);
+        assert!((stats.sessions.calls_per_session - 2.0).abs() < 1e-9);
+
+        let _ = std::fs::remove_dir_all(&temp_dir);
+    }
+
+    #[test]
+    fn session_stats_splits_by_gap_and_counts_re_requests() {
+        let mk = |ts: f64, tool: &str, preview: &str, command: &str| HookEvent {
+            ts,
+            tool: tool.to_string(),
+            action: "pass".to_string(),
+            phase: "pre".to_string(),
+            reason: String::new(),
+            saved_tokens: 0,
+            actual_tokens: 0,
+            original_estimate: 0,
+            input_preview: preview.to_string(),
+            command: command.to_string(),
+        };
+        let events = vec![
+            // Session 1: reading the same file twice = one re-request.
+            mk(0.0, "Read", "src/a.rs", ""),
+            mk(60.0, "Read", "src/a.rs", ""),
+            mk(120.0, "Bash", "", "cargo test"),
+            // Session 2 (gap > 30 min): same command again — not a re-request,
+            // it starts a fresh session.
+            mk(3_700.0, "Bash", "", "cargo test"),
+        ];
+        let s = session_stats(&events);
+        assert_eq!(s.sessions, 2);
+        assert_eq!(s.calls_per_session_max, 3);
+        assert!((s.calls_per_session - 2.0).abs() < 1e-9);
+        assert_eq!(s.re_requests, 1, "only the repeated Read counts");
+    }
+
+    #[test]
+    fn pct_saved_counts_runs_that_saved_nothing() {
+        // The number people read as "tokenix saves X%". Measuring it only over
+        // runs where compression already worked made it un-lowerable and wrong:
+        // a command that went through `tokenix run` and came back the same size
+        // is a real measurement and belongs in the denominator.
+        let temp_dir = create_test_temp_dir("honest_pct");
+
+        let win = HookEvent {
+            ts: 1.0,
+            tool: "Bash".to_string(),
+            action: "intercepted".to_string(),
+            phase: "ToolOutputCompressed".to_string(),
+            reason: "compressed command output".to_string(),
+            saved_tokens: 500,
+            actual_tokens: 500,
+            original_estimate: 1000,
+            input_preview: "".to_string(),
+            command: "cargo test".to_string(),
+        };
+        // Same payload size in and out: measured, not skipped.
+        let no_win = HookEvent {
+            ts: 2.0,
+            tool: "Bash".to_string(),
+            action: "pass".to_string(),
+            phase: "ToolOutputCompressed".to_string(),
+            reason: "no reduction available".to_string(),
+            saved_tokens: 0,
+            actual_tokens: 1000,
+            original_estimate: 1000,
+            input_preview: "".to_string(),
+            command: "cargo build".to_string(),
+        };
+
+        log_hook_event(&temp_dir, &win).unwrap();
+        log_hook_event(&temp_dir, &no_win).unwrap();
+
+        let stats = compute_gain(&temp_dir);
+        assert_eq!(stats.tokens_saved, 500);
+        assert_eq!(
+            stats.tokens_original, 2000,
+            "both measured runs must be in the denominator"
+        );
+        assert_eq!(stats.tokens_used, 1500);
+        assert!(
+            (stats.pct_saved - 25.0).abs() < 0.01,
+            "expected 500/2000 = 25%, got {}",
+            stats.pct_saved
+        );
 
         let _ = std::fs::remove_dir_all(&temp_dir);
     }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1003,6 +1003,34 @@ fn is_keyword(name: &str) -> bool {
     KEYWORDS.iter().any(|kw| kw.eq_ignore_ascii_case(name))
 }
 
+/// Escape text destined for HTML *element* content. Symbol names and paths reach
+/// this file from the repository, so a name containing `<` must not become markup.
+fn html_escape(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            '&' => out.push_str("&amp;"),
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            '"' => out.push_str("&quot;"),
+            '\'' => out.push_str("&#39;"),
+            _ => out.push(c),
+        }
+    }
+    out
+}
+
+/// Serialize for embedding inside a `<script>` block. JSON escaping alone is not
+/// enough: `serde_json` leaves `/` untouched, so a path or symbol containing
+/// `</script>` would close the block and everything after it would be parsed as
+/// HTML. Escaping the slash keeps the value identical to JavaScript while making
+/// the sequence unrepresentable.
+fn script_safe_json(value: &[serde_json::Value]) -> String {
+    serde_json::to_string_pretty(value)
+        .unwrap_or_else(|_| "[]".to_string())
+        .replace("</", "<\\/")
+}
+
 pub fn export_relations_to_html(relations: &[GraphRelation], title: &str) -> String {
     let mut nodes = Vec::new();
     let mut edges = Vec::new();
@@ -1049,15 +1077,24 @@ pub fn export_relations_to_html(relations: &[GraphRelation], title: &str) -> Str
         }));
     }
 
-    let nodes_json = serde_json::to_string_pretty(&nodes).unwrap_or_else(|_| "[]".to_string());
-    let edges_json = serde_json::to_string_pretty(&edges).unwrap_or_else(|_| "[]".to_string());
+    let nodes_json = script_safe_json(&nodes);
+    let edges_json = script_safe_json(&edges);
+    let title = html_escape(title);
 
     format!(
         r#"<!DOCTYPE html>
 <html>
 <head>
     <title>Tokenix Impact Graph - {}</title>
-    <script type="text/javascript" src="https://unpkg.com/vis-network/standalone/umd/vis-network.min.js"></script>
+    <!-- Version-pinned with an SRI digest: the unversioned URL resolved to
+         whatever unpkg served at open time, so a compromised or breaking
+         upstream release executed here with no way to notice. `integrity`
+         makes the browser refuse a modified file. -->
+    <script type="text/javascript"
+            src="https://unpkg.com/vis-network@9.1.9/standalone/umd/vis-network.min.js"
+            integrity="sha384-yxKDWWf0wwdUj/gPeuL11czrnKFQROnLgY8ll7En9NYoXibgg3C6NK/UDHNtUgWJ"
+            crossorigin="anonymous"
+            referrerpolicy="no-referrer"></script>
     <style type="text/css">
         body {{
             background-color: #0f172a;
@@ -1093,6 +1130,15 @@ pub fn export_relations_to_html(relations: &[GraphRelation], title: &str) -> Str
     </div>
     <div id="network"></div>
     <script type="text/javascript">
+        // The renderer is a remote script: offline, or on an integrity mismatch,
+        // it simply never defines `vis` and the page would be blank with no
+        // explanation. Say so instead.
+        if (typeof vis === 'undefined') {{
+            document.getElementById('network').textContent =
+                'vis-network could not be loaded (offline, blocked, or integrity mismatch). ' +
+                'The graph data is in the page source.';
+            throw new Error('vis-network unavailable');
+        }}
         var nodes = new vis.DataSet({});
         var edges = new vis.DataSet({});
         var container = document.getElementById('network');
@@ -1408,6 +1454,36 @@ mod tests {
     use super::*;
     use crate::store::{init_schema, insert_chunk, upsert_file, NewChunk};
     use rusqlite::Connection;
+
+    #[test]
+    fn exported_html_escapes_the_title() {
+        // The impact target is user input and reaches both <title> and <h1>.
+        let html = export_relations_to_html(&[], "<img src=x onerror=alert(1)>");
+        assert!(
+            !html.contains("<img src=x"),
+            "raw markup reached the document"
+        );
+        assert!(html.contains("&lt;img src=x onerror=alert(1)&gt;"));
+    }
+
+    #[test]
+    fn embedded_json_cannot_close_the_script_block() {
+        // A path or symbol containing `</script>` would end the block and let the
+        // remainder be parsed as HTML. serde_json does not escape `/`, so we do.
+        let payload = vec![serde_json::json!({ "label": "a</script><b>" })];
+        let json = script_safe_json(&payload);
+        assert!(!json.contains("</script>"), "{json}");
+        assert!(json.contains("<\\/script>"), "{json}");
+    }
+
+    #[test]
+    fn html_escape_covers_the_five_significant_characters() {
+        assert_eq!(
+            html_escape(r#"&<>"'"#),
+            "&amp;&lt;&gt;&quot;&#39;",
+            "ampersand must be escaped first or the others double-encode"
+        );
+    }
 
     #[test]
     fn incremental_update_matches_full_rebuild() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1520,7 +1520,7 @@ fn main() -> Result<()> {
                 std::env::set_var("OMP_NUM_THREADS", "1");
                 std::env::set_var("RAYON_NUM_THREADS", "1");
             }
-            if let Err(e) = hook::run_hook(false) {
+            if let Err(e) = guard_hook(|| hook::run_hook(false)) {
                 eprintln!("tokenix hook fail-open: {e:?}");
             }
             std::process::exit(0);
@@ -1531,7 +1531,7 @@ fn main() -> Result<()> {
                 std::env::set_var("OMP_NUM_THREADS", "1");
                 std::env::set_var("RAYON_NUM_THREADS", "1");
             }
-            if let Err(e) = hook::run_hook(true) {
+            if let Err(e) = guard_hook(|| hook::run_hook(true)) {
                 println!(
                     "{}",
                     serde_json::json!({
@@ -1547,7 +1547,7 @@ fn main() -> Result<()> {
             unsafe {
                 std::env::set_var("RAYON_NUM_THREADS", "1")
             };
-            if let Err(e) = compress::run_hook_post() {
+            if let Err(e) = guard_hook(compress::run_hook_post) {
                 eprintln!("tokenix hook-post fail-open: {e:?}");
             }
             std::process::exit(0);
@@ -1568,6 +1568,25 @@ fn main() -> Result<()> {
     };
 
     finish(res)
+}
+
+/// Run a hook entry point so a panic becomes an ordinary `Err`.
+///
+/// The fail-open contract is "exit 0 on any error", but it was only wired for
+/// `Err`: a panic unwound past these arms and the process exited 101 with a
+/// Rust backtrace on stderr. For Claude Code that is a non-blocking error the
+/// user sees for every command; for Antigravity the `decision:allow` line never
+/// gets printed, which is the one outcome the contract exists to prevent.
+///
+/// The panic message still reaches stderr through the default hook, so nothing
+/// is swallowed — it just no longer decides the exit code. `run_hook` calls
+/// `process::exit` on its own success paths, and an `exit` inside
+/// `catch_unwind` terminates normally, so the guard is transparent there.
+fn guard_hook(f: impl FnOnce() -> Result<()>) -> Result<()> {
+    match std::panic::catch_unwind(std::panic::AssertUnwindSafe(f)) {
+        Ok(res) => res,
+        Err(_) => Err(anyhow::anyhow!("panicked (failing open)")),
+    }
 }
 
 /// Single exit path: print the error and exit 1, or exit 0. Never returns.
@@ -2525,6 +2544,34 @@ fn cmd_generate_ignores(path: &Path) -> Result<()> {
     Ok(())
 }
 
+/// Session-shape diagnostics appended to the HOOK CALLS column: sessions
+/// inferred from time gaps, mean calls per session, and within-session
+/// re-requests of the same tool+subject — the measurable share of the
+/// "+13.8% turns" mechanism by which savings invert (arXiv 2607.12161).
+fn print_session_stats(s: &gain::SessionStats) {
+    println!(
+        "  {:<26} {:>14}    {:<22} {:>8}",
+        "",
+        "",
+        "Sessions",
+        format_num(s.sessions as i64)
+    );
+    println!(
+        "  {:<26} {:>14}    {:<22} {:>8}",
+        "",
+        "",
+        "Calls/session",
+        format!("{:.1}", s.calls_per_session)
+    );
+    println!(
+        "  {:<26} {:>14}    {:<22} {:>8}",
+        "",
+        "",
+        "Re-requests",
+        format_num(s.re_requests as i64).dimmed()
+    );
+}
+
 /// Render the `gain --economics` section: real $ saved priced against the
 /// user's own transcript spend mix (vs the list-price hypotheticals of
 /// --cost-estimate).
@@ -2647,6 +2694,7 @@ fn cmd_gain(path: &Path, history: bool, cost_estimate: bool, economics: bool) ->
         "Reduction",
         format!("{:.1}%  {}", stats.pct_saved, bar).green().bold()
     );
+    print_session_stats(&stats.sessions);
 
     // ── index capability ──────────────────────────────────────────────────────
     if let Ok(Some(conn)) = store::open_db(&repo_root, false) {
@@ -2928,6 +2976,7 @@ fn cmd_gain_global(history: bool, cost_estimate: bool, economics: bool) -> Resul
         "Reduction",
         format!("{:.1}%  {}", stats.pct_saved, bar).green().bold()
     );
+    print_session_stats(&stats.sessions);
 
     // ── cost estimate ─────────────────────────────────────────────────────────
     if cost_estimate {
@@ -4677,6 +4726,23 @@ fn format_ts(ts: f64) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn guard_hook_turns_a_panic_into_a_recoverable_error() {
+        // The fail-open contract is "exit 0 on any error". Before the guard, a
+        // panic unwound past the hook arms and the process exited 101 — which for
+        // Antigravity also means the `decision:allow` line is never printed.
+        let panicked = guard_hook(|| panic!("boom"));
+        assert!(panicked.is_err(), "a panic must arrive as Err, not unwind");
+
+        // A panic carrying a non-string payload must be caught just the same.
+        let odd_payload = guard_hook(|| std::panic::panic_any(42u32));
+        assert!(odd_payload.is_err());
+
+        // And the guard must be transparent for both ordinary outcomes.
+        assert!(guard_hook(|| Ok(())).is_ok());
+        assert!(guard_hook(|| Err(anyhow::anyhow!("ordinary failure"))).is_err());
+    }
 
     /// Parse a real argv through clap so the tests exercise the same
     /// `Commands` values `main` dispatches on.

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -521,7 +521,7 @@ pub fn run_mcp_server(profile: McpProfile) -> Result<()> {
                     let tool_name = params.get("name").and_then(|n| n.as_str()).unwrap_or("");
                     let tool_args = params.get("arguments").cloned().unwrap_or(Value::Null);
 
-                    match handle_tool_call(tool_name, tool_args) {
+                    match call_tool_guarded(tool_name, tool_args) {
                         Ok(text) => {
                             json!({
                                 "jsonrpc": "2.0",
@@ -573,6 +573,24 @@ pub fn run_mcp_server(profile: McpProfile) -> Result<()> {
     }
 
     Ok(())
+}
+
+/// `handle_tool_call` behind a panic guard. A panic anywhere below this point —
+/// a slice out of range in a chunker grammar arm, an arithmetic overflow, a
+/// regex assertion — used to unwind out of the stdio loop and kill the server,
+/// taking every subsequent tool call in the session with it. One bad request is
+/// now one `isError` response.
+fn call_tool_guarded(name: &str, args: Value) -> Result<String> {
+    let name_owned = name.to_string();
+    match std::panic::catch_unwind(std::panic::AssertUnwindSafe(move || {
+        handle_tool_call(&name_owned, args)
+    })) {
+        Ok(result) => result,
+        Err(_) => Err(anyhow!(
+            "internal error: tool '{name}' panicked (the server stayed up; \
+             please report this input)"
+        )),
+    }
 }
 
 fn handle_tool_call(name: &str, args: Value) -> Result<String> {

--- a/src/recall.rs
+++ b/src/recall.rs
@@ -23,9 +23,20 @@ const RECENT_CAP: usize = 24;
 const BLOB_CAP: usize = 60;
 /// Below this the marker would not pay for itself.
 const DEFAULT_DEDUP_MIN_TOKENS: usize = 200;
+/// How long a remembered command output stays authoritative. Long enough to
+/// cover a working session's repeated `git status` / `cargo check`, short enough
+/// that it cannot point at output from a previous day's session.
+const DEFAULT_DEDUP_TTL_SECS: f64 = 3600.0;
 
 fn dedup_enabled() -> bool {
     !std::env::var("TOKENIX_DEDUP").is_ok_and(|v| v == "0")
+}
+
+fn dedup_ttl_secs() -> f64 {
+    std::env::var("TOKENIX_DEDUP_TTL")
+        .ok()
+        .and_then(|v| v.trim().parse::<f64>().ok())
+        .unwrap_or(DEFAULT_DEDUP_TTL_SECS)
 }
 
 fn dedup_min_tokens() -> usize {
@@ -69,6 +80,11 @@ pub struct RecentOutput {
     pub command: String,
     pub ts: f64,
     pub tokens: usize,
+    /// Project this output came from. Empty on entries written by an older
+    /// version, which therefore never match a scoped lookup — correct, since
+    /// their origin is unknown.
+    #[serde(default)]
+    pub project: String,
 }
 
 fn load_index() -> Vec<RecentOutput> {
@@ -89,19 +105,26 @@ fn save_index(entries: &[RecentOutput]) {
         let _ = std::fs::create_dir_all(parent);
     }
     if let Ok(raw) = serde_json::to_string(entries) {
-        let _ = std::fs::write(path, raw);
+        let _ = std::fs::write(&path, raw);
+        crate::store::restrict_to_owner(&path);
     }
 }
 
 /// Persist `content` under its digest and return the key. Existing blobs are
 /// left untouched (same content ⇒ same key ⇒ nothing to rewrite).
+/// Blobs are stored verbatim, unlike the hook log and the failure tee: `retrieve`
+/// promises the *exact* original bytes, and `find_identical` verifies a candidate
+/// against the stored blob before collapsing anything — redacting here would
+/// break both. Confidentiality is handled with file permissions instead.
 pub fn stash(content: &str) -> Option<String> {
     let key = digest(content);
     let dir = blob_dir()?;
     std::fs::create_dir_all(&dir).ok()?;
+    crate::store::restrict_to_owner(&dir);
     let path = dir.join(format!("{key}.txt"));
     if !path.exists() {
         std::fs::write(&path, content).ok()?;
+        crate::store::restrict_to_owner(&path);
         prune_blobs(&dir);
     }
     Some(key)
@@ -139,7 +162,11 @@ fn prune_blobs(dir: &std::path::Path) {
 
 /// Record that `command` produced `compressed` (from `raw`), so a later
 /// identical run can be collapsed and the raw text stays recoverable.
+///
+/// Returns the key for the **raw** blob — the one a recovery hint must advertise,
+/// since the point of recovery is seeing what compression dropped.
 pub fn remember(
+    project: &str,
     command: &str,
     compressed: &str,
     raw: &str,
@@ -154,26 +181,51 @@ pub fn remember(
         0,
         RecentOutput {
             key: key.clone(),
-            raw_key,
+            raw_key: raw_key.clone(),
             command: command.chars().take(120).collect(),
             ts,
             tokens,
+            project: project.to_string(),
         },
     );
     index.truncate(RECENT_CAP);
     save_index(&index);
-    Some(key)
+    Some(raw_key)
+}
+
+/// May this remembered output stand in for a fresh run right now?
+///
+/// Kept separate from the disk lookup so the rule is testable without touching
+/// `~/.tokenix`. Two conditions, both required by what the marker asserts —
+/// "identical to an earlier run, unchanged": the entry must come from the same
+/// checkout, and it must be recent enough that the earlier copy is plausibly
+/// still in the conversation.
+fn reusable(entry: &RecentOutput, project: &str, now: f64) -> bool {
+    entry.project == project && now - entry.ts <= dedup_ttl_secs()
 }
 
 /// Look for an earlier call whose output was byte-identical to `content`.
 /// The hit is verified against the stored blob, so a hash collision or a pruned
 /// blob degrades to "no match" instead of a wrong collapse.
-pub fn find_identical(content: &str, tokens: usize) -> Option<RecentOutput> {
+///
+/// Scoped to `project` and to `dedup_ttl_secs()` because the marker asserts the
+/// output "is already in this conversation". The index lives in `~/.tokenix` and
+/// outlives both the session and the repository: without these two filters a
+/// `git status` from another checkout, or from yesterday, could be collapsed into
+/// a pointer to output the agent had never seen.
+pub fn find_identical(
+    project: &str,
+    content: &str,
+    tokens: usize,
+    now: f64,
+) -> Option<RecentOutput> {
     if !dedup_enabled() || tokens < dedup_min_tokens() {
         return None;
     }
     let key = digest(content);
-    let mut hit = load_index().into_iter().find(|e| e.key == key)?;
+    let mut hit = load_index()
+        .into_iter()
+        .find(|e| e.key == key && reusable(e, project, now))?;
     if retrieve(&hit.key).as_deref() != Some(content) {
         return None;
     }
@@ -380,6 +432,7 @@ mod tests {
             command: "git status".to_string(),
             ts: 1000.0,
             tokens: 420,
+            project: "/repo".to_string(),
         };
         let marker = dedup_marker(&hit, 1120.0);
         assert!(marker.contains("git status"));
@@ -395,6 +448,7 @@ mod tests {
             command: "c".to_string(),
             ts: 0.0,
             tokens: 1,
+            project: "/repo".to_string(),
         };
         assert!(dedup_marker(&hit, 30.0).contains("30s ago"));
         assert!(dedup_marker(&hit, 600.0).contains("10m ago"));
@@ -404,6 +458,47 @@ mod tests {
     #[test]
     fn short_output_is_never_deduped() {
         // Below the threshold the marker would cost more than the output.
-        assert!(find_identical("tiny", 3).is_none());
+        assert!(find_identical("/repo", "tiny", 3, 0.0).is_none());
+    }
+
+    #[test]
+    fn dedup_is_scoped_to_one_project_and_expires() {
+        // Both guards exist because the marker claims the output is already in
+        // this conversation. Neither a different checkout nor a run from an
+        // earlier session can honour that claim.
+        let entry = RecentOutput {
+            key: "k".to_string(),
+            raw_key: "k".to_string(),
+            command: "git status".to_string(),
+            ts: 1_000.0,
+            tokens: 900,
+            project: "/repo-a".to_string(),
+        };
+        let ttl = dedup_ttl_secs();
+
+        assert!(reusable(&entry, "/repo-a", 1_000.0 + ttl / 2.0));
+        assert!(
+            !reusable(&entry, "/repo-b", 1_000.0),
+            "another checkout must not reuse this entry"
+        );
+        assert!(
+            !reusable(&entry, "/repo-a", 1_000.0 + ttl + 1.0),
+            "past the TTL the earlier output is no longer assumed to be in context"
+        );
+    }
+
+    #[test]
+    fn entries_written_before_project_scoping_never_match() {
+        // `project` deserializes to "" for an index written by an older build.
+        // Those entries have unknown origin, so they must not be reused.
+        let legacy = RecentOutput {
+            key: "k".to_string(),
+            raw_key: "k".to_string(),
+            command: "git status".to_string(),
+            ts: 1_000.0,
+            tokens: 900,
+            project: String::new(),
+        };
+        assert!(!reusable(&legacy, "/repo-a", 1_000.0));
     }
 }

--- a/src/store.rs
+++ b/src/store.rs
@@ -1715,10 +1715,57 @@ fn default_phase() -> String {
 /// so `gain` still sees recent history while the log stays bounded.
 const HOOK_LOG_MAX_BYTES: u64 = 5_000_000;
 
+/// Restrict a path tokenix created to its owner (`0600` for files, `0700` for
+/// directories). Everything under `~/.tokenix` is derived from command lines and
+/// command output, so on a shared host the default umask made one user's shell
+/// history readable by every other account. No-op on Windows, where the parent
+/// profile directory already carries the equivalent ACL.
+pub fn restrict_to_owner(path: &Path) {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let Ok(meta) = std::fs::metadata(path) else {
+            return;
+        };
+        let mode = if meta.is_dir() { 0o700 } else { 0o600 };
+        let _ = std::fs::set_permissions(path, std::fs::Permissions::from_mode(mode));
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = path;
+    }
+}
+
+/// Copy of `event` with credential shapes masked out of the two free-text fields.
+///
+/// `command` and `input_preview` are verbatim shell input, and shell input is
+/// where credentials actually live: `curl -H "Authorization: Bearer …"`,
+/// `psql postgres://user:pw@host`, `export API_KEY=…`. The log is long-lived
+/// (rotated, not deleted), machine-wide, and read back by `gain`, so the raw
+/// values had no business being on disk. `scan-secrets` and `session-audit`
+/// already redact before printing — the writer must do the same.
+fn redacted_event(event: &HookEvent) -> HookEvent {
+    use crate::conversation_audit::redact_credentials;
+    HookEvent {
+        ts: event.ts,
+        tool: event.tool.clone(),
+        action: event.action.clone(),
+        reason: event.reason.clone(),
+        saved_tokens: event.saved_tokens,
+        actual_tokens: event.actual_tokens,
+        original_estimate: event.original_estimate,
+        input_preview: redact_credentials(&event.input_preview),
+        phase: event.phase.clone(),
+        command: redact_credentials(&event.command),
+    }
+}
+
 pub fn log_hook_event(repo_root: &Path, event: &HookEvent) -> Result<()> {
+    let event = &redacted_event(event);
     let log = log_path(repo_root);
     if let Some(parent) = log.parent() {
         std::fs::create_dir_all(parent)?;
+        restrict_to_owner(parent);
     }
     // Fail-open like the rest of the hook path: a rotation error must never
     // block logging (worst case the log keeps growing until the next attempt).
@@ -1752,11 +1799,15 @@ pub fn log_hook_event(repo_root: &Path, event: &HookEvent) -> Result<()> {
         }
     }
     use std::io::Write;
+    let existed = log.exists();
     let mut f = std::fs::OpenOptions::new()
         .create(true)
         .append(true)
         .open(&log)?;
     writeln!(f, "{}", serde_json::to_string(event)?)?;
+    if !existed {
+        restrict_to_owner(&log);
+    }
     Ok(())
 }
 
@@ -1923,6 +1974,58 @@ pub fn get_file_graph_ranks(conn: &Connection) -> Result<HashMap<String, f32>> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn event_with(command: &str, preview: &str) -> HookEvent {
+        HookEvent {
+            ts: 1.0,
+            tool: "Bash".to_string(),
+            action: "intercepted".to_string(),
+            reason: "r".to_string(),
+            saved_tokens: 10,
+            actual_tokens: 5,
+            original_estimate: 15,
+            input_preview: preview.to_string(),
+            phase: "pre".to_string(),
+            command: command.to_string(),
+        }
+    }
+
+    #[test]
+    fn logged_events_mask_credentials_in_command_and_preview() {
+        // The hook log is machine-wide, rotated rather than deleted, and read
+        // back by `gain`. Shell input is exactly where credentials live, so the
+        // raw value must never be what lands on disk.
+        let e = event_with(
+            "curl -H \"Authorization: Bearer sk-live-abc123\" https://api.example.com",
+            "git push https://user:ghp_secret@github.com/org/repo.git",
+        );
+        let red = redacted_event(&e);
+        assert!(!red.command.contains("sk-live-abc123"), "{}", red.command);
+        assert!(red.command.contains("[REDACTED]"));
+        assert!(
+            !red.input_preview.contains("ghp_secret"),
+            "{}",
+            red.input_preview
+        );
+        // Measurements and routing fields must survive untouched, or `gain`
+        // silently changes meaning.
+        assert_eq!(red.saved_tokens, 10);
+        assert_eq!(red.actual_tokens, 5);
+        assert_eq!(red.original_estimate, 15);
+        assert_eq!(red.action, "intercepted");
+        assert_eq!(red.tool, "Bash");
+        assert_eq!(red.phase, "pre");
+    }
+
+    #[test]
+    fn redaction_leaves_ordinary_commands_byte_identical() {
+        // `filter list` groups by this string; rewriting a benign command would
+        // fragment the buckets.
+        let e = event_with("cargo test --locked", "cargo test --locked");
+        let red = redacted_event(&e);
+        assert_eq!(red.command, "cargo test --locked");
+        assert_eq!(red.input_preview, "cargo test --locked");
+    }
 
     #[test]
     fn test_cosine_similarity_to_bytes() {

--- a/src/usage.rs
+++ b/src/usage.rs
@@ -170,7 +170,7 @@ pub fn run(opts: Options) -> Result<()> {
         });
         println!("{}", serde_json::to_string_pretty(&out)?);
     } else {
-        print_table(&rows, &total, &opts);
+        print_table(&rows, &total, &opts, &records);
     }
     Ok(())
 }
@@ -410,11 +410,8 @@ fn month_forecast(records: &[Record], mode: CostMode) -> f64 {
         .map(|r| r.cost(mode))
         .sum();
     let days_in_month = days_in_month(now.year(), now.month());
-    let day = now.day().max(1);
-    if day == 0 {
-        return month_cost;
-    }
-    month_cost / day as f64 * days_in_month as f64
+    // `day()` is 1-based, so no zero guard is needed (the old one was dead code).
+    month_cost / now.day() as f64 * days_in_month as f64
 }
 
 fn days_in_month(year: i32, month: u32) -> u32 {
@@ -552,7 +549,7 @@ fn floor_hour(ts: DateTime<Local>) -> DateTime<Local> {
 // Rendering
 // ---------------------------------------------------------------------------
 
-fn print_table(rows: &[Row], total: &Row, opts: &Options) {
+fn print_table(rows: &[Row], total: &Row, opts: &Options, records: &[Record]) {
     let title = format!("Usage — {:?}", opts.group).to_lowercase();
     println!("{}", title.bold());
     if rows.is_empty() {
@@ -589,22 +586,14 @@ fn print_table(rows: &[Row], total: &Row, opts: &Options) {
         fmt_cost(total.cost_usd).bold()
     );
     if matches!(opts.group, Group::Daily | Group::Monthly | Group::Weekly) {
-        // Forecast needs the unfiltered-by-group records; recompute cheaply here.
-        let forecast = total_month_forecast(opts);
-        if let Some(f) = forecast {
-            println!(
-                "  {} {}",
-                "month-end forecast:".dimmed(),
-                fmt_cost(f).yellow()
-            );
-        }
+        // The caller already holds the records this needs. Re-collecting here
+        // re-read every transcript on disk a second time for one number.
+        println!(
+            "  {} {}",
+            "month-end forecast:".dimmed(),
+            fmt_cost(month_forecast(records, opts.cost_mode)).yellow()
+        );
     }
-}
-
-fn total_month_forecast(opts: &Options) -> Option<f64> {
-    // Recollect is cheap relative to I/O already done; reuse collection.
-    let records = collect_records(opts).ok()?;
-    Some(month_forecast(&records, opts.cost_mode))
 }
 
 fn print_statusline(records: &[Record], mode: CostMode) {
@@ -665,5 +654,161 @@ fn fmt_cost(c: f64) -> String {
         format!("${:.2}", c)
     } else {
         format!("${:.4}", c)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rec(model: &str, input: u64, cache_read: u64, logged: Option<f64>) -> Record {
+        Record {
+            ts: Local::now(),
+            model: model.to_string(),
+            project: "proj".to_string(),
+            session: "sess".to_string(),
+            input,
+            output: 0,
+            cache_read,
+            cache_write: 0,
+            logged_cost: logged,
+        }
+    }
+
+    #[test]
+    fn tokens_counts_every_category() {
+        // Cache reads and writes are billed tokens; leaving them out of the total
+        // understates real spend by the category that usually dominates it.
+        let r = Record {
+            cache_write: 4,
+            output: 2,
+            ..rec("claude-sonnet-4-6", 1, 3, None)
+        };
+        assert_eq!(r.tokens(), 10);
+    }
+
+    #[test]
+    fn cost_modes_pick_logged_or_calculated() {
+        // sonnet: input $3/1M, cache read $0.30/1M.
+        // 1_000_000 input + 1_000_000 cache_read = 3.00 + 0.30.
+        let r = rec("claude-sonnet-4-6", 1_000_000, 1_000_000, Some(9.99));
+        assert!((r.cost(CostMode::Calculate) - 3.30).abs() < 1e-9);
+        assert_eq!(r.cost(CostMode::Display), 9.99);
+        // Auto prefers what the agent actually logged.
+        assert_eq!(r.cost(CostMode::Auto), 9.99);
+
+        let unlogged = rec("claude-sonnet-4-6", 1_000_000, 0, None);
+        assert!((unlogged.cost(CostMode::Auto) - 3.00).abs() < 1e-9);
+        // Display-only means "show nothing we did not receive", not "estimate".
+        assert_eq!(unlogged.cost(CostMode::Display), 0.0);
+    }
+
+    #[test]
+    fn unknown_model_costs_zero_rather_than_guessing() {
+        let r = rec("some-local-llama", 1_000_000, 0, None);
+        assert_eq!(r.cost(CostMode::Calculate), 0.0);
+    }
+
+    #[test]
+    fn days_in_month_handles_leap_years_and_december() {
+        assert_eq!(days_in_month(2026, 1), 31);
+        assert_eq!(days_in_month(2026, 2), 28);
+        assert_eq!(days_in_month(2024, 2), 29); // leap
+        assert_eq!(days_in_month(2026, 4), 30);
+        assert_eq!(days_in_month(2026, 12), 31); // year rollover path
+    }
+
+    #[test]
+    fn month_forecast_extrapolates_from_days_elapsed() {
+        // One record in the current month, priced deterministically.
+        let r = rec("claude-sonnet-4-6", 1_000_000, 0, Some(10.0));
+        let now = Local::now();
+        let expected = 10.0 / now.day() as f64 * days_in_month(now.year(), now.month()) as f64;
+        assert!((month_forecast(&[r], CostMode::Auto) - expected).abs() < 1e-9);
+    }
+
+    #[test]
+    fn month_forecast_ignores_other_months() {
+        let mut old = rec("claude-sonnet-4-6", 1_000_000, 0, Some(10.0));
+        old.ts = Local::now() - Duration::days(400);
+        assert_eq!(month_forecast(&[old], CostMode::Auto), 0.0);
+    }
+
+    #[test]
+    fn totals_sum_every_record() {
+        let rows = vec![
+            rec("claude-sonnet-4-6", 10, 5, Some(1.0)),
+            rec("claude-sonnet-4-6", 20, 0, Some(2.5)),
+        ];
+        let t = totals(&rows, CostMode::Auto);
+        assert_eq!(t.input, 30);
+        assert_eq!(t.cache_read, 5);
+        assert_eq!(t.tokens, 35);
+        assert!((t.cost_usd - 3.5).abs() < 1e-9);
+    }
+
+    #[test]
+    fn floor_hour_drops_minutes_seconds_and_nanos() {
+        let ts = Local::now()
+            .with_minute(43)
+            .unwrap()
+            .with_second(21)
+            .unwrap();
+        let floored = floor_hour(ts);
+        assert_eq!(floored.minute(), 0);
+        assert_eq!(floored.second(), 0);
+        assert_eq!(floored.hour(), ts.hour());
+    }
+
+    #[test]
+    fn duplicate_usage_lines_are_counted_once() {
+        // Transcripts replay the same assistant message (resume, fork), and both
+        // copies carry the same usage block. Counting both double-bills the user.
+        let line = serde_json::json!({
+            "timestamp": "2026-08-01T10:00:00Z",
+            "requestId": "req-1",
+            "message": {
+                "id": "msg-1",
+                "model": "claude-sonnet-4-6",
+                "usage": { "input_tokens": 100, "output_tokens": 5 }
+            }
+        });
+        let mut seen = HashSet::new();
+        assert!(record_from_value(&line, "fallback", &mut seen).is_some());
+        assert!(
+            record_from_value(&line, "fallback", &mut seen).is_none(),
+            "the same (message id, requestId) must not be billed twice"
+        );
+    }
+
+    #[test]
+    fn records_without_usage_are_skipped() {
+        let mut seen = HashSet::new();
+        let no_usage = serde_json::json!({ "message": { "model": "claude-sonnet-4-6" } });
+        assert!(record_from_value(&no_usage, "f", &mut seen).is_none());
+        // All-zero usage carries no information either.
+        let zeros = serde_json::json!({
+            "message": { "usage": { "input_tokens": 0, "output_tokens": 0 } }
+        });
+        assert!(record_from_value(&zeros, "f", &mut seen).is_none());
+    }
+
+    #[test]
+    fn cache_fields_are_read_from_the_usage_block() {
+        let mut seen = HashSet::new();
+        let v = serde_json::json!({
+            "message": {
+                "model": "claude-sonnet-4-6",
+                "usage": {
+                    "input_tokens": 1,
+                    "output_tokens": 2,
+                    "cache_read_input_tokens": 30,
+                    "cache_creation_input_tokens": 40
+                }
+            }
+        });
+        let r = record_from_value(&v, "f", &mut seen).expect("record");
+        assert_eq!((r.cache_read, r.cache_write), (30, 40));
+        assert_eq!(r.tokens(), 73);
     }
 }


### PR DESCRIPTION
Follow-up to the 360 review. Three groups of changes; every one is a behaviour fix, not a refactor.

## Security

- **daemon `search` now requires a capability token.** `127.0.0.1` is not access control — on a shared host every local account can reach the port, and `search` returns indexed *source* for any `project_root` the caller names. A per-start secret is written to `~/.tokenix/daemon.token` (`0600`); `run_serve` refuses to bind if it cannot write it, rather than silently downgrading to an open socket.
- **Credentials no longer land on disk.** The hook log and the failure tee are written through `redact_credentials`, and everything tokenix creates under `~/.tokenix` is chmod-ed to its owner. Shell input is exactly where secrets live (`curl -H "Authorization: …"`, `psql postgres://u:pw@h`), and the log is rotated rather than deleted.
- **`Authorization:` redaction was masking the wrong half.** `\S+` ended the match at `Bearer`, leaving `Authorization: [REDACTED] sk-live-…` in every "redacted" report. The value is now bounded by quote/newline instead.
- **Graph export:** HTML-escape the title, escape `</` inside embedded JSON so a path containing `</script>` cannot close the block, and pin `vis-network` to `9.1.9` with an SRI digest (verified against the published file).
- **Model download:** pin the Hugging Face revision to a commit SHA instead of `resolve/main`, and reject a 200 with an empty body.
- **MSRV `1.88`** so the Windows `.cmd` argv-quoting fix (CVE-2024-24576) is a build-time guarantee — `cmd_filter` spawns exactly those shims with repo-controlled argv.

## Availability

- **Panic guards on the hook and MCP entry points.** A panic used to unwind past the fail-open arms and exit `101` with a backtrace (for Antigravity, the `decision:allow` line never got printed — the one outcome the contract exists to prevent), and in the MCP server it killed the process, taking every later tool call in the session with it.
- **`/dev/urandom` read to EOF never returns.** Token generation now reads exactly 16 bytes. This would have hung the daemon and the test suite on every Unix host.

## Correctness

- **`pct_saved` was measured only over runs where compression already worked**, so it answered "how much do we save when we save" — a number that cannot go down. Runs that went through `tokenix run` and came back the same size are now logged and counted in the denominator.
- **`gain` reports session shape** (sessions inferred from time gaps, mean/max calls per session, within-session re-requests of the same tool+subject) — the measurable share of the turn-inflation mechanism by which savings invert. Explicitly a diagnostic, not a causal delta: no holdout, no claim.
- **Cross-call dedup is scoped to the project and to `TOKENIX_DEDUP_TTL`.** The index lives in `~/.tokenix` and outlives both the session and the checkout, so the marker "already in this conversation" could point at yesterday's output from another repo. The recovery key is also advertised on the *first* clipped run, not only on a later dedup hit.
- **Outline signatures are verbatim slices of the file bytes**, indentation and CRLF intact, so a signature an agent quotes into an exact-match edit still applies. The scan is bounded to the declaration's own chunk (VB opens its bodies on none of the markers, so an unbounded scan spliced the rest of the file into one entry).
- **Project config rejects typo'd keys** and reports a parse error on stderr instead of silently falling back to defaults.
- **`usage`** no longer re-reads every transcript on disk a second time for the month-end forecast.

## Verification

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and 431 tests — all green locally on Windows. New regression tests cover the redaction gap, the token check, the script-block escape, the dedup scoping, the verbatim/CRLF/bounded signature cases, and the honest `pct_saved` denominator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SkEKrrAv15VUHAKsVBLVZJ