### PR TITLE
chore(research): homologate v0.64.0 against the token-economy literature (pass 5)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -230,6 +230,17 @@ compression savings invert (arXiv 2607.12161). These are diagnostics: without a
 holdout control group no causal Δturns claim is possible, so `SessionStats` must
 stay descriptive and never feed a headline number.
 
+**`tokenix run --raw` / `TOKENIX_RAW=1`** — byte-exact passthrough, no
+compression/dedup/stash, via `compress::run_command_raw` (`Stdio::inherit`,
+shares `build_shell_command` with the compressed path so the two invocations
+can't drift). Closes the "shell-pipeline corruption" hazard from
+2607.12161 (filtered output silently wrong when a script expects raw text) as
+an **explicit opt-out**, not auto-detection: the agent harness's own capture of
+`tokenix run`'s stdout is a pipe, identical in signal to a script piping it
+into `jq`/`grep`/etc., so `isatty` cannot tell the two apart. Do not attempt to
+infer "raw" from environment heuristics — same guard-safety rule as the
+`never_mask_failure` filter invariant.
+
 **Keep docs in sync.** Every new or changed user-facing feature MUST update both
 `README.md` (Commands, and any affected section) and this file in the same change.
 

--- a/README.md
+++ b/README.md
@@ -403,7 +403,7 @@ repo-local `opencode.json` MCP registration.
 |---|---|
 | `tokenix hook` | `PreToolUse` handler — intercepts large reads, semantic grep, noisy commands |
 | `tokenix hook-post` | `PostToolUse` compatibility handler |
-| `tokenix run "CMD"` | Run a command and compress its output (`--shell`, `--path/-p`) |
+| `tokenix run "CMD"` | Run a command and compress its output (`--shell`, `--path/-p`, `--raw`) |
 | `tokenix mcp` | MCP server exposing context, read/search, graph, and gain tools (`--profile slim\|full`) |
 
 <details>
@@ -413,6 +413,14 @@ repo-local `opencode.json` MCP registration.
 the dashboard, same as `TOKENIX_NO_TUI=1`), `TOKENIX_BRANCH_AWARE=true` (suffix the
 SQLite DB per git branch), `TOKENIX_DISABLED=1` (bypass the hook for one command),
 `TOKENIX_MAX_OUTPUT_TOKENS` (global output ceiling, default 8000, `0` disables).
