### PR TITLE
fix: make PostToolUse actually redact and compress for Claude Code

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,7 @@ them weekly and on demand — that is the only place they execute.
 | `blast.rs` | Diff → changed symbols → reverse call graph (`tokenix blast`) |
 | `snapshot.rs` | `export-index` / `import-index` — gzipped `VACUUM INTO` copy for teams |
 | `hook.rs` | `PreToolUse` handler — the interception decision tree |
-| `compress.rs` | Generic output compression, base64 redaction, token ceiling, EOL preservation |
+| `compress.rs` | Generic output compression, base64 redaction, token ceiling, EOL preservation; `run_hook_post` also redacts known secrets on every PostToolUse tool result via `secrets_scan::redact_known_secrets`, then emits `hookSpecificOutput.updatedToolOutput` for Claude Code/Codex |
 | `filters.rs` | `FilterDef` schema, filter resolution, `apply_filter_with_exit` |
 | `cmd_filter.rs` | `filter list/active/generate/verify` + recording |
 | `pack.rs` | `tokenix pack` — budgeted repo map, `order_by_priority` (reason → PageRank → path) |

--- a/README.md
+++ b/README.md
@@ -402,7 +402,7 @@ repo-local `opencode.json` MCP registration.
 | Command | Description |
 |---|---|
 | `tokenix hook` | `PreToolUse` handler — intercepts large reads, semantic grep, noisy commands |
-| `tokenix hook-post` | `PostToolUse` compatibility handler |
+| `tokenix hook-post` | `PostToolUse` handler — redacts secrets and compresses tool output before the model sees it (Claude Code, Codex, Copilot CLI) |
 | `tokenix run "CMD"` | Run a command and compress its output (`--shell`, `--path/-p`, `--raw`) |
 | `tokenix mcp` | MCP server exposing context, read/search, graph, and gain tools (`--profile slim\|full`) |
 

--- a/src/compress.rs
+++ b/src/compress.rs
@@ -2180,70 +2180,100 @@ pub fn run_hook_post() -> Result<()> {
         _ => std::process::exit(0),
     };
 
-    // Non-shell tools (e.g. an MCP image-generation result) are only worth
-    // processing for a dialect that can actually replace the result. Claude/Codex
-    // post is a no-op, so skip the work; Copilot's modifiedResult is honored.
-    let is_shell = POST_HOOK_TOOLS.contains(&input.tool_name.as_str());
-    if !is_shell && input.dialect == PostDialect::ClaudeNoop {
-        std::process::exit(0);
-    }
+    // Redaction runs first and unconditionally — on every tool this hook
+    // fires on, independent of dialect. This is the path that reaches tool
+    // results the PreToolUse Bash rewrite never sees (Read results, MCP
+    // results, ListDirectory, ...). Historically Claude/Codex non-shell
+    // results exited here immediately on the (stale) belief that Claude Code
+    // PostToolUse can never replace a result — as of Claude Code v2.1.121+,
+    // `hookSpecificOutput.updatedToolOutput` is honored for all tools, not
+    // only MCP, so that early exit was silently skipping real redaction.
+    let (redacted, secret_hit) = crate::secrets_scan::redact_known_secrets(&input.text);
 
+    let is_shell = POST_HOOK_TOOLS.contains(&input.tool_name.as_str());
     let compressed = if input.tool_name == "Bash" {
-        compress_bash_output(&input.command, &input.text)
+        compress_bash_output(&input.command, &redacted)
     } else if is_shell {
-        compress_output(&input.text)
+        compress_output(&redacted)
+    } else if input.dialect == PostDialect::ClaudeNoop {
+        // Non-shell, Claude/Codex dialect: no command-oriented compression
+        // heuristics apply — redaction above is the whole job.
+        redacted
     } else {
-        // Non-shell result: skip the command-oriented heuristics, just redact
-        // embedded base64 blobs — the dominant token waste in agent histories.
-        redact_base64_blobs(&input.text)
+        // Non-shell, Copilot dialect: unchanged behavior, redact embedded
+        // base64 blobs — the dominant token waste in agent histories — on
+        // top of the secret redaction already applied.
+        redact_base64_blobs(&redacted)
     };
 
