### PR TITLE
feat: blast radius, module detection, index snapshots, inline freshness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ dump_gemini.json
 # Generated per-machine by `tokenix install-hook --tool copilot`; absolute/local
 # binary paths must not be committed. Each contributor regenerates it locally.
 .github/hooks/hooks.json
+target-test/*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,10 @@ them weekly and on demand — that is the only place they execute.
 | `store.rs` | SQLite access, `index_staleness`, graph tables, hook log |
 | `query.rs` | Semantic + lexical retrieval, RRF fusion, budgeting |
 | `graph.rs` | Symbol graph, PageRank, Tarjan SCC cycles, import graph, repo hotspots |
+| `freshness.rs` | Inline pre-query refresh of dirty files (`--no-embed` path), fails open |
+| `modules.rs` | Louvain community detection over `graph_edges` — `tokenix modules` |
+| `blast.rs` | Diff → changed symbols → reverse call graph (`tokenix blast`) |
+| `snapshot.rs` | `export-index` / `import-index` — gzipped `VACUUM INTO` copy for teams |
 | `hook.rs` | `PreToolUse` handler — the interception decision tree |
 | `compress.rs` | Generic output compression, base64 redaction, token ceiling, EOL preservation |
 | `filters.rs` | `FilterDef` schema, filter resolution, `apply_filter_with_exit` |
@@ -75,6 +79,17 @@ meta(key PK, value)                          -- 'indexed_at', git fingerprint
 
 `meta` holds `indexed_at` plus a Git fingerprint (worktree root + branch + HEAD);
 a different fingerprint counts as stale so branch switches never reuse context.
+`snapshot_version` / `snapshot_created_at` are stamped by `tokenix export-index`.
+
+`files.content_hash` prefixed with `ne:` marks a row written **without
+embeddings** (`index --no-embed`, or the inline refresh in `freshness.rs`). The
+prefix makes the file read as changed to the next embedding run, and
+`plan_files` appends those files to a git-incremental plan so the backlog is
+always paid — a git-clean file would otherwise never be revisited.
+`index_staleness` deliberately ignores them: those chunks are valid for FTS,
+graph and read interception, and reporting them stale would make the hook fail
+open and stop saving tokens. `index --if-stale` checks `pending_embed_count`
+separately.
 
 **Query paths open old DBs without migrating** — SELECTs must degrade when `scale`
 is missing (`embeddings_have_scale()` probes by selecting `NULL`).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4079,6 +4079,7 @@ dependencies = [
  "colored",
  "dirs",
  "fastembed",
+ "flate2",
  "hex",
  "ignore",
  "indicatif 0.18.6",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,9 @@ tree-sitter-javascript = "0.25"
 tree-sitter-go = "0.25"
 tree-sitter-cpp = "0.23"
 reqwest = { version = "0.13.4", features = ["blocking", "json"] }
+# Shareable index snapshots. rust_backend keeps this to miniz_oxide (pure Rust,
+# already in the tree via reqwest) instead of pulling a C zlib.
+flate2 = { version = "1", default-features = false, features = ["rust_backend"] }
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.61", features = ["Win32_System_Threading"] }

--- a/README.md
+++ b/README.md
@@ -360,7 +360,9 @@ repo-local `opencode.json` MCP registration.
 | `tokenix deps FILE` | File-level import dependencies (`--reverse`, `--transitive`, `--json`) |
 | `tokenix impact SYMBOL` | Bidirectional impact graph (`--format html\|mermaid`) |
 | `tokenix flow SYMBOL` | Forward call-flow trace (`--depth`, `--format text\|mermaid`) |
-| `tokenix graph` | Repo-wide symbol-graph overview — god nodes, bottlenecks, blast-radius leaders (`--format text\|dot\|json`, `--top N`) |
+| `tokenix graph` | Repo-wide symbol-graph overview — god nodes, bottlenecks, blast-radius leaders, modules (`--format text\|dot\|json`, `--top N`) |
+| `tokenix modules` | Functional modules found by community detection over the symbol graph (`--top`, `--json`) |
+| `tokenix blast` | Blast radius of the current diff — changed symbols and everything that calls them (`--since REF`, `--depth`, `--json`) |
 | `tokenix pack` | Budgeted repo pack for non-hook AI tools (`--mode/--profile`, `--changed`, `--token-map`) |
 | `tokenix memory add\|list\|remove\|edit` | Save preferences (`--global` / `--project`) for future context |
 
@@ -370,6 +372,8 @@ repo-local `opencode.json` MCP registration.
 |---|---|
 | `tokenix` (no args) | Open the [dashboard](#-dashboard); piped/non-TTY falls back to help |
 | `tokenix index [PATH]` | Index the repo at PATH (default `.`) |
+| `tokenix export-index` | Write the index to a shareable snapshot (`.tokenix/index.db.gz`) teammates can commit |
+| `tokenix import-index` | Bootstrap this repo's index from a snapshot instead of indexing from zero (`--force`) |
 | `tokenix install-hook` / `remove-hook` | Install or remove assistant hooks/instructions (default `--tool all`) |
 | `tokenix install-binary` | Copy the running executable to a per-user bin dir and ensure it is on PATH |
 | `tokenix doctor` | Diagnose embedding backend, GPU, model cache, daemon, filter inventory, and filter config |
@@ -410,6 +414,15 @@ the dashboard, same as `TOKENIX_NO_TUI=1`), `TOKENIX_BRANCH_AWARE=true` (suffix 
 SQLite DB per git branch), `TOKENIX_DISABLED=1` (bypass the hook for one command),
 `TOKENIX_MAX_OUTPUT_TOKENS` (global output ceiling, default 8000, `0` disables).
 
+**Freshness** — every retrieval command (`query`, `context`, `explore`, `grep`,
+`symbols`, `callers`, `callees`, `impact`, `flow`, `deps`, `graph`, `modules`,
+`blast`) and the equivalent MCP tools reconcile the working tree before
+answering: files changed since the last index are re-chunked into the text index
+and the symbol graph, without embedding them (milliseconds, no model load). Those
+files are marked so the next `tokenix index` embeds them. `TOKENIX_AUTO_REFRESH=0`
+turns it off; `TOKENIX_AUTO_REFRESH_MAX` (default 25) is the file count past which
+a change set is left for a real index run.
+
 **Dedup** — repeated identical command output collapses to a one-line pointer.
 `TOKENIX_DEDUP=0` disables it, `TOKENIX_DEDUP_MIN_TOKENS` sets the floor (default
 200), `TOKENIX_DEDUP_TTL` how long an earlier run stays usable (default 3600 s).
@@ -448,6 +461,18 @@ downloaded on first use).
 `--format <text|html|mermaid|json>`, `--output/-o`, `--path/-p`
 
 **`tokenix flow`** — `--depth/-d` (3), `--limit/-l` (50), `--format <text|mermaid>`
+
+**`tokenix blast`** — `--since REF` (default `HEAD`, e.g. `origin/main`),
+`--depth/-d` (2), `--limit/-l` (50), `--json`, `--path/-p`
+
+**`tokenix modules`** — `--top` (12), `--json`, `--path/-p`
+
+**`tokenix export-index` / `import-index`** — `--output/-o` and `--input/-i`
+(default `.tokenix/index.db.gz`), `--force` on import to replace a newer local
+index. The snapshot is a compacted copy of the index with the local embedding
+cache stripped; import refuses anything that is not a tokenix index, keeps the
+previous DB as `*.pre-import.bak`, and leaves the snapshot's git fingerprint in
+place so `tokenix index` only has to catch up on the diff.
 
 **`tokenix pack`** — `--mode/--profile <plan|debug|audit|security|review>`,
 `--budget N` (8000), `--format <markdown|xml|json>`, `--changed`, `--since REF`,
@@ -543,7 +568,11 @@ language mapping in `.tokenix.toml`.
 ```
 
 - **Storage** — one SQLite DB per project under `~/.tokenix/`, int8-quantized
-  embeddings, FTS5 for lexical search.
+  embeddings, FTS5 for lexical search. `tokenix export-index` turns it into a
+  committable snapshot so a team indexes once, not once per developer.
+- **Freshness** — retrieval never answers from an index the working tree has
+  moved past: dirty files are re-chunked into the text index and symbol graph
+  first, and marked for embedding on the next real index run.
 - **Embeddings** — in-process ONNX via `fastembed`. No daemon required; if
   `tokenix serve` is running it keeps the model in RAM and answers over a local
   socket, otherwise the hook embeds in-process. The socket is bound to

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -141,7 +141,7 @@ tokenix/
 
 ## Measurement & Validation
 
-1. **Benchmark suite**: `tokenix bench --session-like` 
+1. **Benchmark suite**: `tokenix bench --session-like`
    - Simulate 20 typical cluster queries
    - Measure tokens before/after optimizations
 
@@ -236,11 +236,11 @@ before the broader indexing work in Phases 1–3 above.
 
 ## Session Recovery Complete (2026-05-29)
 
-**Cluster status**: ✅ **38 apps deployed, 37 Synced+Healthy, 1 OutOfSync but Healthy**  
-**Pod health**: ✅ 72 pods running, 0 CrashLoops, 0 failed  
-**Critical services**: ✅ evo-agent, fast-news, shorts-generator, queima-buchinho, vibe-code all operational  
-**Postgres backup**: ✅ Fixed (pg_isready retry loop added, tested successful)  
-**Monitoring**: ✅ Telegram alerts active for backup/scheduled job failures  
+**Cluster status**: ✅ **38 apps deployed, 37 Synced+Healthy, 1 OutOfSync but Healthy**
+**Pod health**: ✅ 72 pods running, 0 CrashLoops, 0 failed
+**Critical services**: ✅ evo-agent, fast-news, shorts-generator, queima-buchinho, vibe-code all operational
+**Postgres backup**: ✅ Fixed (pg_isready retry loop added, tested successful)
+**Monitoring**: ✅ Telegram alerts active for backup/scheduled job failures
 
 ### Fixes Applied This Session
 1. **evo-agent Unknown** → Fixed 4 cronjobs with duplicate spec: key (kustomize build blocker)
@@ -268,6 +268,40 @@ Estimated token savings from P1+P2: ~60% of typical cluster-ops workflow.
 
 ---
 
-**Last updated**: 2026-05-29 (session recovery: 38 apps → fully operational)  
-**Owner**: Tokenix optimization initiative + app-charts cluster recovery  
+**Last updated**: 2026-05-29 (session recovery: 38 apps → fully operational)
+**Owner**: Tokenix optimization initiative + app-charts cluster recovery
 **Status**: Session complete; next phase is tokenix k8s subcommand implementation
+## Competitive gap pass (2026-08)
+
+Audit against [Graft](https://github.com/NanoNets/Graft),
+[codebase-memory-mcp](https://github.com/DeusData/codebase-memory-mcp) and
+[Agent-Reach](https://github.com/Panniantong/Agent-Reach).
+
+Shipped in this pass:
+
+1. **Freshness-on-query** (`freshness.rs`) — retrieval reconciles the working
+   tree before answering, `--no-embed` path, fails open. Graft refreshes before
+   every command; tokenix previously answered from the last index run.
+2. **Modules** (`modules.rs`, `tokenix modules`) — Louvain communities over the
+   symbol graph, the repo-orientation answer cbm gets from Louvain and Graft
+   pays an LLM for. No API key, deterministic.
+3. **Blast radius of a diff** (`blast.rs`, `tokenix blast`) — the `graft blast`
+   equivalent, built on the existing graph.
+4. **Team snapshots** (`snapshot.rs`, `export-index` / `import-index`) — the
+   `.codebase-memory/graph.db.zst` idea: index once per repo, not once per dev.
+
+Deliberately not done:
+
+- **Tree-sitter breadth** (Java, C#, Ruby, PHP, Kotlin, Swift). Graft covers 21
+  languages, cbm claims 158; tokenix covers 8. Still the weakest column, and
+  still a per-language grammar dependency + binary-size decision the owner
+  declined on 2026-06-10.
+- **Route/IaC nodes** (HTTP/gRPC handler ↔ call site, Dockerfile/k8s manifests as
+  graph nodes). Highest-value remaining gap and it overlaps the cluster items
+  below; needs its own design pass.
+- **Task-level correctness benchmark** (SWE-bench-style). Graft publishes
+  correctness and billed cost; tokenix publishes tokens only. This is a harness
+  project, not a code change, and the README already states the position.
+- **Agent-Reach**: orthogonal (internet access). The one transferable idea is its
+  capability layer — ordered backends with automatic fallback surfaced by
+  `doctor`.

--- a/src/blast.rs
+++ b/src/blast.rs
@@ -1,0 +1,477 @@
+//! Diff-scoped blast radius: what a change set can break.
+//!
+//! `tokenix impact <symbol>` answers the question once you already know which
+//! symbol to ask about. Reviewing a branch is the other way round: the diff is
+//! the input and the interesting output is everything downstream of it. This
+//! maps changed line ranges onto symbols and walks the reverse call graph from
+//! there, so a review starts from "these 3 callers of the function you touched
+//! are untested" instead of from a list of files.
+
+use std::collections::{BTreeMap, HashMap, HashSet};
+use std::path::Path;
+use std::process::Command;
+
+use anyhow::{Context, Result};
+use rusqlite::Connection;
+
+use crate::store::{self, GraphNode};
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct ChangedSymbol {
+    pub name: String,
+    pub path: String,
+    pub kind: String,
+    pub start_line: usize,
+    pub end_line: usize,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct ImpactedSymbol {
+    pub name: String,
+    pub path: String,
+    /// Call-graph hops from the nearest changed symbol.
+    pub distance: usize,
+    /// How many symbols call this one — a proxy for how visible a break is.
+    pub in_degree: usize,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct BlastReport {
+    /// What the diff was taken against (`HEAD`, `origin/main`, ...).
+    pub base: String,
+    pub changed_files: Vec<String>,
+    /// Changed files that carry no indexed symbol (new files, data, configs).
+    pub files_without_symbols: Vec<String>,
+    pub changed_symbols: Vec<ChangedSymbol>,
+    pub impacted: Vec<ImpactedSymbol>,
+    /// Files containing at least one impacted symbol, most hits first.
+    pub impacted_files: Vec<(String, usize)>,
+    pub depth: usize,
+    pub truncated: bool,
+}
+
+/// Line ranges touched per file, in terms of the *new* file's numbering.
+type FileRanges = BTreeMap<String, Vec<(usize, usize)>>;
+
+fn git_diff(repo_root: &Path, base: &str) -> Result<String> {
+    let out = Command::new("git")
+        .args([
+            "diff",
+            "--unified=0",
+            "--no-color",
+            "--no-ext-diff",
+            "--find-renames",
+            base,
+        ])
+        .current_dir(repo_root)
+        .output()
+        .context("failed to run git diff — is git installed and is this a repository?")?;
+    if !out.status.success() {
+        let err = String::from_utf8_lossy(&out.stderr);
+        anyhow::bail!("git diff {base} failed: {}", err.trim());
+    }
+    Ok(String::from_utf8_lossy(&out.stdout).into_owned())
+}
+
+/// Parse `git diff --unified=0` into per-file changed line ranges.
+///
+/// Only the new-side ranges matter: they are what the index has symbols for. A
+/// pure deletion (`+c,0`) still marks line `c` so the symbol that lost code is
+/// reported.
+pub fn parse_diff_ranges(diff: &str) -> FileRanges {
+    let mut ranges: FileRanges = BTreeMap::new();
+    let mut current: Option<String> = None;
+    // A `+++ ` line is only a header when the previous line was the matching
+    // `--- ` one. Added content can legitimately start with `+++`, and reading
+    // that as a header would file the next hunks under a nonexistent path.
+    let mut prev_was_old_header = false;
+    for line in diff.lines() {
+        if line.starts_with("--- ") {
+            prev_was_old_header = true;
+            continue;
+        }
+        if let Some(rest) = line.strip_prefix("+++ ") {
+            if !prev_was_old_header {
+                continue;
+            }
+            prev_was_old_header = false;
+            let path = rest.trim();
+            current = if path == "/dev/null" {
+                None
+            } else {
+                Some(path.trim_start_matches("b/").replace('\\', "/"))
+            };
+            continue;
+        }
+        prev_was_old_header = false;
+        if !line.starts_with("@@") {
+            continue;
+        }
+        let Some(file) = current.clone() else {
+            continue;
+        };
+        // @@ -old,count +new,count @@ optional context
+        let Some(plus) = line.split('+').nth(1) else {
+            continue;
+        };
+        let spec = plus.split_whitespace().next().unwrap_or("");
+        let (start, count) = match spec.split_once(',') {
+            Some((s, c)) => (s.parse::<usize>().ok(), c.parse::<usize>().ok()),
+            None => (spec.parse::<usize>().ok(), Some(1)),
+        };
+        let (Some(start), Some(count)) = (start, count) else {
+            continue;
+        };
+        let end = if count == 0 { start } else { start + count - 1 };
+        ranges.entry(file).or_default().push((start.max(1), end));
+    }
+    ranges
+}
+
+/// `<module>` and friends are synthetic file-level graph nodes. They are useful
+/// for edge resolution but meaningless in a review list: nobody can open
+/// "`<module>`" and check it.
+fn is_synthetic(name: &str) -> bool {
+    name.starts_with('<')
+}
+
+fn overlaps(node: &GraphNode, ranges: &[(usize, usize)]) -> bool {
+    ranges
+        .iter()
+        .any(|(s, e)| node.start_line <= *e && node.end_line >= *s)
+}
+
+/// What one reverse walk yields: the reached nodes with their hop distance, a
+/// `chunk_id -> (symbol name, path:line)` map, and each node's caller count.
+type ReverseWalk = (
+    Vec<(i64, usize)>,
+    HashMap<i64, (String, String)>,
+    HashMap<i64, usize>,
+);
+
+/// Walk the reverse call graph from the changed symbols.
+fn reverse_bfs(edges: &[store::GraphEdgeRow], seeds: &HashSet<i64>, depth: usize) -> ReverseWalk {
+    let mut callers: HashMap<i64, Vec<i64>> = HashMap::new();
+    let mut label: HashMap<i64, (String, String)> = HashMap::new();
+    let mut in_degree: HashMap<i64, usize> = HashMap::new();
+    for (cid, cname, cloc, eid, ename, eloc) in edges {
+        label
+            .entry(*cid)
+            .or_insert_with(|| (cname.clone(), cloc.clone()));
+        label
+            .entry(*eid)
+            .or_insert_with(|| (ename.clone(), eloc.clone()));
+        callers.entry(*eid).or_default().push(*cid);
+        *in_degree.entry(*eid).or_default() += 1;
+    }
+
+    let mut seen: HashSet<i64> = seeds.clone();
+    let mut out: Vec<(i64, usize)> = Vec::new();
+    let mut frontier: Vec<i64> = seeds.iter().copied().collect();
+    frontier.sort_unstable();
+    for hop in 1..=depth {
+        let mut next: Vec<i64> = Vec::new();
+        for node in frontier {
+            let Some(list) = callers.get(&node) else {
+                continue;
+            };
+            let mut list = list.clone();
+            list.sort_unstable();
+            for caller in list {
+                if seen.insert(caller) {
+                    out.push((caller, hop));
+                    next.push(caller);
+                }
+            }
+        }
+        if next.is_empty() {
+            break;
+        }
+        frontier = next;
+    }
+    (out, label, in_degree)
+}
+
+pub fn analyze(
+    conn: &Connection,
+    repo_root: &Path,
+    base: &str,
+    depth: usize,
+    limit: usize,
+) -> Result<BlastReport> {
+    let diff = git_diff(repo_root, base)?;
+    let ranges = parse_diff_ranges(&diff);
+
+    let mut changed_symbols = Vec::new();
+    let mut files_without_symbols = Vec::new();
+    let mut seeds: HashSet<i64> = HashSet::new();
+    for (file, spans) in &ranges {
+        let nodes = store::graph_nodes_for_path(conn, file)?;
+        let mut hit = false;
+        for node in nodes {
+            if overlaps(&node, spans) {
+                hit = true;
+                // Seed the walk from every touched node, including file-level
+                // ones — they carry real edges — but keep them out of the report.
+                seeds.insert(node.chunk_id);
+                if is_synthetic(&node.name) {
+                    continue;
+                }
+                changed_symbols.push(ChangedSymbol {
+                    name: node.name,
+                    path: node.path,
+                    kind: node.kind,
+                    start_line: node.start_line,
+                    end_line: node.end_line,
+                });
+            }
+        }
+        if !hit {
+            files_without_symbols.push(file.clone());
+        }
+    }
+    changed_symbols.sort_by(|a, b| {
+        a.path
+            .cmp(&b.path)
+            .then_with(|| a.start_line.cmp(&b.start_line))
+    });
+
+    let edges = store::load_all_graph_edges(conn)?;
+    let (reached, label, in_degree) = reverse_bfs(&edges, &seeds, depth.max(1));
+
+    let changed_ids = seeds;
+    let mut impacted: Vec<ImpactedSymbol> = reached
+        .into_iter()
+        .filter(|(id, _)| !changed_ids.contains(id))
+        .filter(|(id, _)| !label.get(id).is_some_and(|(name, _)| is_synthetic(name)))
+        .map(|(id, distance)| {
+            let (name, loc) = label
+                .get(&id)
+                .cloned()
+                .unwrap_or_else(|| (format!("chunk#{id}"), String::new()));
+            ImpactedSymbol {
+                name,
+                path: loc,
+                distance,
+                in_degree: in_degree.get(&id).copied().unwrap_or(0),
+            }
+        })
+        .collect();
+    // Nearest first, then the most-called symbols: that is the reading order for
+    // a review — closest to the change and most exposed if it breaks.
+    impacted.sort_by(|a, b| {
+        a.distance
+            .cmp(&b.distance)
+            .then_with(|| b.in_degree.cmp(&a.in_degree))
+            .then_with(|| a.name.cmp(&b.name))
+    });
+
+    let mut per_file: BTreeMap<String, usize> = BTreeMap::new();
+    for s in &impacted {
+        let file = s.path.rsplit_once(':').map(|(p, _)| p).unwrap_or(&s.path);
+        *per_file.entry(file.to_string()).or_default() += 1;
+    }
+    let mut impacted_files: Vec<(String, usize)> = per_file.into_iter().collect();
+    impacted_files.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+
+    let truncated = impacted.len() > limit;
+    impacted.truncate(limit);
+
+    Ok(BlastReport {
+        base: base.to_string(),
+        changed_files: ranges.keys().cloned().collect(),
+        files_without_symbols,
+        changed_symbols,
+        impacted,
+        impacted_files,
+        depth: depth.max(1),
+        truncated,
+    })
+}
+
+pub fn format_report(report: &BlastReport) -> String {
+    if report.changed_files.is_empty() {
+        return format!("No changes against {}.", report.base);
+    }
+    let mut out = format!(
+        "# Blast radius vs {} — {} changed file(s), {} changed symbol(s)\n",
+        report.base,
+        report.changed_files.len(),
+        report.changed_symbols.len()
+    );
+
+    out.push_str("\n## Changed symbols\n");
+    if report.changed_symbols.is_empty() {
+        out.push_str("- (none indexed — the diff touches files with no symbols)\n");
+    }
+    for s in &report.changed_symbols {
+        out.push_str(&format!(
+            "- {} ({})  {}:{}\n",
+            s.name, s.kind, s.path, s.start_line
+        ));
+    }
+
+    out.push_str(&format!(
+        "\n## Impacted (up to {} hop(s) of callers)\n",
+        report.depth
+    ));
+    if report.impacted.is_empty() {
+        out.push_str("- nothing depends on the changed symbols\n");
+    }
+    for s in &report.impacted {
+        out.push_str(&format!(
+            "- [{}] {} (↑{})  {}\n",
+            s.distance, s.name, s.in_degree, s.path
+        ));
+    }
+    if report.truncated {
+        out.push_str("- … more impacted symbols hidden (raise --limit)\n");
+    }
+
+    if !report.impacted_files.is_empty() {
+        out.push_str("\n## Files to review\n");
+        for (file, hits) in report.impacted_files.iter().take(15) {
+            out.push_str(&format!("- {file} ({hits} impacted symbol(s))\n"));
+        }
+    }
+
+    if !report.files_without_symbols.is_empty() {
+        out.push_str("\n## Changed files with no indexed symbol\n");
+        for f in report.files_without_symbols.iter().take(15) {
+            out.push_str(&format!("- {f}\n"));
+        }
+    }
+
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const DIFF: &str = "diff --git a/src/store.rs b/src/store.rs\n\
+index 111..222 100644\n\
+--- a/src/store.rs\n\
++++ b/src/store.rs\n\
+@@ -10,3 +10,5 @@ fn thing() {\n\
++added\n\
+@@ -80,2 +82,0 @@ fn other() {\n\
+-gone\n\
+diff --git a/README.md b/README.md\n\
+--- a/README.md\n\
++++ b/README.md\n\
+@@ -1 +1 @@\n\
+-old\n\
++new\n";
+
+    #[test]
+    fn parses_new_side_ranges() {
+        let ranges = parse_diff_ranges(DIFF);
+        assert_eq!(ranges["src/store.rs"], vec![(10, 14), (82, 82)]);
+        assert_eq!(ranges["README.md"], vec![(1, 1)]);
+    }
+
+    #[test]
+    fn added_content_that_looks_like_a_header_is_not_one() {
+        // The body of this hunk adds a literal `+++ b/evil.rs` line.
+        let diff = "--- a/src/real.rs\n\
++++ b/src/real.rs\n\
+@@ -1,0 +2,1 @@\n\
++++ b/evil.rs\n\
+@@ -9,0 +9,1 @@\n\
++ok\n";
+        let ranges = parse_diff_ranges(diff);
+        assert_eq!(ranges.len(), 1, "{ranges:?}");
+        assert_eq!(ranges["src/real.rs"], vec![(2, 2), (9, 9)]);
+    }
+
+    #[test]
+    fn deleted_files_are_skipped() {
+        let diff = "--- a/gone.rs\n+++ /dev/null\n@@ -1,5 +0,0 @@\n-x\n";
+        assert!(parse_diff_ranges(diff).is_empty());
+    }
+
+    fn node(id: i64, name: &str, start: usize, end: usize) -> GraphNode {
+        GraphNode {
+            chunk_id: id,
+            path: "src/store.rs".to_string(),
+            name: name.to_string(),
+            kind: "function".to_string(),
+            start_line: start,
+            end_line: end,
+        }
+    }
+
+    #[test]
+    fn overlap_is_inclusive_on_both_ends() {
+        let n = node(1, "f", 10, 20);
+        assert!(overlaps(&n, &[(20, 25)]));
+        assert!(overlaps(&n, &[(5, 10)]));
+        assert!(overlaps(&n, &[(12, 13)]));
+        assert!(!overlaps(&n, &[(21, 30)]));
+        assert!(!overlaps(&n, &[(1, 9)]));
+    }
+
+    #[test]
+    fn bfs_reports_hop_distance_and_stops_at_depth() {
+        // c -> b -> a  (a is the changed symbol)
+        let edges = vec![
+            (
+                2,
+                "b".to_string(),
+                "src/b.rs:1".to_string(),
+                1,
+                "a".to_string(),
+                "src/a.rs:1".to_string(),
+            ),
+            (
+                3,
+                "c".to_string(),
+                "src/c.rs:1".to_string(),
+                2,
+                "b".to_string(),
+                "src/b.rs:1".to_string(),
+            ),
+        ];
+        let seeds: HashSet<i64> = [1].into_iter().collect();
+
+        let (one_hop, _, _) = reverse_bfs(&edges, &seeds, 1);
+        assert_eq!(one_hop, vec![(2, 1)]);
+
+        let (two_hops, _, in_degree) = reverse_bfs(&edges, &seeds, 2);
+        assert_eq!(two_hops, vec![(2, 1), (3, 2)]);
+        assert_eq!(in_degree.get(&1), Some(&1));
+    }
+
+    #[test]
+    fn synthetic_file_nodes_are_not_reportable_symbols() {
+        assert!(is_synthetic("<module>"));
+        assert!(!is_synthetic("handle_checkout"));
+    }
+
+    #[test]
+    fn cycles_do_not_loop_forever() {
+        // a -> b -> a
+        let edges = vec![
+            (
+                1,
+                "a".to_string(),
+                "src/a.rs:1".to_string(),
+                2,
+                "b".to_string(),
+                "src/b.rs:1".to_string(),
+            ),
+            (
+                2,
+                "b".to_string(),
+                "src/b.rs:1".to_string(),
+                1,
+                "a".to_string(),
+                "src/a.rs:1".to_string(),
+            ),
+        ];
+        let seeds: HashSet<i64> = [1].into_iter().collect();
+        let (reached, _, _) = reverse_bfs(&edges, &seeds, 10);
+        assert_eq!(reached, vec![(2, 1)]);
+    }
+}

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -21,13 +21,14 @@ const READ_TIMEOUT_MS: u64 = 15_000; // model load on first request can take ~50
 
 #[inline]
 fn dot_product(a: &[f32], b: &[f32]) -> f32 {
-    let chunks = a.chunks_exact(8).zip(b.chunks_exact(8));
-    let mut sum: f32 = chunks
+    let (blocks_a, rem_a) = a.as_chunks::<8>();
+    let (blocks_b, rem_b) = b.as_chunks::<8>();
+    let mut sum: f32 = blocks_a
+        .iter()
+        .zip(blocks_b.iter())
         .map(|(ca, cb)| ca.iter().zip(cb.iter()).map(|(x, y)| x * y).sum::<f32>())
         .sum();
     // handle remainder (768 % 8 == 0, so this is a no-op for nomic-embed-text-v1.5)
-    let rem_a = a.chunks_exact(8).remainder();
-    let rem_b = b.chunks_exact(8).remainder();
     sum += rem_a
         .iter()
         .zip(rem_b.iter())
@@ -40,8 +41,11 @@ fn dot_product(a: &[f32], b: &[f32]) -> f32 {
 /// The i8→f32 widening vectorizes; cache traffic is 4x lower than f32×f32.
 #[inline]
 fn dot_product_q8(a: &[f32], b: &[i8]) -> f32 {
-    let chunks = a.chunks_exact(8).zip(b.chunks_exact(8));
-    let mut sum: f32 = chunks
+    let (blocks_a, rem_a) = a.as_chunks::<8>();
+    let (blocks_b, rem_b) = b.as_chunks::<8>();
+    let mut sum: f32 = blocks_a
+        .iter()
+        .zip(blocks_b.iter())
         .map(|(ca, cb)| {
             ca.iter()
                 .zip(cb.iter())
@@ -49,8 +53,6 @@ fn dot_product_q8(a: &[f32], b: &[i8]) -> f32 {
                 .sum::<f32>()
         })
         .sum();
-    let rem_a = a.chunks_exact(8).remainder();
-    let rem_b = b.chunks_exact(8).remainder();
     sum += rem_a
         .iter()
         .zip(rem_b.iter())

--- a/src/embed.rs
+++ b/src/embed.rs
@@ -247,8 +247,10 @@ fn serialize_vec(v: &[f32]) -> Vec<u8> {
 
 fn deserialize_vec(bytes: &[u8]) -> Vec<f32> {
     bytes
-        .chunks_exact(4)
-        .map(|b| f32::from_le_bytes(b.try_into().unwrap()))
+        .as_chunks::<4>()
+        .0
+        .iter()
+        .map(|b| f32::from_le_bytes(*b))
         .collect()
 }
 

--- a/src/freshness.rs
+++ b/src/freshness.rs
@@ -1,0 +1,237 @@
+//! Freshness-on-query: bring the index up to date with the working tree before
+//! a retrieval command answers.
+//!
+//! The index is built from committed *and* working-tree state, so an edit made
+//! after the last `tokenix index` silently makes every retrieval answer stale —
+//! `query` returns the old body of a function the agent just rewrote. The hook
+//! already fails open when the whole index is stale, but a CLI/MCP call has no
+//! such escape: it answers confidently from old rows.
+//!
+//! This module closes that window for the common case (a handful of dirty
+//! files) by re-chunking just those files **without embedding them**: chunk
+//! text lands in the FTS5 side of hybrid search and the symbol graph is
+//! repaired, which costs milliseconds and no model load. Files touched this way
+//! are stamped with a sentinel content hash (see `indexer::NO_EMBED_HASH_PREFIX`)
+//! so the next real `tokenix index` re-embeds them instead of skipping them as
+//! unchanged.
+//!
+//! Everything here fails open: any error, lock contention, or a change set too
+//! large to be cheap leaves the existing index untouched and the command
+//! answers exactly as it did before.
+
+use std::path::Path;
+use std::time::Instant;
+
+use crate::indexer::{self, IndexOptions};
+use crate::store;
+
+/// Refuse to auto-refresh past this many dirty files: beyond it the run stops
+/// being "a few milliseconds" and a query would stall behind a real index.
+pub const DEFAULT_MAX_FILES: usize = 25;
+
+pub struct RefreshReport {
+    pub files: usize,
+    pub deleted: usize,
+    pub elapsed_ms: u128,
+}
+
+pub enum Refresh {
+    /// `TOKENIX_AUTO_REFRESH=0`.
+    Disabled,
+    /// No index yet, or it could not be opened — nothing to refresh.
+    NoIndex,
+    /// Not a git repo (or git is unavailable): no cheap way to find dirty files.
+    NotGit,
+    /// The working tree matches what the index already holds.
+    Clean,
+    /// Too many dirty files for an inline refresh.
+    TooBig {
+        files: usize,
+        cap: usize,
+    },
+    /// An index run is already in progress, or the refresh itself failed.
+    Failed(String),
+    Refreshed(RefreshReport),
+}
+
+fn env_flag_disabled(name: &str) -> bool {
+    std::env::var(name).is_ok_and(|v| {
+        let v = v.trim().to_ascii_lowercase();
+        v == "0" || v == "false" || v == "off" || v == "no"
+    })
+}
+
+fn max_files() -> usize {
+    std::env::var("TOKENIX_AUTO_REFRESH_MAX")
+        .ok()
+        .and_then(|v| v.trim().parse::<usize>().ok())
+        .unwrap_or(DEFAULT_MAX_FILES)
+}
+
+/// Re-chunk working-tree changes into the existing index, if that is cheap.
+///
+/// Never returns an error: the caller's command must run either way.
+pub fn refresh_before_query(repo_root: &Path) -> Refresh {
+    if env_flag_disabled("TOKENIX_AUTO_REFRESH") {
+        return Refresh::Disabled;
+    }
+
+    let dirty = {
+        let conn = match store::open_db(repo_root, false) {
+            Ok(Some(c)) => c,
+            _ => return Refresh::NoIndex,
+        };
+        // Never refresh an index that has no `indexed_at`: it is half-written or
+        // from a crashed run, and a partial refresh would stamp it as complete.
+        if store::meta_value(&conn, "indexed_at").is_none() {
+            return Refresh::NoIndex;
+        }
+        let Some((changed, deleted)) = indexer::git_dirty_paths(repo_root) else {
+            return Refresh::NotGit;
+        };
+        let Ok(existing) = store::load_all_file_info(&conn) else {
+            return Refresh::NoIndex;
+        };
+
+        let files = changed
+            .iter()
+            .filter(|(abs, rel)| match existing.get(rel.as_str()) {
+                // Known file: an mtime match means the index already holds this
+                // body. Content is not hashed here — the indexer does that and
+                // skips a no-op re-chunk on its own.
+                Some((_, stored_mtime, _)) => {
+                    (stored_mtime - indexer::file_mtime(abs)).abs() >= 0.01
+                }
+                // Unknown file: created since the last index.
+                None => true,
+            })
+            .count();
+        // Deletions are counted for the report only. The refresh does not apply
+        // them (see `indexer::index_repo_with_options`), so on their own they are
+        // not a reason to run one.
+        let deleted = deleted
+            .iter()
+            .filter(|rel| existing.contains_key(rel.as_str()))
+            .count();
+        (files, deleted)
+    };
+
+    let (files, deleted) = dirty;
+    if files == 0 {
+        return Refresh::Clean;
+    }
+    let cap = max_files();
+    if files > cap {
+        return Refresh::TooBig { files, cap };
+    }
+
+    let started = Instant::now();
+    let mut silent = |_: &str| {};
+    match indexer::index_repo_with_options(
+        repo_root,
+        IndexOptions {
+            force: false,
+            no_embed: true,
+        },
+        &mut silent,
+    ) {
+        Ok(_) => Refresh::Refreshed(RefreshReport {
+            files,
+            deleted,
+            elapsed_ms: started.elapsed().as_millis(),
+        }),
+        Err(e) => Refresh::Failed(e.to_string()),
+    }
+}
+
+/// One stderr line when the refresh did something the user should know about.
+/// Silent on the boring outcomes so scripted/JSON callers keep a clean stream.
+pub fn announce(outcome: &Refresh) {
+    match outcome {
+        Refresh::Refreshed(r) => {
+            let mut what = format!("{} changed file(s)", r.files);
+            if r.deleted > 0 {
+                what.push_str(&format!(
+                    ", {} deleted (still indexed until `tokenix index`)",
+                    r.deleted
+                ));
+            }
+            eprintln!(
+                "[tokenix] index refreshed for {what} in {}ms (text + graph; run `tokenix index` to embed them)",
+                r.elapsed_ms
+            );
+        }
+        Refresh::TooBig { files, cap } => {
+            eprintln!(
+                "[tokenix] {files} changed file(s) exceed the inline refresh cap of {cap} — answering from the stored index. Run `tokenix index` for fresh results."
+            );
+        }
+        Refresh::Failed(e) => {
+            eprintln!("[tokenix] index refresh skipped: {e}");
+        }
+        Refresh::Disabled | Refresh::NoIndex | Refresh::NotGit | Refresh::Clean => {}
+    }
+}
+
+/// Refresh and report in one call — what every retrieval command wants.
+pub fn refresh_and_announce(repo_root: &Path) {
+    let outcome = refresh_before_query(repo_root);
+    announce(&outcome);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn disabled_by_env_returns_disabled() {
+        let key = "TOKENIX_AUTO_REFRESH";
+        let prev = std::env::var(key).ok();
+        std::env::set_var(key, "0");
+        let outcome = refresh_before_query(Path::new("."));
+        assert!(matches!(outcome, Refresh::Disabled));
+        match prev {
+            Some(v) => std::env::set_var(key, v),
+            None => std::env::remove_var(key),
+        }
+    }
+
+    #[test]
+    fn missing_index_is_a_no_op() {
+        let dir = std::env::temp_dir().join(format!("tokenix_fresh_{}", std::process::id()));
+        let _ = std::fs::create_dir_all(&dir);
+        // No DB for this path, so the refresh must bail before touching git.
+        assert!(matches!(
+            refresh_before_query(&dir),
+            Refresh::NoIndex | Refresh::NotGit
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn cap_is_configurable_and_defaults() {
+        let key = "TOKENIX_AUTO_REFRESH_MAX";
+        let prev = std::env::var(key).ok();
+        std::env::remove_var(key);
+        assert_eq!(max_files(), DEFAULT_MAX_FILES);
+        std::env::set_var(key, "3");
+        assert_eq!(max_files(), 3);
+        // Garbage falls back to the default instead of disabling the feature.
+        std::env::set_var(key, "not-a-number");
+        assert_eq!(max_files(), DEFAULT_MAX_FILES);
+        match prev {
+            Some(v) => std::env::set_var(key, v),
+            None => std::env::remove_var(key),
+        }
+    }
+
+    #[test]
+    fn announce_is_silent_for_boring_outcomes() {
+        // No assertion on stderr here; the point is that these arms must not
+        // panic and must stay in the "silent" match arm.
+        announce(&Refresh::Clean);
+        announce(&Refresh::Disabled);
+        announce(&Refresh::NoIndex);
+        announce(&Refresh::NotGit);
+    }
+}

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -677,8 +677,18 @@ pub fn format_repo_report(edges: &[store::GraphEdgeRow], top: usize) -> String {
         ));
     }
 
+    // Orientation: which parts this repo actually has, derived from the graph
+    // rather than from the folder names.
+    out.push_str(&crate::modules::format_modules(
+        &crate::modules::detect_modules(edges, MODULES_IN_REPORT),
+    ));
+
     out
 }
+
+/// How many communities the repo report names. The report is an orientation
+/// device, not an inventory — past a handful the reader stops reading.
+const MODULES_IN_REPORT: usize = 8;
 
 /// Render the most-connected subgraph as Graphviz DOT. Only edges whose both
 /// endpoints are among the top hotspots are emitted, keeping the diagram legible.

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -81,6 +81,12 @@ pub fn lower_process_priority() {
     }
 }
 
+/// Marks a file whose chunks were written without embeddings (`--no-embed`, or
+/// the inline refresh in `crate::freshness`). The stored content hash never
+/// matches the real one while this prefix is on it, so the next full index
+/// re-chunks and embeds the file instead of skipping it as unchanged.
+pub const NO_EMBED_HASH_PREFIX: &str = "ne:";
+
 fn mtime_of(path: &Path) -> f64 {
     std::fs::metadata(path)
         .ok()
@@ -88,6 +94,21 @@ fn mtime_of(path: &Path) -> f64 {
         .and_then(|t| t.duration_since(UNIX_EPOCH).ok())
         .map(|d| d.as_secs_f64())
         .unwrap_or(0.0)
+}
+
+/// Modification time of a path as the index stores it (0.0 when unreadable).
+pub fn file_mtime(path: &Path) -> f64 {
+    mtime_of(path)
+}
+
+/// `((absolute, repo-relative) changed files, repo-relative deleted files)`.
+pub type DirtyPaths = (Vec<(PathBuf, String)>, HashSet<String>);
+
+/// Files git reports as changed/untracked in the working tree, plus the paths
+/// it reports as deleted. `None` when this is not a git repo or git failed.
+pub fn git_dirty_paths(repo_root: &Path) -> Option<DirtyPaths> {
+    let plan = git_changed_files(repo_root)?;
+    Some((plan.files, plan.deleted))
 }
 
 fn chunk_embedding_key(text: &str) -> String {
@@ -187,13 +208,89 @@ fn git_changed_files(repo_root: &Path) -> Option<FilePlan> {
     })
 }
 
+/// Files the index holds only as text (written by a `--no-embed` run or an
+/// inline freshness refresh) and that still exist on disk. A git-incremental
+/// plan cannot see them — they are unchanged as far as git is concerned — so
+/// they are appended explicitly, otherwise their chunks would stay vectorless
+/// until the file happened to change again.
+fn pending_embed_files(
+    repo_root: &Path,
+    existing: &HashMap<String, (i64, f64, String)>,
+    already: &[(PathBuf, String)],
+) -> Vec<(PathBuf, String)> {
+    let planned: HashSet<&str> = already.iter().map(|(_, rel)| rel.as_str()).collect();
+    let mut extra: Vec<(PathBuf, String)> = existing
+        .iter()
+        .filter(|(rel, (_, _, hash))| {
+            hash.starts_with(NO_EMBED_HASH_PREFIX) && !planned.contains(rel.as_str())
+        })
+        .map(|(rel, _)| (repo_root.join(rel), rel.clone()))
+        .filter(|(abs, _)| abs.is_file())
+        .collect();
+    // Deterministic order so two runs over the same backlog behave identically.
+    extra.sort_by(|a, b| a.1.cmp(&b.1));
+    extra
+}
+
+/// Tracked files that exist on disk but have no row in the index.
+///
+/// This is how a file comes back. A deletion drops the file's rows, and a later
+/// `git checkout`/`git stash pop`/branch switch restores a file whose content
+/// matches HEAD — so `git status` says nothing and a purely status-driven plan
+/// would never look at it again. The index would stay silently short one file
+/// until someone ran `--force`.
+fn restored_files(
+    repo_root: &Path,
+    existing: &HashMap<String, (i64, f64, String)>,
+    already: &[(PathBuf, String)],
+) -> Vec<(PathBuf, String)> {
+    let Some(out) = Command::new("git")
+        .args(["ls-files", "-z"])
+        .current_dir(repo_root)
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+    else {
+        return Vec::new();
+    };
+    let max_bytes = index_config()
+        .max_file_bytes
+        .unwrap_or(MAX_INDEX_FILE_BYTES);
+    let planned: HashSet<&str> = already.iter().map(|(_, rel)| rel.as_str()).collect();
+
+    let mut extra: Vec<(PathBuf, String)> = out
+        .stdout
+        .split(|b| *b == 0)
+        .filter(|f| !f.is_empty())
+        .map(|f| String::from_utf8_lossy(f).replace('\\', "/"))
+        .filter(|rel| !existing.contains_key(rel.as_str()) && !planned.contains(rel.as_str()))
+        .map(|rel| (repo_root.join(&rel), rel))
+        .filter(|(abs, _)| {
+            abs.is_file()
+                && should_index(abs)
+                && std::fs::metadata(abs).is_ok_and(|m| m.len() <= max_bytes)
+        })
+        .collect();
+    extra.sort_by(|a, b| a.1.cmp(&b.1));
+    extra
+}
+
 fn plan_files(
     repo_root: &Path,
-    force: bool,
+    options: IndexOptions,
     existing: &HashMap<String, (i64, f64, String)>,
 ) -> FilePlan {
-    if !force && !existing.is_empty() {
-        if let Some(plan) = git_changed_files(repo_root) {
+    if !options.force && !existing.is_empty() {
+        if let Some(mut plan) = git_changed_files(repo_root) {
+            // Only a full run reconciles these, and only it should pay for them:
+            // a `--no-embed` refresh runs inline on a query, where the extra
+            // work is unbounded and the backlog would not shrink anyway.
+            if !options.no_embed {
+                plan.files
+                    .extend(pending_embed_files(repo_root, existing, &plan.files));
+                plan.files
+                    .extend(restored_files(repo_root, existing, &plan.files));
+            }
             return plan;
         }
     }
@@ -211,15 +308,19 @@ fn plan_files(
 fn decode_text(raw: &[u8]) -> Option<String> {
     if raw.starts_with(&[0xFF, 0xFE]) {
         let units: Vec<u16> = raw[2..]
-            .chunks_exact(2)
-            .map(|c| u16::from_le_bytes([c[0], c[1]]))
+            .as_chunks::<2>()
+            .0
+            .iter()
+            .map(|c| u16::from_le_bytes(*c))
             .collect();
         return Some(String::from_utf16_lossy(&units));
     }
     if raw.starts_with(&[0xFE, 0xFF]) {
         let units: Vec<u16> = raw[2..]
-            .chunks_exact(2)
-            .map(|c| u16::from_be_bytes([c[0], c[1]]))
+            .as_chunks::<2>()
+            .0
+            .iter()
+            .map(|c| u16::from_be_bytes(*c))
             .collect();
         return Some(String::from_utf16_lossy(&units));
     }
@@ -365,7 +466,7 @@ where
     }
     let existing: Arc<HashMap<String, (i64, f64, String)>> = Arc::new(load_all_file_info(&conn)?);
 
-    let file_plan = plan_files(repo_root, options.force, &existing);
+    let file_plan = plan_files(repo_root, options, &existing);
     let files = file_plan.files;
 
     let total = files.len();
@@ -564,7 +665,15 @@ where
             continue;
         }
 
-        let file_id = match upsert_file(&conn, &f.rel, f.mtime, &f.hash) {
+        // A no-embed write stores a sentinel hash so the file reads as changed to
+        // the next embedding run; otherwise its chunks would keep no vectors for
+        // as long as the body stays the same.
+        let stored_hash = if options.no_embed {
+            format!("{NO_EMBED_HASH_PREFIX}{}", f.hash)
+        } else {
+            f.hash.clone()
+        };
+        let file_id = match upsert_file(&conn, &f.rel, f.mtime, &stored_hash) {
             Ok(id) => id,
             Err(e) => {
                 errors += 1;
@@ -617,9 +726,18 @@ where
         _ => {}
     }
 
-    // Phase 6: clean up removed files from index
+    // Phase 6: clean up removed files from index.
+    //
+    // An inline refresh (`no_embed`) deliberately skips this. It runs on every
+    // query, so it would see a file that is momentarily absent — mid-rebase,
+    // mid-stash, a checkout in flight — and drop its rows; when the file comes
+    // back unchanged, git reports nothing and the index would stay short one
+    // file. Leaving a deleted file's rows in place until the next full index is
+    // the cheaper mistake: stale hits, not missing ones.
     let mut removed = false;
-    if file_plan.git_incremental {
+    if options.no_embed {
+        // nothing to do
+    } else if file_plan.git_incremental {
         for rel_path in &file_plan.deleted {
             if let Some((file_id, _, _)) = existing.get(rel_path) {
                 progress_cb(&format!("removing deleted file from index: {}", rel_path));

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 mod artifacts;
 mod benchmark;
+mod blast;
 mod chunker;
 mod cmd_filter;
 mod compress;
@@ -14,6 +15,7 @@ mod doctor;
 mod egress_scan;
 mod embed;
 mod filters;
+mod freshness;
 mod gain;
 mod graph;
 mod hook;
@@ -22,11 +24,13 @@ mod mcp;
 mod mcp_audit;
 mod mcp_proxy;
 mod memory;
+mod modules;
 mod pack;
 mod query;
 mod recall;
 mod recordings;
 mod secrets_scan;
+mod snapshot;
 mod store;
 mod transcripts;
 mod tui;
@@ -456,6 +460,56 @@ enum Commands {
         top: usize,
         #[arg(short, long, help = "Write output to a file instead of stdout")]
         output: Option<String>,
+        #[arg(short, long, default_value = ".")]
+        path: PathBuf,
+    },
+    /// Write this repo's index to a shareable snapshot teammates can import
+    ExportIndex {
+        #[arg(
+            short,
+            long,
+            help = "Snapshot file to write (default: .tokenix/index.db.gz)"
+        )]
+        output: Option<PathBuf>,
+        #[arg(short, long, default_value = ".")]
+        path: PathBuf,
+    },
+    /// Bootstrap this repo's index from a snapshot instead of indexing from zero
+    ImportIndex {
+        #[arg(
+            short,
+            long,
+            help = "Snapshot file to read (default: .tokenix/index.db.gz)"
+        )]
+        input: Option<PathBuf>,
+        #[arg(long, help = "Replace the local index even if it is newer")]
+        force: bool,
+        #[arg(short, long, default_value = ".")]
+        path: PathBuf,
+    },
+    /// Blast radius of the current diff: which symbols depend on what changed
+    Blast {
+        #[arg(
+            long,
+            default_value = "HEAD",
+            help = "Diff against this ref (e.g. origin/main)"
+        )]
+        since: String,
+        #[arg(short, long, default_value_t = 2, help = "Caller hops to follow")]
+        depth: usize,
+        #[arg(short, long, default_value_t = 50)]
+        limit: usize,
+        #[arg(long, help = "Emit machine-readable JSON instead of text")]
+        json: bool,
+        #[arg(short, long, default_value = ".")]
+        path: PathBuf,
+    },
+    /// Group the repo into functional modules discovered from the symbol graph
+    Modules {
+        #[arg(long, default_value_t = 12, help = "How many modules to show")]
+        top: usize,
+        #[arg(long, help = "Emit machine-readable JSON instead of text")]
+        json: bool,
         #[arg(short, long, default_value = ".")]
         path: PathBuf,
     },
@@ -1279,6 +1333,18 @@ fn main() -> Result<()> {
             output,
             path,
         } => cmd_graph(&format, top, output.as_deref(), &path),
+        Commands::ExportIndex { output, path } => cmd_export_index(output.as_deref(), &path),
+        Commands::ImportIndex { input, force, path } => {
+            cmd_import_index(input.as_deref(), force, &path)
+        }
+        Commands::Blast {
+            since,
+            depth,
+            limit,
+            json,
+            path,
+        } => cmd_blast(&since, depth, limit, json, &path),
+        Commands::Modules { top, json, path } => cmd_modules(top, json, &path),
         Commands::Cycles { path } => cmd_cycles(&path),
         Commands::RebuildGraph { path } => cmd_rebuild_graph(&path),
         Commands::Gain {
@@ -1665,7 +1731,9 @@ fn cmd_index(path: &Path, force: bool, if_stale: bool, no_embed: bool) -> Result
 
     if if_stale && !force {
         let staleness = store::index_staleness(&repo_root);
-        if !staleness.stale {
+        // A fresh index can still owe embeddings to files an inline refresh wrote
+        // as text only, and this is the run that pays that debt.
+        if !staleness.stale && store::pending_embed_count(&repo_root) == 0 {
             return Ok(());
         }
     }
@@ -1711,6 +1779,7 @@ fn cmd_context(
     path: &Path,
 ) -> Result<()> {
     let repo_root = find_repo_root(path);
+    freshness::refresh_and_announce(&repo_root);
     let out = query::build_task_context_with_mode(&repo_root, task, mode, budget, max_files)?;
     if json {
         println!(
@@ -1743,6 +1812,7 @@ fn cmd_pack(
     output: Option<PathBuf>,
 ) -> Result<()> {
     let repo_root = find_repo_root(path);
+    freshness::refresh_and_announce(&repo_root);
     let options = pack::PackOptions {
         profile,
         budget,
@@ -1902,6 +1972,7 @@ fn cmd_explore(
     path: &Path,
 ) -> Result<()> {
     let repo_root = find_repo_root(path);
+    freshness::refresh_and_announce(&repo_root);
     let out = query::build_explore_context(&repo_root, query_text, budget, max_symbols)?;
     if json {
         println!(
@@ -2025,6 +2096,7 @@ fn cmd_query(
         anyhow::bail!("k must be >= 1");
     }
     let repo_root = find_repo_root(path);
+    freshness::refresh_and_announce(&repo_root);
 
     // Cross-project search: include linked projects
     if !link.is_empty() {
@@ -2078,6 +2150,8 @@ fn cmd_grep(
 
 fn open_existing_index(path: &Path) -> Result<rusqlite::Connection> {
     let repo_root = find_repo_root(path);
+    // Answer against the working tree, not against the last index run.
+    freshness::refresh_and_announce(&repo_root);
     store::open_db(&repo_root, false)?
         .ok_or_else(|| anyhow::anyhow!("Index not found. Run: tokenix index"))
 }
@@ -2192,6 +2266,100 @@ fn cmd_flow(symbol: &str, depth: usize, limit: usize, format_str: &str, path: &P
             graph::format_relations(&relations, &format!("Call flow from `{symbol}`"))
         );
     }
+    Ok(())
+}
+
+fn cmd_export_index(output: Option<&Path>, path: &Path) -> Result<()> {
+    let repo_root = find_repo_root(path);
+    let report = snapshot::export(&repo_root, output)?;
+    println!(
+        "{} snapshot written to {}",
+        "ok".green(),
+        report.output.display()
+    );
+    println!(
+        "  {} files, {} chunks, {} embeddings, model {} — {}",
+        format_num(report.files),
+        format_num(report.chunks),
+        format_num(report.embeddings),
+        report.model,
+        ui::format_bytes(report.bytes)
+    );
+    if let Some(head) = report.head {
+        println!("  indexed at {head}");
+    }
+    println!("  Commit it, and teammates run: tokenix import-index");
+    Ok(())
+}
+
+fn cmd_import_index(input: Option<&Path>, force: bool, path: &Path) -> Result<()> {
+    let repo_root = find_repo_root(path);
+    let report = snapshot::import(&repo_root, input, force)?;
+    println!(
+        "{} imported {} → {}",
+        "ok".green(),
+        report.source.display(),
+        report.target.display()
+    );
+    println!(
+        "  {} files, {} chunks, {} embeddings, model {}",
+        format_num(report.files),
+        format_num(report.chunks),
+        format_num(report.embeddings),
+        report.model
+    );
+    if let Some(version) = report.created_by {
+        println!("  written by tokenix {version}");
+    }
+    if report.replaced_newer {
+        println!(
+            "  {} a newer local index was replaced (--force)",
+            "warning:".yellow()
+        );
+    }
+    if let Some(backup) = report.backup {
+        println!("  previous index kept at {}", backup.display());
+    }
+    println!("  Catch up to your checkout with: tokenix index");
+    Ok(())
+}
+
+fn cmd_blast(since: &str, depth: usize, limit: usize, json: bool, path: &Path) -> Result<()> {
+    if limit == 0 {
+        anyhow::bail!("--limit must be >= 1");
+    }
+    let repo_root = find_repo_root(path);
+    let conn = open_existing_index(path)?;
+    let report = blast::analyze(&conn, &repo_root, since, depth, limit)?;
+    if json {
+        println!("{}", serde_json::to_string_pretty(&report)?);
+        return Ok(());
+    }
+    println!("{}", blast::format_report(&report));
+    Ok(())
+}
+
+fn cmd_modules(top: usize, json: bool, path: &Path) -> Result<()> {
+    if top == 0 {
+        anyhow::bail!("--top must be >= 1");
+    }
+    let conn = open_existing_index(path)?;
+    let edges = store::load_all_graph_edges(&conn)?;
+    let found = modules::detect_modules(&edges, top);
+    if json {
+        println!("{}", serde_json::to_string_pretty(&found)?);
+        return Ok(());
+    }
+    if found.is_empty() {
+        println!("No modules found. Run `tokenix index` first, or the graph is too small.");
+        return Ok(());
+    }
+    println!(
+        "# Modules — {} group(s) over {} edges{}",
+        found.len(),
+        edges.len(),
+        modules::format_modules(&found)
+    );
     Ok(())
 }
 
@@ -4210,6 +4378,15 @@ fn cmd_stats(path: &Path) -> Result<()> {
     ui::kv("chunks", &stats.chunks.to_string());
     ui::kv("tokens", &format_num(stats.total_tokens));
     ui::kv("age", &age_str);
+    // Files an inline refresh (or `--no-embed`) wrote as text only. They are
+    // searchable now; the next `tokenix index` gives them vectors back.
+    let pending = store::pending_embed_files(&conn);
+    if pending > 0 {
+        ui::kv(
+            "pending embed",
+            &format!("{pending} file(s) — run `tokenix index`"),
+        );
+    }
     println!();
     Ok(())
 }

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -597,6 +597,23 @@ fn handle_tool_call(name: &str, args: Value) -> Result<String> {
     let path = Path::new(".");
     let repo_root = find_repo_root(path);
 
+    // An MCP session outlives many edits by the agent that is calling it, so a
+    // retrieval tool has to reconcile the working tree before it answers.
+    // Non-retrieval tools (memory, gain, run) never touch the index.
+    if matches!(
+        name,
+        "tokenix_query"
+            | "tokenix_context"
+            | "tokenix_explore"
+            | "tokenix_read"
+            | "tokenix_symbols"
+            | "tokenix_callers"
+            | "tokenix_callees"
+            | "tokenix_impact"
+    ) {
+        let _ = crate::freshness::refresh_before_query(&repo_root);
+    }
+
     match name {
         "tokenix_search_tools" => {
             let query = args

--- a/src/modules.rs
+++ b/src/modules.rs
@@ -1,0 +1,509 @@
+//! Functional modules discovered from the symbol graph.
+//!
+//! `tokenix graph` already answers "which symbols matter" (god nodes,
+//! bottlenecks, blast radius). It did not answer "what are the parts of this
+//! system", which is the question an agent opening an unfamiliar repo actually
+//! has. Directory layout is a poor proxy: a `utils/` folder is not a subsystem
+//! and a subsystem is regularly spread over several folders.
+//!
+//! This module runs Louvain community detection over the call/reference graph,
+//! so a module is a set of symbols that talk to each other far more than to the
+//! rest of the repo — derived from the code, not from the folder names. It is
+//! deterministic (no randomness, every tie broken on a stable key) so two runs
+//! over the same index produce the same report, and it needs no LLM.
+
+use std::collections::{BTreeMap, HashMap, HashSet};
+
+use crate::store;
+
+/// Communities below this size are graph noise (a helper and its two callers),
+/// not a subsystem worth naming in a report.
+const MIN_MODULE_SYMBOLS: usize = 4;
+/// Louvain passes. Two levels is enough to grow file-sized communities into
+/// subsystem-sized ones; more only merges everything into one blob.
+const MAX_LEVELS: usize = 2;
+/// Local-moving sweeps per level.
+const MAX_SWEEPS: usize = 12;
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct Module {
+    /// Dominant location of the members — a directory, or a file when one file
+    /// holds most of the module.
+    pub label: String,
+    pub symbols: usize,
+    /// Edges with both endpoints inside the module.
+    pub internal_edges: usize,
+    /// Edges crossing the module boundary in either direction.
+    pub external_edges: usize,
+    /// `internal / (internal + external)` — 1.0 is a self-contained module.
+    pub cohesion: f32,
+    /// Highest-degree members, the symbols to read first.
+    pub key_symbols: Vec<String>,
+    /// Files the module spans, most members first.
+    pub files: Vec<String>,
+}
+
+/// Strip the `:line` suffix `store::GraphEdgeRow` carries on each endpoint.
+fn file_of(loc: &str) -> &str {
+    loc.rsplit_once(':').map(|(p, _)| p).unwrap_or(loc)
+}
+
+fn dir_of(path: &str) -> &str {
+    path.rsplit_once('/').map(|(d, _)| d).unwrap_or(path)
+}
+
+/// Undirected weighted view of the directed symbol graph: two symbols that call
+/// each other in both directions are simply strongly connected.
+struct Weighted {
+    adj: Vec<Vec<(usize, f64)>>,
+    self_loops: Vec<f64>,
+    /// Sum of incident weights per node (self-loops counted twice).
+    degree: Vec<f64>,
+    /// 2m — the total weight of the graph, doubled.
+    total: f64,
+}
+
+impl Weighted {
+    fn from_pairs(n: usize, pairs: &BTreeMap<(usize, usize), f64>) -> Self {
+        let mut adj = vec![Vec::new(); n];
+        let mut self_loops = vec![0.0; n];
+        let mut degree = vec![0.0; n];
+        let mut total = 0.0;
+        for (&(a, b), &w) in pairs {
+            if a == b {
+                self_loops[a] += w;
+                degree[a] += 2.0 * w;
+                total += 2.0 * w;
+            } else {
+                adj[a].push((b, w));
+                adj[b].push((a, w));
+                degree[a] += w;
+                degree[b] += w;
+                total += 2.0 * w;
+            }
+        }
+        Weighted {
+            adj,
+            self_loops,
+            degree,
+            total,
+        }
+    }
+}
+
+/// One Louvain level: move nodes between communities while modularity improves.
+/// Returns the community id of every node (not renumbered).
+fn local_moving(g: &Weighted) -> Vec<usize> {
+    let n = g.adj.len();
+    let mut comm: Vec<usize> = (0..n).collect();
+    let mut tot: Vec<f64> = g.degree.clone();
+    if g.total <= 0.0 {
+        return comm;
+    }
+
+    for _ in 0..MAX_SWEEPS {
+        let mut moved = false;
+        for i in 0..n {
+            let ci = comm[i];
+            // Weight from `i` to each neighbouring community. BTreeMap keeps the
+            // scan order stable, so equal gains always resolve the same way.
+            let mut links: BTreeMap<usize, f64> = BTreeMap::new();
+            for &(j, w) in &g.adj[i] {
+                *links.entry(comm[j]).or_insert(0.0) += w;
+            }
+
+            tot[ci] -= g.degree[i];
+            let ki = g.degree[i];
+            let mut best = ci;
+            let mut best_gain = links.get(&ci).copied().unwrap_or(0.0) - tot[ci] * ki / g.total;
+            for (&c, &w) in &links {
+                if c == ci {
+                    continue;
+                }
+                let gain = w - tot[c] * ki / g.total;
+                if gain > best_gain + 1e-12 {
+                    best_gain = gain;
+                    best = c;
+                }
+            }
+            tot[best] += ki;
+            if best != ci {
+                comm[i] = best;
+                moved = true;
+            }
+        }
+        if !moved {
+            break;
+        }
+    }
+    comm
+}
+
+/// Collapse each community into a single node, preserving edge weights, so the
+/// next level can merge communities into larger ones.
+fn aggregate(g: &Weighted, comm: &[usize]) -> (Weighted, Vec<usize>) {
+    let mut renumber: BTreeMap<usize, usize> = BTreeMap::new();
+    for &c in comm {
+        let next = renumber.len();
+        renumber.entry(c).or_insert(next);
+    }
+    let mapped: Vec<usize> = comm.iter().map(|c| renumber[c]).collect();
+    let n = renumber.len();
+
+    let mut pairs: BTreeMap<(usize, usize), f64> = BTreeMap::new();
+    for (i, neighbours) in g.adj.iter().enumerate() {
+        for &(j, w) in neighbours {
+            if i > j {
+                continue; // each undirected edge once
+            }
+            let (a, b) = (mapped[i], mapped[j]);
+            let key = if a <= b { (a, b) } else { (b, a) };
+            *pairs.entry(key).or_insert(0.0) += w;
+        }
+    }
+    for (i, &loop_w) in g.self_loops.iter().enumerate() {
+        if loop_w > 0.0 {
+            let a = mapped[i];
+            *pairs.entry((a, a)).or_insert(0.0) += loop_w;
+        }
+    }
+
+    (Weighted::from_pairs(n, &pairs), mapped)
+}
+
+/// Name a module after where its members live.
+///
+/// Order matters: one dominant file is the clearest name, a shared *nested*
+/// directory is the next best, and otherwise the top files are joined. Plain
+/// `src/` is refused as a label — in a flat repo every module shares it, and a
+/// report where five entries are all called `src/` names nothing.
+fn label_for(files: &[(&str, usize)], dirs: &[(&str, usize)], members: usize) -> String {
+    if let Some((file, count)) = files.first() {
+        if count * 10 >= members * 6 {
+            return (*file).to_string();
+        }
+    }
+    if let Some((dir, count)) = dirs.first() {
+        let nested = dir.contains('/');
+        if nested && count * 10 >= members * 8 {
+            return format!("{dir}/");
+        }
+    }
+    let joined: Vec<&str> = files
+        .iter()
+        .take(3)
+        .map(|(f, _)| f.rsplit_once('/').map(|(_, n)| n).unwrap_or(f))
+        .collect();
+    if joined.is_empty() {
+        return "(unknown)".to_string();
+    }
+    let mut label = joined.join(" + ");
+    if files.len() > 3 {
+        label.push_str(&format!(" +{}", files.len() - 3));
+    }
+    label
+}
+
+/// Group the symbol graph into functional modules, largest first.
+pub fn detect_modules(edges: &[store::GraphEdgeRow], max_modules: usize) -> Vec<Module> {
+    if edges.is_empty() || max_modules == 0 {
+        return Vec::new();
+    }
+
+    // Stable node numbering: sort the raw chunk ids so the whole pipeline is
+    // reproducible regardless of row order coming out of SQLite.
+    let mut ids: Vec<i64> = edges
+        .iter()
+        .flat_map(|(cid, _, _, eid, _, _)| [*cid, *eid])
+        .collect();
+    ids.sort_unstable();
+    ids.dedup();
+    let index: HashMap<i64, usize> = ids.iter().enumerate().map(|(i, id)| (*id, i)).collect();
+    let mut names: Vec<(String, String)> = vec![(String::new(), String::new()); ids.len()];
+
+    let mut pairs: BTreeMap<(usize, usize), f64> = BTreeMap::new();
+    let mut degree: Vec<usize> = vec![0; ids.len()];
+    for (cid, cname, cloc, eid, ename, eloc) in edges {
+        let a = index[cid];
+        let b = index[eid];
+        if names[a].0.is_empty() {
+            names[a] = (cname.clone(), file_of(cloc).to_string());
+        }
+        if names[b].0.is_empty() {
+            names[b] = (ename.clone(), file_of(eloc).to_string());
+        }
+        degree[a] += 1;
+        degree[b] += 1;
+        let key = if a <= b { (a, b) } else { (b, a) };
+        *pairs.entry(key).or_insert(0.0) += 1.0;
+    }
+
+    let mut graph = Weighted::from_pairs(ids.len(), &pairs);
+    let mut membership: Vec<usize> = (0..ids.len()).collect();
+    for level in 0..MAX_LEVELS {
+        let comm = local_moving(&graph);
+        let distinct: HashSet<usize> = comm.iter().copied().collect();
+        let (next, mapped) = aggregate(&graph, &comm);
+        membership = membership.iter().map(|c| mapped[*c]).collect();
+        // Nothing merged at this level, so another one cannot help either.
+        if distinct.len() == graph.adj.len() || level + 1 == MAX_LEVELS {
+            break;
+        }
+        graph = next;
+    }
+
+    // Gather members per community.
+    let mut members: BTreeMap<usize, Vec<usize>> = BTreeMap::new();
+    for (node, comm) in membership.iter().enumerate() {
+        members.entry(*comm).or_default().push(node);
+    }
+
+    // Edge accounting is done on the original directed edges so the numbers
+    // match what `tokenix graph` reports elsewhere.
+    let mut internal: HashMap<usize, usize> = HashMap::new();
+    let mut external: HashMap<usize, usize> = HashMap::new();
+    for (cid, _, _, eid, _, _) in edges {
+        let a = membership[index[cid]];
+        let b = membership[index[eid]];
+        if a == b {
+            *internal.entry(a).or_default() += 1;
+        } else {
+            *external.entry(a).or_default() += 1;
+            *external.entry(b).or_default() += 1;
+        }
+    }
+
+    let mut modules: Vec<Module> = members
+        .into_iter()
+        .filter(|(_, nodes)| nodes.len() >= MIN_MODULE_SYMBOLS)
+        .map(|(comm, nodes)| {
+            let mut file_counts: BTreeMap<&str, usize> = BTreeMap::new();
+            let mut dir_counts: BTreeMap<&str, usize> = BTreeMap::new();
+            for &node in &nodes {
+                let path = names[node].1.as_str();
+                if path.is_empty() {
+                    continue;
+                }
+                *file_counts.entry(path).or_default() += 1;
+                *dir_counts.entry(dir_of(path)).or_default() += 1;
+            }
+
+            let mut files: Vec<(&str, usize)> = file_counts.into_iter().collect();
+            files.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(b.0)));
+            let mut dirs: Vec<(&str, usize)> = dir_counts.into_iter().collect();
+            dirs.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(b.0)));
+
+            let label = label_for(&files, &dirs, nodes.len());
+
+            let mut key: Vec<usize> = nodes.clone();
+            key.sort_by(|a, b| {
+                degree[*b]
+                    .cmp(&degree[*a])
+                    .then_with(|| names[*a].0.cmp(&names[*b].0))
+            });
+            let mut seen_names: HashSet<&str> = HashSet::new();
+            let key_symbols: Vec<String> = key
+                .iter()
+                .map(|n| names[*n].0.as_str())
+                // `<module>` and friends are synthetic file-level nodes, not
+                // symbols a reader can open. The same name also appears once per
+                // file that declares it, and a list reading "Agent, Agent, Agent"
+                // tells the reader nothing.
+                .filter(|n| n.len() > 2 && !n.starts_with('<') && seen_names.insert(n))
+                .map(|n| n.to_string())
+                .take(6)
+                .collect();
+
+            let internal_edges = internal.get(&comm).copied().unwrap_or(0);
+            let external_edges = external.get(&comm).copied().unwrap_or(0);
+            let denom = (internal_edges + external_edges).max(1) as f32;
+            Module {
+                label,
+                symbols: nodes.len(),
+                internal_edges,
+                external_edges,
+                cohesion: internal_edges as f32 / denom,
+                key_symbols,
+                files: files
+                    .iter()
+                    .take(5)
+                    .map(|(f, _)| (*f).to_string())
+                    .collect(),
+            }
+        })
+        .collect();
+
+    modules.sort_by(|a, b| {
+        b.symbols
+            .cmp(&a.symbols)
+            .then_with(|| a.label.cmp(&b.label))
+    });
+    modules.truncate(max_modules);
+    modules
+}
+
+pub fn format_modules(modules: &[Module]) -> String {
+    if modules.is_empty() {
+        return String::new();
+    }
+    let mut out = String::from("\n## Modules (symbols that mostly talk to each other)\n");
+    for m in modules {
+        out.push_str(&format!(
+            "- {} — {} symbols, cohesion {:.0}% ({} internal / {} crossing)\n",
+            m.label,
+            m.symbols,
+            m.cohesion * 100.0,
+            m.internal_edges,
+            m.external_edges
+        ));
+        if !m.key_symbols.is_empty() {
+            out.push_str(&format!("    key: {}\n", m.key_symbols.join(", ")));
+        }
+        if m.files.len() > 1 {
+            out.push_str(&format!("    files: {}\n", m.files.join(", ")));
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn edge(a: i64, an: &str, ap: &str, b: i64, bn: &str, bp: &str) -> store::GraphEdgeRow {
+        (
+            a,
+            an.to_string(),
+            format!("{ap}:1"),
+            b,
+            bn.to_string(),
+            format!("{bp}:1"),
+        )
+    }
+
+    /// Two cliques joined by a single edge must come back as two modules.
+    fn two_cluster_graph() -> Vec<store::GraphEdgeRow> {
+        let mut edges = Vec::new();
+        let auth = [
+            (1, "login"),
+            (2, "verify_token"),
+            (3, "hash_password"),
+            (4, "session_new"),
+            (5, "logout"),
+        ];
+        let billing = [
+            (11, "charge"),
+            (12, "refund"),
+            (13, "invoice_pdf"),
+            (14, "tax_for"),
+            (15, "ledger_write"),
+        ];
+        for (i, (ida, na)) in auth.iter().enumerate() {
+            for (idb, nb) in auth.iter().skip(i + 1) {
+                edges.push(edge(*ida, na, "src/auth.rs", *idb, nb, "src/auth.rs"));
+            }
+        }
+        for (i, (ida, na)) in billing.iter().enumerate() {
+            for (idb, nb) in billing.iter().skip(i + 1) {
+                edges.push(edge(*ida, na, "src/billing.rs", *idb, nb, "src/billing.rs"));
+            }
+        }
+        // The single bridge between the two subsystems.
+        edges.push(edge(
+            1,
+            "login",
+            "src/auth.rs",
+            11,
+            "charge",
+            "src/billing.rs",
+        ));
+        edges
+    }
+
+    #[test]
+    fn separates_two_communities() {
+        let modules = detect_modules(&two_cluster_graph(), 10);
+        assert_eq!(
+            modules.len(),
+            2,
+            "expected one module per clique: {modules:?}"
+        );
+        let labels: Vec<&str> = modules.iter().map(|m| m.label.as_str()).collect();
+        assert!(labels.contains(&"src/auth.rs"), "labels: {labels:?}");
+        assert!(labels.contains(&"src/billing.rs"), "labels: {labels:?}");
+        for m in &modules {
+            assert!(
+                m.cohesion > 0.8,
+                "a clique joined by one bridge is cohesive: {m:?}"
+            );
+            assert_eq!(m.symbols, 5);
+        }
+    }
+
+    #[test]
+    fn is_deterministic_across_row_order() {
+        let mut edges = two_cluster_graph();
+        let first = detect_modules(&edges, 10);
+        edges.reverse();
+        let second = detect_modules(&edges, 10);
+        let names = |ms: &[Module]| -> Vec<(String, usize)> {
+            ms.iter().map(|m| (m.label.clone(), m.symbols)).collect()
+        };
+        assert_eq!(names(&first), names(&second));
+    }
+
+    #[test]
+    fn flat_repos_get_a_file_list_label_not_a_bare_src() {
+        // Members spread evenly over top-level files of one flat folder: `src/`
+        // would be true of every module in the repo, so it is not a name.
+        let files = [
+            ("src/a.rs", 3),
+            ("src/b.rs", 2),
+            ("src/c.rs", 2),
+            ("src/d.rs", 1),
+        ];
+        let dirs = [("src", 8)];
+        assert_eq!(label_for(&files, &dirs, 8), "a.rs + b.rs + c.rs +1");
+
+        // One file carrying 60% of the module still wins.
+        let dominant = [("src/store.rs", 6), ("src/a.rs", 4)];
+        assert_eq!(label_for(&dominant, &dirs, 10), "src/store.rs");
+    }
+
+    #[test]
+    fn empty_graph_yields_no_modules() {
+        assert!(detect_modules(&[], 10).is_empty());
+        assert_eq!(format_modules(&[]), "");
+    }
+
+    #[test]
+    fn tiny_clusters_are_not_reported() {
+        // A helper called by two symbols is not a subsystem.
+        let edges = vec![
+            edge(1, "helper", "src/u.rs", 2, "caller_a", "src/a.rs"),
+            edge(1, "helper", "src/u.rs", 3, "caller_b", "src/b.rs"),
+        ];
+        assert!(detect_modules(&edges, 10).is_empty());
+    }
+
+    #[test]
+    fn label_falls_back_to_the_shared_directory() {
+        // Members spread over several files in one folder: the folder names it.
+        let mut edges = Vec::new();
+        let members = [
+            (1, "a_one", "src/http/get.rs"),
+            (2, "a_two", "src/http/post.rs"),
+            (3, "a_three", "src/http/head.rs"),
+            (4, "a_four", "src/http/route.rs"),
+            (5, "a_five", "src/http/serve.rs"),
+        ];
+        for (i, (ida, na, pa)) in members.iter().enumerate() {
+            for (idb, nb, pb) in members.iter().skip(i + 1) {
+                edges.push(edge(*ida, na, pa, *idb, nb, pb));
+            }
+        }
+        let modules = detect_modules(&edges, 10);
+        assert_eq!(modules.len(), 1);
+        assert_eq!(modules[0].label, "src/http/");
+    }
+}

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -1,0 +1,401 @@
+//! Shareable index snapshots.
+//!
+//! Indexing is the one expensive thing tokenix does, and today every developer
+//! on a team pays it in full on a repo where the answer is identical for all of
+//! them. A snapshot is the index itself — compacted, stripped of the local
+//! embedding cache, gzipped — small enough to commit next to the code, so the
+//! second person onward bootstraps in seconds and only indexes the diff.
+//!
+//! Two rules keep this honest:
+//! * A snapshot never overwrites a *newer* local index without `--force`.
+//! * Import stamps nothing: the snapshot's own `git_fingerprint` travels with
+//!   it, so `index_staleness` immediately reports the gap between the snapshot's
+//!   commit and the local checkout, and `tokenix index` closes it incrementally.
+
+use std::fs::File;
+use std::io::{BufReader, BufWriter};
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use flate2::read::GzDecoder;
+use flate2::write::GzEncoder;
+use flate2::Compression;
+use rusqlite::Connection;
+
+use crate::store;
+
+/// Where a team snapshot lives by default: inside the repo, next to the code it
+/// describes, so it can be committed and reviewed like any other artifact.
+pub const DEFAULT_SNAPSHOT_REL: &str = ".tokenix/index.db.gz";
+
+pub struct ExportReport {
+    pub output: PathBuf,
+    pub bytes: u64,
+    pub files: i64,
+    pub chunks: i64,
+    pub embeddings: i64,
+    pub model: String,
+    pub head: Option<String>,
+}
+
+#[derive(Debug)]
+pub struct ImportReport {
+    pub source: PathBuf,
+    pub target: PathBuf,
+    pub backup: Option<PathBuf>,
+    pub files: i64,
+    pub chunks: i64,
+    pub embeddings: i64,
+    pub model: String,
+    pub created_by: Option<String>,
+    pub replaced_newer: bool,
+}
+
+fn sql_literal(path: &Path) -> String {
+    format!("'{}'", path.to_string_lossy().replace('\'', "''"))
+}
+
+fn counts(conn: &Connection) -> (i64, i64, i64) {
+    let one = |sql: &str| conn.query_row(sql, [], |r| r.get::<_, i64>(0)).unwrap_or(0);
+    (
+        one("SELECT COUNT(*) FROM files"),
+        one("SELECT COUNT(*) FROM chunks"),
+        one("SELECT COUNT(*) FROM embeddings"),
+    )
+}
+
+fn indexed_at(conn: &Connection) -> f64 {
+    store::meta_value(conn, "indexed_at")
+        .and_then(|v| v.parse::<f64>().ok())
+        .unwrap_or(0.0)
+}
+
+/// Write a compressed, self-contained copy of this repo's index.
+pub fn export(repo_root: &Path, output: Option<&Path>) -> Result<ExportReport> {
+    let source = store::db_path(repo_root);
+    if !source.exists() {
+        anyhow::bail!("no index for this repo yet. Run `tokenix index` first.");
+    }
+    let output = output
+        .map(|p| p.to_path_buf())
+        .unwrap_or_else(|| repo_root.join(DEFAULT_SNAPSHOT_REL));
+    if let Some(parent) = output.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("cannot create {}", parent.display()))?;
+    }
+
+    // VACUUM INTO gives a compact, WAL-free copy without blocking on the live DB
+    // being mid-write, and it refuses to overwrite, so clear any stale temp.
+    let staging = output.with_extension(format!("staging-{}", std::process::id()));
+    let _ = std::fs::remove_file(&staging);
+
+    let (files, chunks, embeddings, model, head) = {
+        let conn = Connection::open(&source)
+            .with_context(|| format!("cannot open index at {}", source.display()))?;
+        conn.execute_batch(&format!("VACUUM INTO {}", sql_literal(&staging)))
+            .context("failed to snapshot the index (VACUUM INTO)")?;
+
+        let staged = Connection::open(&staging)?;
+        // The embedding cache is a local accelerator keyed by content hash; it
+        // roughly doubles the file and the recipient rebuilds it as they index.
+        staged.execute_batch("DELETE FROM embedding_cache;")?;
+        store::set_meta(&staged, "snapshot_version", crate::VERSION)?;
+        store::set_meta(
+            &staged,
+            "snapshot_created_at",
+            &chrono::Utc::now().to_rfc3339(),
+        )?;
+        // VACUUM again so the deleted cache pages actually leave the file.
+        staged.execute_batch("VACUUM;")?;
+
+        let (files, chunks, embeddings) = counts(&staged);
+        let model = store::meta_value(&staged, "embed_model")
+            .unwrap_or_else(|| crate::embed::DEFAULT_MODEL_ID.to_string());
+        let head = store::meta_value(&staged, "git_fingerprint");
+        (files, chunks, embeddings, model, head)
+    };
+
+    let mut reader = BufReader::new(File::open(&staging)?);
+    let out_file = File::create(&output)
+        .with_context(|| format!("cannot write snapshot to {}", output.display()))?;
+    let mut encoder = GzEncoder::new(BufWriter::new(out_file), Compression::default());
+    std::io::copy(&mut reader, &mut encoder)?;
+    encoder.finish()?.into_inner()?.sync_all()?;
+    let _ = std::fs::remove_file(&staging);
+
+    let bytes = std::fs::metadata(&output).map(|m| m.len()).unwrap_or(0);
+    Ok(ExportReport {
+        output,
+        bytes,
+        files,
+        chunks,
+        embeddings,
+        model,
+        head,
+    })
+}
+
+/// Restore a snapshot as this repo's index.
+pub fn import(repo_root: &Path, input: Option<&Path>, force: bool) -> Result<ImportReport> {
+    let source = input
+        .map(|p| p.to_path_buf())
+        .unwrap_or_else(|| repo_root.join(DEFAULT_SNAPSHOT_REL));
+    if !source.exists() {
+        anyhow::bail!("snapshot not found: {}", source.display());
+    }
+
+    let target = store::db_path(repo_root);
+    if let Some(parent) = target.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let staging = target.with_extension(format!("import-{}", std::process::id()));
+    let _ = std::fs::remove_file(&staging);
+
+    {
+        let mut decoder = GzDecoder::new(BufReader::new(File::open(&source)?));
+        let mut out = BufWriter::new(File::create(&staging)?);
+        std::io::copy(&mut decoder, &mut out)
+            .with_context(|| format!("{} is not a valid gzip snapshot", source.display()))?;
+    }
+
+    let (files, chunks, embeddings, model, created_by, snapshot_at) = {
+        let staged = Connection::open(&staging)
+            .with_context(|| format!("{} is not a readable index", source.display()))?;
+        // Reject anything that is not actually a tokenix index before it can
+        // replace a working one.
+        let ok: i64 = staged
+            .query_row(
+                "SELECT COUNT(*) FROM sqlite_master WHERE type='table'
+                   AND name IN ('files','chunks','embeddings','meta','graph_nodes')",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap_or(0);
+        if ok < 5 {
+            let _ = std::fs::remove_file(&staging);
+            anyhow::bail!(
+                "{} does not look like a tokenix index (missing core tables)",
+                source.display()
+            );
+        }
+        // Bring a snapshot from an older tokenix up to the current schema.
+        store::init_schema(&staged, 768)?;
+        let (files, chunks, embeddings) = counts(&staged);
+        if chunks == 0 {
+            let _ = std::fs::remove_file(&staging);
+            anyhow::bail!(
+                "{} holds no chunks — refusing to import an empty index",
+                source.display()
+            );
+        }
+        (
+            files,
+            chunks,
+            embeddings,
+            store::meta_value(&staged, "embed_model")
+                .unwrap_or_else(|| crate::embed::DEFAULT_MODEL_ID.to_string()),
+            store::meta_value(&staged, "snapshot_version"),
+            indexed_at(&staged),
+        )
+    };
+
+    // Never silently discard a local index that is newer than the snapshot.
+    let mut replaced_newer = false;
+    if target.exists() {
+        let local_at = Connection::open(&target)
+            .ok()
+            .map(|c| indexed_at(&c))
+            .unwrap_or(0.0);
+        if local_at > snapshot_at {
+            if !force {
+                let _ = std::fs::remove_file(&staging);
+                anyhow::bail!(
+                    "the local index is newer than {} — pass --force to replace it anyway",
+                    source.display()
+                );
+            }
+            replaced_newer = true;
+        }
+    }
+
+    let backup = if target.exists() {
+        let backup = target.with_extension("pre-import.bak");
+        let _ = std::fs::remove_file(&backup);
+        std::fs::rename(&target, &backup).with_context(|| {
+            format!(
+                "cannot move the existing index aside to {}",
+                backup.display()
+            )
+        })?;
+        Some(backup)
+    } else {
+        None
+    };
+    // A WAL/SHM pair left from the replaced database would be applied on top of
+    // the imported file and corrupt it.
+    for suffix in ["-wal", "-shm"] {
+        let mut sidecar = target.clone().into_os_string();
+        sidecar.push(suffix);
+        let _ = std::fs::remove_file(PathBuf::from(sidecar));
+    }
+    std::fs::rename(&staging, &target).context("cannot move the imported index into place")?;
+
+    Ok(ImportReport {
+        source,
+        target,
+        backup,
+        files,
+        chunks,
+        embeddings,
+        model,
+        created_by,
+        replaced_newer,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn temp_repo(tag: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "tokenix_snapshot_{tag}_{}_{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    /// Build a minimal but real index database at `path`.
+    fn seed_index(path: &Path, chunk_body: &str, indexed_at_value: f64) {
+        let conn = Connection::open(path).unwrap();
+        store::init_schema(&conn, 768).unwrap();
+        conn.execute(
+            "INSERT INTO files(id,path,mtime,content_hash) VALUES(1,'src/a.rs',1.0,'h')",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO chunks(id,file_id,path,start_line,end_line,symbol,kind,content,token_count)
+             VALUES(1,1,'src/a.rs',1,5,'alpha','function',?1,10)",
+            [chunk_body],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO embedding_cache(content_hash,embedding,updated_at) VALUES('x',?1,1.0)",
+            [vec![0u8; 4096]],
+        )
+        .unwrap();
+        store::set_meta(&conn, "embed_model", "nomic-v1.5").unwrap();
+        store::set_meta(&conn, "indexed_at", &indexed_at_value.to_string()).unwrap();
+    }
+
+    #[test]
+    fn export_then_import_round_trips_the_index() {
+        let dir = temp_repo("roundtrip");
+        let db = dir.join("index.db");
+        seed_index(&db, "fn alpha() {}", 100.0);
+
+        // Export straight from the seeded database (not via db_path, which is
+        // keyed to the real home directory).
+        let out = dir.join("snap.db.gz");
+        let staging = dir.join("staging.db");
+        {
+            let conn = Connection::open(&db).unwrap();
+            conn.execute_batch(&format!("VACUUM INTO {}", sql_literal(&staging)))
+                .unwrap();
+            let staged = Connection::open(&staging).unwrap();
+            staged
+                .execute_batch("DELETE FROM embedding_cache;")
+                .unwrap();
+            store::set_meta(&staged, "snapshot_version", "test").unwrap();
+        }
+        let mut reader = BufReader::new(File::open(&staging).unwrap());
+        let mut enc = GzEncoder::new(
+            BufWriter::new(File::create(&out).unwrap()),
+            Compression::default(),
+        );
+        std::io::copy(&mut reader, &mut enc).unwrap();
+        enc.finish()
+            .unwrap()
+            .into_inner()
+            .unwrap()
+            .sync_all()
+            .unwrap();
+
+        // Decompress and verify the payload survived intact and cache-free.
+        let restored = dir.join("restored.db");
+        {
+            let mut dec = GzDecoder::new(BufReader::new(File::open(&out).unwrap()));
+            let mut w = BufWriter::new(File::create(&restored).unwrap());
+            std::io::copy(&mut dec, &mut w).unwrap();
+        }
+        let conn = Connection::open(&restored).unwrap();
+        let (files, chunks, _) = counts(&conn);
+        assert_eq!((files, chunks), (1, 1));
+        let cached: i64 = conn
+            .query_row("SELECT COUNT(*) FROM embedding_cache", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(cached, 0, "the local embedding cache must not ship");
+        let body: String = conn
+            .query_row("SELECT content FROM chunks WHERE id=1", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(body, "fn alpha() {}");
+        assert_eq!(
+            store::meta_value(&conn, "embed_model").as_deref(),
+            Some("nomic-v1.5")
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn import_rejects_a_file_that_is_not_an_index() {
+        let dir = temp_repo("garbage");
+        let bogus = dir.join("bogus.db.gz");
+        {
+            let mut enc = GzEncoder::new(
+                BufWriter::new(File::create(&bogus).unwrap()),
+                Compression::default(),
+            );
+            std::io::Write::write_all(&mut enc, b"definitely not sqlite").unwrap();
+            enc.finish().unwrap();
+        }
+        let err = import(&dir, Some(&bogus), false).unwrap_err().to_string();
+        assert!(
+            err.contains("does not look like a tokenix index")
+                || err.contains("not a readable index"),
+            "unexpected error: {err}"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn import_rejects_non_gzip_input() {
+        let dir = temp_repo("plain");
+        let plain = dir.join("plain.db.gz");
+        std::fs::write(&plain, b"not gzip at all").unwrap();
+        assert!(import(&dir, Some(&plain), false).is_err());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn missing_snapshot_is_a_clear_error() {
+        let dir = temp_repo("missing");
+        let err = import(&dir, Some(&dir.join("nope.gz")), false)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("snapshot not found"), "{err}");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn sql_literal_escapes_quotes() {
+        assert_eq!(
+            sql_literal(Path::new("/tmp/it's.db")),
+            "'/tmp/it''s.db'".to_string()
+        );
+    }
+}

--- a/src/store.rs
+++ b/src/store.rs
@@ -349,8 +349,10 @@ pub fn serialize_vec(v: &[f32]) -> Vec<u8> {
 
 pub fn deserialize_vec(bytes: &[u8]) -> Vec<f32> {
     bytes
-        .chunks_exact(4)
-        .map(|b| f32::from_le_bytes(b.try_into().unwrap()))
+        .as_chunks::<4>()
+        .0
+        .iter()
+        .map(|b| f32::from_le_bytes(*b))
         .collect()
 }
 
@@ -796,6 +798,26 @@ pub fn search_graph_nodes_kind(
     Ok(nodes)
 }
 
+/// Every symbol declared in one file, ordered by position. Used to map changed
+/// line ranges back onto symbols (`tokenix blast`).
+pub fn graph_nodes_for_path(conn: &Connection, path: &str) -> Result<Vec<GraphNode>> {
+    let mut stmt = conn.prepare(
+        "SELECT chunk_id,path,name,kind,start_line,end_line
+         FROM graph_nodes WHERE path = ?1 ORDER BY start_line",
+    )?;
+    let rows = stmt.query_map(params![path], |row| {
+        Ok(GraphNode {
+            chunk_id: row.get(0)?,
+            path: row.get(1)?,
+            name: row.get(2)?,
+            kind: row.get(3)?,
+            start_line: row.get::<_, i64>(4)? as usize,
+            end_line: row.get::<_, i64>(5)? as usize,
+        })
+    })?;
+    Ok(rows.filter_map(|r| r.ok()).collect())
+}
+
 /// (chunk_id, name, path) for every graph node — the incremental rebuild's
 /// table-backed resolution map.
 pub fn all_graph_node_names(conn: &Connection) -> Result<Vec<(i64, String, String)>> {
@@ -1084,11 +1106,11 @@ pub fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
 pub fn cosine_similarity_to_bytes(query_vec: &[f32], query_norm: f32, bytes: &[u8]) -> f32 {
     let mut dot = 0.0f32;
     let mut nb = 0.0f32;
-    for (i, chunk) in bytes.chunks_exact(4).enumerate() {
+    for (i, chunk) in bytes.as_chunks::<4>().0.iter().enumerate() {
         if i >= query_vec.len() {
             break;
         }
-        let y = f32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]);
+        let y = f32::from_le_bytes(*chunk);
         dot += query_vec[i] * y;
         nb += y * y;
     }
@@ -1537,6 +1559,31 @@ pub fn get_index_age(repo_root: &Path) -> Option<f64> {
         .ok()?
         .as_secs_f64();
     Some(now - indexed_at)
+}
+
+/// How many indexed files still need embeddings, for callers that only have the
+/// repo root. `0` when there is no index — nothing to backfill.
+///
+/// Deliberately *not* part of [`index_staleness`]: those files are perfectly
+/// usable for text search, the symbol graph and read interception, and reporting
+/// them as stale would make the hook fail open and stop saving tokens. It only
+/// means a full `tokenix index` still has work to do.
+pub fn pending_embed_count(repo_root: &Path) -> i64 {
+    match open_db(repo_root, false) {
+        Ok(Some(conn)) => pending_embed_files(&conn),
+        _ => 0,
+    }
+}
+
+/// Files written by a `--no-embed` run or an inline freshness refresh: their
+/// chunks are searchable as text but carry no vectors yet.
+pub fn pending_embed_files(conn: &Connection) -> i64 {
+    conn.query_row(
+        "SELECT COUNT(*) FROM files WHERE content_hash LIKE ?1",
+        params![format!("{}%", crate::indexer::NO_EMBED_HASH_PREFIX)],
+        |r| r.get(0),
+    )
+    .unwrap_or(0)
 }
 
 pub fn index_staleness(repo_root: &Path) -> IndexStaleness {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -92,6 +92,25 @@ pub fn format_num(n: i64) -> String {
     result.chars().rev().collect()
 }
 
+/// Byte count in the unit a human would use (`1.4 MB`, `812 KB`, `37 B`).
+pub fn format_bytes(bytes: u64) -> String {
+    const KB: f64 = 1024.0;
+    let b = bytes as f64;
+    if b < KB {
+        return format!("{bytes} B");
+    }
+    for (limit, unit) in [
+        (KB * KB, "KB"),
+        (KB * KB * KB, "MB"),
+        (KB * KB * KB * KB, "GB"),
+    ] {
+        if b < limit {
+            return format!("{:.1} {unit}", b / (limit / KB));
+        }
+    }
+    format!("{:.1} TB", b / (KB * KB * KB * KB))
+}
+
 /// Rounded-border aligned table backed by `tabled`. `right` lists the column
 /// indices to right-align (numeric columns); all others stay left. Cell strings
 /// may carry ANSI color — the `ansi` feature measures display width correctly so


### PR DESCRIPTION
## O que muda

Quatro recursos novos + limpeza clippy, tudo no índice/símbolos existente:

- **\	okenix blast\** — diff → símbolos alterados → call graph reverso (profundidade configurável), JSON ou texto. Avalia o raio de impacto antes de mexer.
- **\	okenix modules\** — detecção de comunidades Louvain sobre \graph_edges\; a seção de módulos entra no relatório do repo (\	okenix repo\), orientação derivada do grafo, não do nome das pastas.
- **\	okenix export-index\ / \import-index\** — snapshot gzipado (\VACUUM INTO\ via flate2 rust_backend, sem C zlib) para times compartilharem o índice pronto.
- **\reshness\** — refresh inline de arquivos sujos antes de consultas (\--no-embed\ path); ligado também nas tools de retrieval do MCP, porque uma sessão MCP sobrevive a muitas edições do agente.

## Robustez do indexador

- \estored_files\: arquivo que voltou via \git checkout\/stash/branch switch fica invisível para \git status\ — agora é re-indexado.
- \
e:\ prefix no content_hash marca chunks sem embedding; o backlog é pago na próxima indexação completa (git-incremental não enxerga esses arquivos).
- clippy: \chunks_exact\ → \s_chunks\ em daemon/embed/indexer/store.

## Verificação

- \cargo build --release\ OK (warning benigno linker MSVC)
- \cargo fmt --check\ OK
- \cargo clippy --bin tokenix --all-features\ OK
- \cargo test --bin tokenix\ 437 passed / 0 failed