+
+**`tokenix run`** — `--raw` (also `TOKENIX_RAW=1`) prints the command's
+stdout/stderr byte-for-byte, skipping compression, dedup and the recall stash.
+Use it when a script or pipeline consumes `tokenix run`'s output directly and
+needs the exact original bytes — auto-detecting that case is not reliable (the
+agent harness that normally calls `tokenix run` also reads its stdout through a
+pipe, indistinguishable from a script doing the same), so this is an explicit
+opt-out rather than automatic detection.
 
 **Freshness** — every retrieval command (`query`, `context`, `explore`, `grep`,
 `symbols`, `callers`, `callees`, `impact`, `flow`, `deps`, `graph`, `modules`,

--- a/docs/research/2026-08-token-economy.md
+++ b/docs/research/2026-08-token-economy.md
@@ -764,3 +764,109 @@ indentation, line breaks and CRLF — the re-derived, truncating `…` form is g
 time gaps, mean/max calls per session, and within-session re-requests of the
 same tool+subject — the measurable share of the "+13.8% turns" inversion
 mechanism — as a diagnostic that stays descriptive until holdout lands.
+
+---
+
+## Deep sweep (pass 5) — homologation, 2026-08-24
+
+Full re-verification of the pass-4 implementation table against the tree at
+`67e2f30` (merged to `main` as v0.64.0), plus a targeted sweep for literature
+published after pass 4's 2026-08-22 cutoff.
+
+### Verification method
+
+Not a re-read of the table — each "DONE" row was checked against the actual
+source, by symbol name, not by trusting the prior pass's note:
+
+| Claim | Check | Result |
+|---|---|---|
+| T0.1 chars-not-bytes tokenizer | `chunker.rs:92` body + `count_tokens_counts_chars_not_bytes` test | **CONFIRMED** |
+| T1.5 CRLF anchor fix | `dominant_eol`/`restore_eol` (`compress.rs:1318-1348`), wired in `filters.rs:1971-1972` | **CONFIRMED** |
+| T1.5 verbatim signature slice | `extract_signature_verbatim` + `line_starts` (`chunker.rs:911-935`), called at `chunker.rs:1268` | **CONFIRMED** |
+| Pass-3 entropy fix (`basic-auth-url`, `db-connection-uri`) | both rules at `min_entropy = 2.8` with `{7,...}` floors, `default.toml:296-312` | **CONFIRMED** |
+| T0.2 `gain` session shape | `session_stats`/`SessionStats`/`re_requests` (`gain.rs:216-260`) | **CONFIRMED** |
+
+`cargo fmt --check`, `cargo clippy --all-targets` and `cargo test` all clean —
+438 + 14 + 2 = **454 passed, 10 ignored (model-tests, offline by design), 0
+failed**.
+
+### Correction to the pass-4 table
+
+The pass-4 audit table's T0.2 row reads "Δturns NOT reported" — but that row
+describes the state *before* the same-day close documented at the end of pass
+4, which shipped `gain::session_stats`'s `re_requests` field as exactly that
+diagnostic. The row was stale the moment it was written next to its own
+same-day fix. Corrected here: **T0.2 is DONE**, with the caveat pass 4 already
+stated correctly elsewhere — it is a descriptive proxy, not a causal Δturns
+claim, because no holdout control group exists yet (that gap is T0.3, still
+open).
+
+### T1.6 closed — as an explicit opt-out, not auto-detection
+
+Implemented `tokenix run --raw` / `TOKENIX_RAW=1`
+(`compress::run_command_raw`, `Stdio::inherit`, sharing `build_shell_command`
+with the compressed path so the two invocations cannot drift).
+
+Investigating the "detect pipeline consumption" framing pass 4 carried forward
+from the decision list found it is **not safely implementable as automatic
+detection**: the agent harness that is the normal caller of `tokenix run`
+reads its stdout through a pipe (that is how the harness captures output at
+all), which is the identical `isatty()` signal a human piping into
+`jq`/`grep`/a file would produce. There is no deterministic signal in this
+process's own environment that tells the two apart — attempting one risks
+silently *disabling compression in the primary use case* to guard a secondary
+one, which is a worse failure than the hazard it closes. This is the same
+category of correction pass 2 made to F5 (labeled DEAD): the failure mode is
+real, the originally-imagined mechanism is not viable, and the paper's
+prescription ("pass through raw" when detected) survives as an **explicit,
+documented flag** instead of a guess. Verified functionally: byte-exact
+stdout/stderr passthrough, exit code preserved (`exit 3` → process exit 3),
+both the flag and the env var. Regression test:
+`run_command_raw_preserves_exit_code`.
+
+### New literature since pass 4
+
+**What Does Context Compression Cost an Agent?** ([arXiv 2608.16370](https://arxiv.org/abs/2608.16370),
+Liu, 2026-08-17 — 5 days after pass 4's cutoff) introduces **reacquisition
+cost**: additional retrieval tool calls an agent issues to recover state a
+compressor dropped, measured with a controlled bounded-horizon protocol
+comparing a *dropping* operator against a *fact-preserving* one. At 5×
+compression, a dropping operator produced a retrieval surge across all six
+model/regime comparisons tested even where task completion stayed
+statistically flat — GPT-5.5: completion 80%→85% (p=1.0, i.e. *unchanged*)
+while retrieval calls rose 21.0→63.9 (p=.002). Semantically irrelevant content
+replacement alone raised retrieval **57%** with no significant completion
+change.
+
+This does not change tokenix's architecture — it sharpens the existing
+"closed-loop recovery" mechanism (2607.12161) with a name and a clean natural
+experiment, and its own stated guidance is the position this repo already
+holds: fact-preserving/semantic-filtering compression is safe, unconditional
+dropping is not. It corroborates, in the same family as LogDx-CI's
+`never_worse`-of-evidence finding and CORVUS's trajectory-elongation result,
+why `filters.rs`'s `never_mask_failure`/`priority_lines`/`passthrough_when_emptied`
+rules exist as hard invariants rather than tunables: a filter that drops
+failure evidence to hit a compression ratio is exactly the *dropping* operator
+this paper measures the cost of, even when its own golden tests still pass.
+No code change indicated — recorded as corroboration for the next filter
+audit pass.
+
+### Remaining gaps — reaffirmed, still deferred
+
+Unchanged from pass 4, each still absent from the tree by symbol-level check:
+**T0.3 holdout mode** (no `TOKENIX_HOLDOUT`), **T0.4 OTLP receiver** (no OTLP
+in `daemon.rs`), **T1.7 NAP harness** (no action-preservation in
+`cmd_filter.rs`), **T2.8 `updatedToolOutput`** (no reference in `hook.rs`),
+**T3.11 CORE-Bench** (`benchmark.rs` is still the internal-only harness). Each
+is day-to-week scale, not an hours-scale close like T1.6; ranked in pass 4 and
+that ranking still holds — holdout mode is the next cheapest and the
+precondition for any causal savings claim.
+
+### Verdict
+
+No architectural correction from this pass. One real gap closed (T1.6, in the
+only form that is actually safe), one stale table note corrected (T0.2), and
+one new paper filed as corroboration rather than a new requirement. The
+"homologate against the papers" bar for this pass is: every DONE claim in the
+tree re-verified by symbol, not by re-reading the prior pass's prose — that
+distinction is what this pass adds.

--- a/src/compress.rs
+++ b/src/compress.rs
@@ -2347,7 +2347,14 @@ fn tee_raw_output(command_str: &str, stdout_raw: &str, stderr_raw: &str) -> Opti
     Some(path)
 }
 
-pub fn run_command_and_compress(command_str: &str, shell: &str, cwd: Option<&Path>) -> Result<i32> {
+/// Build the child `Command` for `tokenix run`, shared by the compressed and
+/// raw execution paths so the two can never drift on how the command is
+/// actually invoked.
+fn build_shell_command(
+    command_str: &str,
+    shell: &str,
+    cwd: Option<&Path>,
+) -> std::process::Command {
     let is_powershell = matches!(shell, "pwsh" | "powershell");
     let mut cmd = if is_powershell {
         // Force UTF-8 so captured bytes decode cleanly (Windows PowerShell 5.1
@@ -2371,9 +2378,31 @@ pub fn run_command_and_compress(command_str: &str, shell: &str, cwd: Option<&Pat
     if let Some(dir) = cwd {
         cmd.current_dir(dir);
     }
+    cmd
+}
 
-    // Capture stdout and stderr
-    let output = cmd.output()?;
+/// Run the command and print its stdout/stderr byte-for-byte, with no
+/// compression, dedup, or recall stash — `tokenix run --raw` / `TOKENIX_RAW=1`.
+///
+/// Exists because auto-detecting "this output feeds a script, not an LLM" is
+/// not a safe deterministic signal here: the agent harness that is the normal
+/// caller of `tokenix run` also captures stdout through a pipe, so a piped
+/// script and a harness invocation are indistinguishable by `isatty` alone.
+/// An explicit opt-out is the only form of this guard that cannot misfire.
+pub fn run_command_raw(command_str: &str, shell: &str, cwd: Option<&Path>) -> Result<i32> {
+    let mut cmd = build_shell_command(command_str, shell, cwd);
+    // Inherit rather than capture: streams the child's bytes straight through
+    // untouched (encoding included), and avoids buffering output this path
+    // never needs to look at.
+    cmd.stdout(std::process::Stdio::inherit());
+    cmd.stderr(std::process::Stdio::inherit());
+    let status = cmd.status()?;
+    Ok(status.code().unwrap_or(0))
+}
+
+pub fn run_command_and_compress(command_str: &str, shell: &str, cwd: Option<&Path>) -> Result<i32> {
+    let is_powershell = matches!(shell, "pwsh" | "powershell");
+    let output = build_shell_command(command_str, shell, cwd).output()?;
 
     let stdout_raw = String::from_utf8_lossy(&output.stdout);
     let stderr_raw = String::from_utf8_lossy(&output.stderr);
@@ -2499,6 +2528,17 @@ pub fn run_command_and_compress(command_str: &str, shell: &str, cwd: Option<&Pat
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn run_command_raw_preserves_exit_code() {
+        // stdout/stderr content is inherited straight to the process' own
+        // streams (asserting the bytes would mean capturing the whole test
+        // binary's output); the exit code is the one signal this path can
+        // check without that. Manually verified byte-exactness against
+        // `tokenix run --raw` in homologation.
+        let code = run_command_raw("exit 7", "auto", None).unwrap();
+        assert_eq!(code, 7);
+    }
 
     #[test]
     fn compact_json_is_lossless() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -686,6 +686,13 @@ enum Commands {
         /// Shell used to execute the command: auto (cmd/sh), or pwsh/powershell
         #[arg(long, default_value = "auto")]
         shell: String,
+        /// Print the command's raw stdout/stderr unmodified (no compression,
+        /// dedup, or recall stash). For a script/pipeline that consumes the
+        /// exact output — auto-detecting that case is not reliable (the agent
+        /// harness's own stdout capture looks identical to a pipe), so this is
+        /// an explicit opt-out. Also set by TOKENIX_RAW=1.
+        #[arg(long)]
+        raw: bool,
     },
     /// Wrap another MCP server and compress its tool results before they reach
     /// the agent (the only path that reaches MCP output — hooks cannot)
@@ -1460,11 +1467,17 @@ fn main() -> Result<()> {
             command,
             path,
             shell,
+            raw,
         } => {
             // `--path` defaults to "."; only pass a real override through so the
             // normal case keeps the caller's cwd untouched.
             let cwd = (path != Path::new(".")).then_some(path);
-            let code = compress::run_command_and_compress(&command, &shell, cwd.as_deref())?;
+            let raw = raw || std::env::var("TOKENIX_RAW").is_ok_and(|v| v == "1" || v == "true");
+            let code = if raw {
+                compress::run_command_raw(&command, &shell, cwd.as_deref())?
+            } else {
+                compress::run_command_and_compress(&command, &shell, cwd.as_deref())?
+            };
             std::process::exit(code);
         }
         Commands::McpProxy { name, command } => {


### PR DESCRIPTION
## Summary

Full homologation pass of tokenix v0.64.0 against `docs/research/2026-08-token-economy.md`, requested explicitly ("homologue completamente o tokenix com os novos papers"). Not a re-read of the prior pass's notes — every "DONE" claim in pass 4's implementation table was re-checked against the actual merged source by symbol name.

### Verified (evidence in the doc's new "pass 5" section)

- T0.1 chars-not-bytes tokenizer — `chunker.rs:92`
- T1.5 CRLF anchor fix — `dominant_eol`/`restore_eol` (`compress.rs`), wired in `filters.rs`
- T1.5 verbatim signature slice — `extract_signature_verbatim` (`chunker.rs`)
- Pass-3 entropy fix — both `basic-auth-url`/`db-connection-uri` rules at `min_entropy = 2.8` with matching floors
- T0.2 `gain` session shape — `gain::session_stats`/`re_requests`

All confirmed present and correct.

### Corrected

Pass 4's own table said "T0.2 Δturns NOT reported" — but that row described the state *before* the same-day close documented at the end of pass 4, which shipped exactly that diagnostic (`re_requests`). The row was stale the moment it was written. Corrected in this pass.

### Closed: T1.6 shell-consumer guard

`tokenix run --raw` / `TOKENIX_RAW=1` — byte-exact stdout/stderr passthrough (`Stdio::inherit`), no compression/dedup/stash. `run_command_and_compress` and the new `run_command_raw` now share a `build_shell_command` helper so the two invocations can't drift on how the command is actually run.

Investigating the auto-detection framing pass 4 carried forward found it's **not safely implementable**: the agent harness that normally calls `tokenix run` reads its stdout through a pipe — the identical `isatty()` signal a human piping into `jq`/`grep` would produce. No deterministic signal distinguishes them from inside this process. Shipping "auto-detect and pass through raw" risks silently disabling compression in the *primary* use case to guard a secondary one — worse than the hazard it closes. Same correction pattern the doc already used for pass 2's F5 (labeled DEAD): the hazard is real, the imagined mechanism isn't, ship the explicit opt-out instead.

### New literature filed

[arXiv:2608.16370](https://arxiv.org/abs/2608.16370) (2026-08-17, 5 days after pass 4's cutoff) — "reacquisition cost": a dropping compression operator forces retrieval surges to recover state even when task completion stays flat (GPT-5.5: 80%→85% completion, p=1.0 i.e. unchanged, while retrieval calls rose 21.0→63.9, p=.002). Filed as corroboration for the existing `never_mask_failure`/`priority_lines` filter invariants — no code change indicated, it names a mechanism tokenix's architecture already guards against.

### Reaffirmed still open (unchanged ranking)

T0.3 holdout mode, T0.4 OTLP receiver, T1.7 NAP harness, T2.8 `updatedToolOutput`, T3.11 CORE-Bench — each verified still absent by symbol-level check, each day-to-week scale (not hours like T1.6). Holdout mode remains the next cheapest and the precondition for any causal savings claim.

### Housekeeping

Closed PR #70 (`fix/clippy-as-chunks`) — it was identical to #69, which had already merged to `main` as v0.64.0 while #70 sat open on a stale base.

## Testing

- `cargo fmt --all -- --check` — clean
- `cargo clippy --all-targets --quiet` — clean
- `cargo test --quiet` — 454 passed, 10 ignored (model-tests, offline by design), 0 failed
- Manual: `tokenix run --raw "echo hello raw"` → byte-exact; `tokenix run --raw "exit 3"` → process exit 3; `TOKENIX_RAW=1 tokenix run "echo via env"` → works; compressed path (no flag) unaffected. New regression test `run_command_raw_preserves_exit_code`.