-    if compressed == input.text {
+    let changed = compressed != input.text;
+    if !secret_hit && !changed {
         std::process::exit(0);
     }
 
-    // Claude Code PostToolUse hooks cannot shorten or replace a tool result:
-    // exit 2 surfaces stderr (not stdout) as a blocking error, and the supported
-    // `hookSpecificOutput.additionalContext` only appends next to the original
-    // output. So compressing Bash output here can never reduce the tokens Claude
-    // Code sends to the model. Exit 0 silently to avoid the empty-stderr blocking
-    // error, and do NOT log savings the model never actually receives. Real Bash
-    // compression must move to a PreToolUse command rewrite (run the command
-    // through tokenix before execution, wrapping it as `tokenix run <cmd>`).
-    if input.dialect == PostDialect::ClaudeNoop {
-        std::process::exit(0);
-    }
-
-    // Only Copilot reaches here, and its modifiedResult JSON genuinely replaces
-    // the tool result — so the logged savings are real for this dialect.
     let repo_root = find_repo_root();
     let original_tokens = count_tokens(&input.text) as i64;
     let actual_tokens = count_tokens(&compressed) as i64;
-    let saved = (original_tokens - actual_tokens).max(0);
 
-    let _ = log_hook_event(
-        &repo_root,
-        &HookEvent {
-            ts: now_ts(),
-            tool: input.tool_name,
-            action: "intercepted".to_string(),
-            phase: "post".to_string(),
-            reason: String::new(),
-            saved_tokens: saved,
-            actual_tokens,
-            original_estimate: original_tokens,
-            input_preview: clean.chars().take(200).collect(),
-            command: input.command,
-        },
-    );
+    if secret_hit {
+        let _ = log_hook_event(
+            &repo_root,
+            &HookEvent {
+                ts: now_ts(),
+                tool: input.tool_name.clone(),
+                action: "intercepted".to_string(),
+                phase: "post".to_string(),
+                reason: "secret-redacted".to_string(),
+                saved_tokens: 0,
+                actual_tokens,
+                original_estimate: original_tokens,
+                input_preview: clean.chars().take(200).collect(),
+                command: input.command.clone(),
+            },
+        );
+    }
+    if changed {
+        let _ = log_hook_event(
+            &repo_root,
+            &HookEvent {
+                ts: now_ts(),
+                tool: input.tool_name.clone(),
+                action: "intercepted".to_string(),
+                phase: "post".to_string(),
+                reason: "size-compressed".to_string(),
+                saved_tokens: (original_tokens - actual_tokens).max(0),
+                actual_tokens,
+                original_estimate: original_tokens,
+                input_preview: clean.chars().take(200).collect(),
+                command: input.command.clone(),
+            },
+        );
+    }
 
-    let out = serde_json::json!({
-        "modifiedResult": {
-            "resultType": "success",
-            "textResultForLlm": compressed,
+    match input.dialect {
+        PostDialect::ClaudeNoop => {
+            // As of Claude Code v2.1.121+, updatedToolOutput is honored for
+            // all tools. Fail open on older installs: the field is simply
+            // ignored and the original tool result stands — never a
+            // blocking error, never malformed stdout.
+            let out = serde_json::json!({
+                "hookSpecificOutput": {
+                    "hookEventName": "PostToolUse",
+                    "updatedToolOutput": compressed,
+                }
+            });
+            println!("{}", serde_json::to_string(&out).unwrap_or_default());
         }
-    });
-    println!("{}", serde_json::to_string(&out).unwrap_or_default());
+        PostDialect::CopilotJson => {
+            let out = serde_json::json!({
+                "modifiedResult": {
+                    "resultType": "success",
+                    "textResultForLlm": compressed,
+                }
+            });
+            println!("{}", serde_json::to_string(&out).unwrap_or_default());
+        }
+    }
     std::process::exit(0);
 }
 

--- a/src/secrets_scan.rs
+++ b/src/secrets_scan.rs
@@ -287,6 +287,25 @@ fn scan_content(content: &str, rules: &[Rule]) -> Vec<RawMatch> {
     out
 }
 
+/// Scan arbitrary text for known secrets and mask every occurrence found,
+/// reusing the same compiled rule set and boundary-safe replacer `scan`
+/// already relies on. For callers outside a file-scan context (a PostToolUse
+/// hook, not a filesystem walk) that need to know *whether* a secret was
+/// found, independent of whatever size compression runs afterward. Returns
+/// the redacted text and `true` if anything matched.
+pub(crate) fn redact_known_secrets(text: &str) -> (String, bool) {
+    let rules = load_rules();
+    let matches = scan_content(text, &rules);
+    if matches.is_empty() {
+        return (text.to_string(), false);
+    }
+    let mut out = text.to_string();
+    for m in &matches {
+        out = redact_occurrences(&out, &m.secret);
+    }
+    (out, true)
+}
+
 fn has_text_ext(p: &Path) -> bool {
     p.extension()
         .and_then(|e| e.to_str())
@@ -1142,6 +1161,42 @@ mod tests {
         assert!(rules_hit.contains(&"aws-access-key-id"), "{rules_hit:?}");
         assert!(rules_hit.contains(&"llm-api-key"), "{rules_hit:?}");
         assert!(rules_hit.contains(&"github-token"), "{rules_hit:?}");
+    }
+
+    #[test]
+    fn redact_known_secrets_no_match_returns_unchanged() {
+        let (out, hit) = redact_known_secrets("just a plain log line, nothing sensitive here");
+        assert_eq!(out, "just a plain log line, nothing sensitive here");
+        assert!(!hit);
+    }
+
+    #[test]
+    fn redact_known_secrets_masks_without_full_exposure() {
+        let (out, hit) = redact_known_secrets("aws=AKIAIOSFODNN7EXAMPLE\n");
+        assert!(hit);
+        assert!(
+            !out.contains("AKIAIOSFODNN7EXAMPLE"),
+            "secret survived: {out}"
+        );
+        assert!(out.contains("[REDACTED]"));
+    }
+
+    #[test]
+    fn redact_known_secrets_multiple_matches_in_one_block() {
+        let content = concat!(
+            "aws key: AKIAIOSFODNN7EXAMPLE\n",
+            "github token: ghp_0123456789abcdefghijklmnopqrstuvwxyzAB\n", // gitleaks:allow synthetic test fixture
+        );
+        let (out, hit) = redact_known_secrets(content);
+        assert!(hit);
+        assert!(
+            !out.contains("AKIAIOSFODNN7EXAMPLE"),
+            "aws key survived: {out}"
+        );
+        assert!(
+            !out.contains("ghp_0123456789abcdefghijklmnopqrstuvwxyzAB"),
+            "github token survived: {out}"
+        );
     }
 
     #[test]

--- a/tests/hook_e2e.rs
+++ b/tests/hook_e2e.rs
@@ -272,3 +272,70 @@ fn powershell_disabled_env_passes_through() {
         "bypass must skip rewrite: {stdout}"
     );
 }
+
+/// Run `tokenix hook-post` with `payload` on stdin, same isolation shape as
+/// `run_hook` — the hook writes its event log relative to the repo root it
+/// detects.
+fn run_hook_post(payload: &str) -> (String, i32) {
+    let dir = std::env::temp_dir().join(format!(
+        "tokenix-hook-post-e2e-{}-{:x}",
+        std::process::id(),
+        payload.len()
+    ));
+    std::fs::create_dir_all(&dir).expect("temp cwd");
+    let mut child = Command::new(env!("CARGO_BIN_EXE_tokenix"))
+        .arg("hook-post")
+        .current_dir(&dir)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn tokenix hook-post");
+    child
+        .stdin
+        .as_mut()
+        .expect("stdin")
+        .write_all(payload.as_bytes())
+        .expect("write payload");
+    let out = child.wait_with_output().expect("hook-post exit");
+    (
+        String::from_utf8_lossy(&out.stdout).into_owned(),
+        out.status.code().unwrap_or(-1),
+    )
+}
+
+/// Regression for the PostToolUse `updatedToolOutput` fix (issue #73): a
+/// non-Bash, non-ListDirectory tool result (e.g. a `Read`) previously exited
+/// this hook immediately on the stale belief that Claude Code PostToolUse
+/// "cannot replace or shorten a tool result" — silently skipping redaction
+/// for exactly the surface the PreToolUse Bash rewrite never sees. A secret
+/// embedded in a `Read` result must now be stripped before the model would
+/// ever receive it.
+#[test]
+fn claude_read_result_secret_is_redacted_via_updated_tool_output() {
+    let secret = "AKIAIOSFODNN7EXAMPLE"; // gitleaks:allow synthetic test fixture
+    let payload = format!(
+        r#"{{"hook_event_name":"PostToolUse","tool_name":"Read","tool_input":{{"file_path":"notes.txt"}},"tool_response":{text}}}"#,
+        text = serde_json::to_string(&format!("config dump:\naws_key={secret}\n")).unwrap()
+    );
+    let (stdout, code) = run_hook_post(&payload);
+    assert_eq!(code, 0, "hook-post must always exit 0");
+
+    let v: serde_json::Value =
+        serde_json::from_str(stdout.trim()).expect("must emit JSON when a secret was redacted");
+    assert_eq!(
+        v["hookSpecificOutput"]["hookEventName"], "PostToolUse",
+        "must carry the PostToolUse hookEventName"
+    );
+    let updated = v["hookSpecificOutput"]["updatedToolOutput"]
+        .as_str()
+        .expect("updatedToolOutput must be a string");
+    assert!(
+        !updated.contains(secret),
+        "secret survived into updatedToolOutput: {updated}"
+    );
+    assert!(
+        updated.contains("[REDACTED]"),
+        "expected a redaction marker: {updated}"
+    );
+}


### PR DESCRIPTION
Closes #73.

## What changed
`run_hook_post()`'s Claude/Codex dialect exited immediately for non-shell
tool results, on the stale belief that PostToolUse "cannot replace or
shorten a tool result" — a dead code path for tokenix's primary harness.
Per current Claude Code docs, `hookSpecificOutput.updatedToolOutput` has
been honored for **all** tools (not just MCP) since v2.1.121+.

- `secrets_scan::redact_known_secrets(text) -> (String, bool)` — scans
  arbitrary text against the existing rule set and masks matches, reusing
  `scan_content`/`redact_occurrences`.
- `run_hook_post()`: redaction now runs first, unconditionally, on every
  tool this hook fires on — covers `Read` results, MCP results, anything
  the PreToolUse Bash rewrite never sees. Compression stays a second,
  tool-gated pass as before. Claude/Codex dialect now emits
  `updatedToolOutput` when output changed, instead of exiting silently.
  Fails open on older Claude Code installs (field simply ignored).
- Two independent `HookEvent`s per call (`reason: "secret-redacted"` /
  `"size-compressed"`) so `gain`/`doctor` can report blocked-secret count
  as its own metric, separate from token savings.

## Why
This closes T2.8 from `docs/research/2026-08-token-economy.md`
(reaffirmed open through 5 homologation passes). Picked over T0.3
(holdout mode) — see `.workflow/73-posttooluse-redact/` for the
research/prototype/plan trail — because this delivers real, direct
benefit (a currently-dead compression path becomes live, and secrets are
blocked from context before the model ever sees them), not just
measurement infrastructure.

## How to run locally
```
cargo build --bin tokenix
echo '{"hook_event_name":"PostToolUse","tool_name":"Read","tool_input":{"file_path":"x"},"tool_response":"aws_key=AKIAIOSFODNN7EXAMPLE"}' | ./target/debug/tokenix hook-post
```
Expect `hookSpecificOutput.updatedToolOutput` on stdout with the key
masked.

## Tests
`cargo fmt --check && cargo clippy --all-targets && cargo test` — fmt
clean, clippy clean, **458 passed** (was 454), 0 failed, 10 ignored.
New: 3 unit tests (`redact_known_secrets_*`) + 1 e2e test
(`claude_read_result_secret_is_redacted_via_updated_tool_output`,
spawns the real `tokenix hook-post` binary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)